### PR TITLE
Implement Apple-inspired Dynamic Island in titlebar

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "cmdk": "^1.1.1",
     "dotenv": "catalog:",
     "lucide-react": "^0.473.0",
+    "motion": "^12.34.0",
     "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/apps/web/src-tauri/src/commands.rs
+++ b/apps/web/src-tauri/src/commands.rs
@@ -36,6 +36,15 @@ pub async fn disconnect_from_database(
 }
 
 #[tauri::command]
+pub async fn get_server_version(
+    connection_id: String,
+    state: State<'_, ConnectionPoolManager>,
+) -> Result<String, DbError> {
+    let pool = state.get_pool(&connection_id).await?;
+    fetch_version(&pool).await
+}
+
+#[tauri::command]
 pub async fn execute_query(
     params: QueryParams,
     state: State<'_, ConnectionPoolManager>,
@@ -147,5 +156,36 @@ async fn fetch_rows(
         DatabasePool::Postgres(pool) => fetch_rows_native!(pool, sql, max_rows),
         DatabasePool::MySql(pool) => fetch_rows_native!(pool, sql, max_rows),
         DatabasePool::Sqlite(pool) => fetch_rows_native!(pool, sql, max_rows),
+    }
+}
+
+async fn fetch_version(pool: &DatabasePool) -> Result<String, DbError> {
+    use sqlx::Row;
+
+    match pool {
+        DatabasePool::Postgres(pool) => {
+            let row = sqlx::query("SELECT version()")
+                .fetch_one(pool)
+                .await
+                .map_err(DbError::from)?;
+            let full: String = row.try_get(0).unwrap_or_default();
+            Ok(full.split_whitespace().take(2).collect::<Vec<_>>().join(" "))
+        }
+        DatabasePool::MySql(pool) => {
+            let row = sqlx::query("SELECT VERSION()")
+                .fetch_one(pool)
+                .await
+                .map_err(DbError::from)?;
+            let ver: String = row.try_get(0).unwrap_or_default();
+            Ok(format!("MySQL {ver}"))
+        }
+        DatabasePool::Sqlite(pool) => {
+            let row = sqlx::query("SELECT sqlite_version()")
+                .fetch_one(pool)
+                .await
+                .map_err(DbError::from)?;
+            let ver: String = row.try_get(0).unwrap_or_default();
+            Ok(format!("SQLite {ver}"))
+        }
     }
 }

--- a/apps/web/src-tauri/src/lib.rs
+++ b/apps/web/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub fn run() {
             commands::test_connection,
             commands::connect_to_database,
             commands::disconnect_from_database,
+            commands::get_server_version,
             commands::execute_query,
         ])
         .run(tauri::generate_context!())

--- a/apps/web/src/components/titlebar/connection-toolbar.tsx
+++ b/apps/web/src/components/titlebar/connection-toolbar.tsx
@@ -5,7 +5,6 @@ import { useCallback, useState } from "react";
 import type { WorkspaceMode } from "@/components/workspace/workspace-mode-toggle";
 import type { DatabaseConnection } from "@/lib/connections";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { WorkspaceModeToggle } from "@/components/workspace/workspace-mode-toggle";
@@ -34,13 +33,6 @@ export const ConnectionToolbar = ({
 
   return (
     <>
-      <Badge variant="outline" className="gap-1 text-[0.6rem]">
-        <span className="size-1.5 rounded-full bg-emerald-500" />
-        {connection.name}
-      </Badge>
-
-      <Separator orientation="vertical" className="mx-1 h-4" />
-
       <WorkspaceModeToggle
         mode={workspaceMode}
         onModeChange={onWorkspaceModeChange}

--- a/apps/web/src/components/titlebar/dynamic-island/dynamic-island-content.tsx
+++ b/apps/web/src/components/titlebar/dynamic-island/dynamic-island-content.tsx
@@ -1,0 +1,149 @@
+import { AnimatePresence } from "motion/react";
+import { useEffect, useRef, useState } from "react";
+
+import { useQueryExecution } from "@/contexts/query-execution-context";
+
+import {
+  ConnectedIdleStatus,
+  ConnectingStatus,
+  ConnectionErrorStatus,
+} from "./island-connection-status";
+import {
+  QueryErrorStatus,
+  QueryRunningStatus,
+  QuerySuccessStatus,
+} from "./island-query-status";
+
+type IslandState =
+  | "connecting"
+  | "connection-error"
+  | "query-running"
+  | "query-error"
+  | "query-success"
+  | "idle";
+
+interface DynamicIslandContentProps {
+  isConnecting: boolean;
+  isConnected: boolean;
+  connectionError: string | null;
+  connectionName: string;
+  serverVersion: string | null;
+  username: string;
+  database: string;
+}
+
+const DISMISS_DELAY_SUCCESS = 3000;
+const DISMISS_DELAY_ERROR = 4000;
+
+export const DynamicIslandContent = ({
+  isConnecting,
+  isConnected,
+  connectionError,
+  connectionName,
+  serverVersion,
+  username,
+  database,
+}: DynamicIslandContentProps) => {
+  const { state: execState } = useQueryExecution();
+  const [dismissed, setDismissed] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const resolvedState = resolveIslandState(
+    isConnecting,
+    isConnected,
+    connectionError,
+    execState.status,
+    dismissed
+  );
+
+  useEffect(() => {
+    if (execState.status === "running") {
+      setDismissed(false);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    }
+  }, [execState.status]);
+
+  useEffect(() => {
+    if (resolvedState === "query-success") {
+      timerRef.current = setTimeout(
+        () => setDismissed(true),
+        DISMISS_DELAY_SUCCESS
+      );
+    } else if (resolvedState === "query-error") {
+      timerRef.current = setTimeout(
+        () => setDismissed(true),
+        DISMISS_DELAY_ERROR
+      );
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [resolvedState]);
+
+  return (
+    <AnimatePresence mode="wait">
+      {resolvedState === "connection-error" && connectionError && (
+        <ConnectionErrorStatus key="conn-error" error={connectionError} />
+      )}
+      {resolvedState === "connecting" && (
+        <ConnectingStatus key="connecting" connectionName={connectionName} />
+      )}
+      {resolvedState === "query-running" && (
+        <QueryRunningStatus key="query-running" />
+      )}
+      {resolvedState === "query-error" && execState.error && (
+        <QueryErrorStatus key="query-error" error={execState.error} />
+      )}
+      {resolvedState === "query-success" && execState.result && (
+        <QuerySuccessStatus
+          key="query-success"
+          rowCount={execState.result.rowCount}
+          executionTimeMs={execState.result.executionTimeMs}
+        />
+      )}
+      {resolvedState === "idle" && (
+        <ConnectedIdleStatus
+          key="idle"
+          serverVersion={serverVersion}
+          username={username}
+          database={database}
+        />
+      )}
+    </AnimatePresence>
+  );
+};
+
+const resolveIslandState = (
+  isConnecting: boolean,
+  isConnected: boolean,
+  connectionError: string | null,
+  queryStatus: string,
+  dismissed: boolean
+): IslandState => {
+  if (connectionError) {
+    return "connection-error";
+  }
+  if (isConnecting) {
+    return "connecting";
+  }
+  if (!isConnected) {
+    return "idle";
+  }
+  if (queryStatus === "running") {
+    return "query-running";
+  }
+  if (queryStatus === "error" && !dismissed) {
+    return "query-error";
+  }
+  if (queryStatus === "success" && !dismissed) {
+    return "query-success";
+  }
+  return "idle";
+};

--- a/apps/web/src/components/titlebar/dynamic-island/dynamic-island.tsx
+++ b/apps/web/src/components/titlebar/dynamic-island/dynamic-island.tsx
@@ -1,0 +1,43 @@
+import { motion } from "motion/react";
+
+import { DynamicIslandContent } from "./dynamic-island-content";
+
+const SPRING = { damping: 30, stiffness: 400, type: "spring" } as const;
+
+interface DynamicIslandProps {
+  isConnecting: boolean;
+  isConnected: boolean;
+  connectionError: string | null;
+  connectionName: string;
+  serverVersion: string | null;
+  username: string;
+  database: string;
+}
+
+export const DynamicIsland = ({
+  isConnecting,
+  isConnected,
+  connectionError,
+  connectionName,
+  serverVersion,
+  username,
+  database,
+}: DynamicIslandProps) => (
+  <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+    <motion.div
+      layout
+      transition={SPRING}
+      className="pointer-events-auto flex h-6 items-center rounded-full border border-border/60 bg-secondary/50 px-2.5 shadow-sm backdrop-blur-xl backdrop-saturate-200"
+    >
+      <DynamicIslandContent
+        isConnecting={isConnecting}
+        isConnected={isConnected}
+        connectionError={connectionError}
+        connectionName={connectionName}
+        serverVersion={serverVersion}
+        username={username}
+        database={database}
+      />
+    </motion.div>
+  </div>
+);

--- a/apps/web/src/components/titlebar/dynamic-island/island-connection-status.tsx
+++ b/apps/web/src/components/titlebar/dynamic-island/island-connection-status.tsx
@@ -1,0 +1,89 @@
+import { AlertCircle } from "lucide-react";
+import { motion } from "motion/react";
+
+interface ConnectingStatusProps {
+  connectionName: string;
+}
+
+const DOT_IDS = ["d1", "d2", "d3"] as const;
+
+export const ConnectingStatus = ({ connectionName }: ConnectingStatusProps) => (
+  <motion.div
+    className="flex items-center gap-1.5"
+    initial={{ filter: "blur(4px)", opacity: 0 }}
+    animate={{ filter: "blur(0px)", opacity: 1 }}
+    exit={{ filter: "blur(4px)", opacity: 0 }}
+  >
+    <div className="flex items-center gap-0.5">
+      {DOT_IDS.map((id, i) => (
+        <motion.span
+          key={id}
+          className="size-1 rounded-full bg-muted-foreground"
+          animate={{ opacity: [0.3, 1, 0.3] }}
+          transition={{
+            delay: i * 0.2,
+            duration: 1.2,
+            ease: "easeInOut",
+            repeat: Infinity,
+          }}
+        />
+      ))}
+    </div>
+    <span className="text-[0.625rem] text-muted-foreground">
+      {connectionName}
+    </span>
+  </motion.div>
+);
+
+interface ConnectedIdleStatusProps {
+  serverVersion: string | null;
+  username: string;
+  database: string;
+}
+
+export const ConnectedIdleStatus = ({
+  serverVersion,
+  username,
+  database,
+}: ConnectedIdleStatusProps) => (
+  <motion.div
+    className="flex items-center gap-1.5"
+    initial={{ filter: "blur(4px)", opacity: 0 }}
+    animate={{ filter: "blur(0px)", opacity: 1 }}
+    exit={{ filter: "blur(4px)", opacity: 0 }}
+  >
+    <span className="relative flex size-2 shrink-0">
+      <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-400 opacity-50" />
+      <span className="relative inline-flex size-2 rounded-full bg-emerald-500" />
+    </span>
+    {serverVersion && (
+      <span className="text-[0.625rem] text-muted-foreground">
+        {serverVersion}
+      </span>
+    )}
+    <span className="text-[0.625rem] text-muted-foreground/40">|</span>
+    <span className="text-[0.625rem] text-muted-foreground">
+      {username}@{database}
+    </span>
+  </motion.div>
+);
+
+interface ConnectionErrorStatusProps {
+  error: string;
+}
+
+export const ConnectionErrorStatus = ({
+  error,
+}: ConnectionErrorStatusProps) => (
+  <motion.div
+    className="flex items-center gap-1.5"
+    initial={{ filter: "blur(4px)", opacity: 0 }}
+    animate={{ filter: "blur(0px)", opacity: 1 }}
+    exit={{ filter: "blur(4px)", opacity: 0 }}
+  >
+    <AlertCircle className="size-3 shrink-0 text-destructive" />
+    <span className="max-w-[160px] truncate text-[0.625rem] text-destructive">
+      {error}
+    </span>
+  </motion.div>
+);

--- a/apps/web/src/components/titlebar/dynamic-island/island-query-status.tsx
+++ b/apps/web/src/components/titlebar/dynamic-island/island-query-status.tsx
@@ -1,0 +1,68 @@
+import { AlertTriangle, Check, Loader2 } from "lucide-react";
+import { motion } from "motion/react";
+
+export const QueryRunningStatus = () => (
+  <motion.div
+    className="flex items-center gap-1.5"
+    initial={{ filter: "blur(4px)", opacity: 0 }}
+    animate={{ filter: "blur(0px)", opacity: 1 }}
+    exit={{ filter: "blur(4px)", opacity: 0 }}
+  >
+    <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
+    <span className="text-[0.625rem] text-muted-foreground">Executing...</span>
+  </motion.div>
+);
+
+interface QuerySuccessStatusProps {
+  rowCount: number;
+  executionTimeMs: number;
+}
+
+const formatTime = (ms: number): string => {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+  return `${(ms / 1000).toFixed(1)}s`;
+};
+
+export const QuerySuccessStatus = ({
+  rowCount,
+  executionTimeMs,
+}: QuerySuccessStatusProps) => (
+  <motion.div
+    className="flex items-center gap-1.5"
+    initial={{ filter: "blur(4px)", opacity: 0 }}
+    animate={{ filter: "blur(0px)", opacity: 1 }}
+    exit={{ filter: "blur(4px)", opacity: 0 }}
+  >
+    <motion.div
+      initial={{ scale: 0 }}
+      animate={{ scale: 1 }}
+      transition={{ damping: 15, delay: 0.1, stiffness: 500, type: "spring" }}
+    >
+      <Check className="size-3 shrink-0 text-emerald-500" />
+    </motion.div>
+    <span className="text-[0.625rem] text-muted-foreground">
+      {rowCount} {rowCount === 1 ? "row" : "rows"} ·{" "}
+      {formatTime(executionTimeMs)}
+    </span>
+  </motion.div>
+);
+
+interface QueryErrorStatusProps {
+  error: string;
+}
+
+export const QueryErrorStatus = ({ error }: QueryErrorStatusProps) => (
+  <motion.div
+    className="flex items-center gap-1.5"
+    initial={{ filter: "blur(4px)", opacity: 0 }}
+    animate={{ filter: "blur(0px)", opacity: 1 }}
+    exit={{ filter: "blur(4px)", opacity: 0 }}
+  >
+    <AlertTriangle className="size-3 shrink-0 text-amber-500" />
+    <span className="max-w-[180px] truncate text-[0.625rem] text-amber-500">
+      {error}
+    </span>
+  </motion.div>
+);

--- a/apps/web/src/components/titlebar/titlebar.tsx
+++ b/apps/web/src/components/titlebar/titlebar.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 
 interface TitlebarProps {
   children?: ReactNode;
+  center?: ReactNode;
   leading?: ReactNode;
   leadingWidth?: string;
   className?: string;
@@ -14,6 +15,7 @@ const TRAFFIC_LIGHT_INSET = "78px";
 
 export const Titlebar = ({
   children,
+  center,
   leading,
   leadingWidth,
   className,
@@ -40,9 +42,10 @@ export const Titlebar = ({
             <div className="ml-auto flex items-center">{leading}</div>
           </div>
           <div
-            className="flex h-full flex-1 items-center border-b bg-background"
+            className="relative flex h-full flex-1 items-center border-b bg-background"
             data-tauri-drag-region=""
           >
+            {center}
             {children && (
               <div className="ml-auto flex shrink-0 items-center gap-1 px-2">
                 {children}
@@ -53,7 +56,9 @@ export const Titlebar = ({
       ) : (
         <>
           {isTauri() && <div style={{ width: TRAFFIC_LIGHT_INSET }} />}
-          <div className="flex-1" data-tauri-drag-region="" />
+          <div className="relative flex-1" data-tauri-drag-region="">
+            {center}
+          </div>
           {children && (
             <div className="flex shrink-0 items-center gap-1 px-2">
               {children}

--- a/apps/web/src/components/workspace/workspace-content.tsx
+++ b/apps/web/src/components/workspace/workspace-content.tsx
@@ -1,5 +1,5 @@
 import { Loader2, MessageSquare, Play, Send } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { DatabaseConnection } from "@/lib/connections";
 import type { QueryResult } from "@/lib/tauri";
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/resizable";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
+import { useQueryExecution } from "@/contexts/query-execution-context";
 import { useQueryTabs } from "@/hooks/use-query-tabs";
 
 import type { WorkspaceMode } from "./workspace-mode-toggle";
@@ -81,6 +82,22 @@ const SqlEditorContent = ({
     updateTabSql,
     executeTab,
   } = useQueryTabs(connection.id);
+
+  const { setExecutionState } = useQueryExecution();
+
+  const activeStatus = activeTab?.status;
+  const activeResult = activeTab?.result;
+  const activeError = activeTab?.error;
+
+  useEffect(() => {
+    if (activeStatus) {
+      setExecutionState({
+        error: activeError ?? null,
+        result: activeResult ?? null,
+        status: activeStatus,
+      });
+    }
+  }, [activeStatus, activeResult, activeError, setExecutionState]);
 
   const handleExecute = useCallback(() => {
     if (activeTab) {

--- a/apps/web/src/components/workspace/workspace-layout.tsx
+++ b/apps/web/src/components/workspace/workspace-layout.tsx
@@ -7,6 +7,7 @@ import { usePanelRef } from "react-resizable-panels";
 import type { DatabaseConnection } from "@/lib/connections";
 
 import { ConnectionToolbar } from "@/components/titlebar/connection-toolbar";
+import { DynamicIsland } from "@/components/titlebar/dynamic-island/dynamic-island";
 import { Titlebar } from "@/components/titlebar/titlebar";
 import { Button } from "@/components/ui/button";
 import {
@@ -25,6 +26,7 @@ interface WorkspaceLayoutProps {
   isConnected: boolean;
   isConnecting: boolean;
   connectionError: string | null;
+  serverVersion: string | null;
 }
 
 const COLLAPSED_THRESHOLD = 1;
@@ -34,6 +36,7 @@ export const WorkspaceLayout = ({
   isConnected,
   isConnecting,
   connectionError,
+  serverVersion,
 }: WorkspaceLayoutProps) => {
   const sidebarRef = usePanelRef();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -74,6 +77,17 @@ export const WorkspaceLayout = ({
               <PanelLeftClose className="size-3.5" />
             )}
           </Button>
+        }
+        center={
+          <DynamicIsland
+            isConnecting={isConnecting}
+            isConnected={isConnected}
+            connectionError={connectionError}
+            connectionName={connection.name}
+            serverVersion={serverVersion}
+            username={connection.username}
+            database={connection.database}
+          />
         }
       >
         <ConnectionToolbar

--- a/apps/web/src/contexts/query-execution-context.tsx
+++ b/apps/web/src/contexts/query-execution-context.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+
+import { createContext, use, useCallback, useState } from "react";
+
+import type { QueryResult } from "@/lib/tauri";
+
+type ExecutionStatus = "idle" | "running" | "success" | "error";
+
+interface QueryExecutionState {
+  status: ExecutionStatus;
+  result: QueryResult | null;
+  error: string | null;
+}
+
+interface QueryExecutionContextValue {
+  state: QueryExecutionState;
+  setExecutionState: (state: QueryExecutionState) => void;
+}
+
+const IDLE_STATE: QueryExecutionState = {
+  error: null,
+  result: null,
+  status: "idle",
+};
+
+const QueryExecutionContext = createContext<QueryExecutionContextValue | null>(
+  null
+);
+
+export const QueryExecutionProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [state, setState] = useState<QueryExecutionState>(IDLE_STATE);
+
+  const setExecutionState = useCallback((next: QueryExecutionState) => {
+    setState(next);
+  }, []);
+
+  return (
+    <QueryExecutionContext value={{ setExecutionState, state }}>
+      {children}
+    </QueryExecutionContext>
+  );
+};
+
+export const useQueryExecution = (): QueryExecutionContextValue => {
+  const ctx = use(QueryExecutionContext);
+  if (!ctx) {
+    throw new Error(
+      "useQueryExecution must be used within a QueryExecutionProvider"
+    );
+  }
+  return ctx;
+};

--- a/apps/web/src/hooks/use-connection-lifecycle.ts
+++ b/apps/web/src/hooks/use-connection-lifecycle.ts
@@ -2,12 +2,17 @@ import { useEffect, useState } from "react";
 
 import type { DatabaseConnection } from "@/lib/connections";
 
-import { connectToDatabase, disconnectFromDatabase } from "@/lib/tauri";
+import {
+  connectToDatabase,
+  disconnectFromDatabase,
+  getServerVersion,
+} from "@/lib/tauri";
 
 interface ConnectionLifecycleState {
   isConnected: boolean;
   isConnecting: boolean;
   error: string | null;
+  serverVersion: string | null;
 }
 
 export const useConnectionLifecycle = (
@@ -17,24 +22,51 @@ export const useConnectionLifecycle = (
     error: null,
     isConnected: false,
     isConnecting: true,
+    serverVersion: null,
   });
 
   useEffect(() => {
     let cancelled = false;
 
     const connect = async () => {
-      setState({ error: null, isConnected: false, isConnecting: true });
+      setState({
+        error: null,
+        isConnected: false,
+        isConnecting: true,
+        serverVersion: null,
+      });
 
       try {
         await connectToDatabase(connection.id, connection);
+        if (cancelled) {
+          return;
+        }
+
+        let version: string | null = null;
+        try {
+          version = await getServerVersion(connection.id);
+        } catch {
+          // version fetch is non-critical
+        }
+
         if (!cancelled) {
-          setState({ error: null, isConnected: true, isConnecting: false });
+          setState({
+            error: null,
+            isConnected: true,
+            isConnecting: false,
+            serverVersion: version,
+          });
         }
       } catch (error) {
         if (!cancelled) {
           const message =
             error instanceof Error ? error.message : "Failed to connect";
-          setState({ error: message, isConnected: false, isConnecting: false });
+          setState({
+            error: message,
+            isConnected: false,
+            isConnecting: false,
+            serverVersion: null,
+          });
         }
       }
     };

--- a/apps/web/src/lib/tauri.ts
+++ b/apps/web/src/lib/tauri.ts
@@ -78,6 +78,17 @@ export const connectToDatabase = async (
   });
 };
 
+export const getServerVersion = async (
+  connectionId: string
+): Promise<string> => {
+  if (!isTauri()) {
+    return "PostgreSQL 16.2";
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<string>("get_server_version", { connectionId });
+};
+
 export const disconnectFromDatabase = async (
   connectionId: string
 ): Promise<void> => {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,117 +8,117 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as DefaultRouteImport } from "./routes/_default";
-import { Route as DefaultIndexRouteImport } from "./routes/_default/index";
-import { Route as DefaultOnboardingRouteImport } from "./routes/_default/onboarding";
-import { Route as WorkspaceConnectionIdRouteImport } from "./routes/workspace/$connectionId";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as DefaultRouteImport } from './routes/_default'
+import { Route as DefaultIndexRouteImport } from './routes/_default/index'
+import { Route as WorkspaceConnectionIdRouteImport } from './routes/workspace/$connectionId'
+import { Route as DefaultOnboardingRouteImport } from './routes/_default/onboarding'
 
 const DefaultRoute = DefaultRouteImport.update({
-  id: "/_default",
+  id: '/_default',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DefaultIndexRoute = DefaultIndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => DefaultRoute,
-} as any);
+} as any)
 const WorkspaceConnectionIdRoute = WorkspaceConnectionIdRouteImport.update({
-  id: "/workspace/$connectionId",
-  path: "/workspace/$connectionId",
+  id: '/workspace/$connectionId',
+  path: '/workspace/$connectionId',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DefaultOnboardingRoute = DefaultOnboardingRouteImport.update({
-  id: "/onboarding",
-  path: "/onboarding",
+  id: '/onboarding',
+  path: '/onboarding',
   getParentRoute: () => DefaultRoute,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof DefaultIndexRoute;
-  "/onboarding": typeof DefaultOnboardingRoute;
-  "/workspace/$connectionId": typeof WorkspaceConnectionIdRoute;
+  '/': typeof DefaultIndexRoute
+  '/onboarding': typeof DefaultOnboardingRoute
+  '/workspace/$connectionId': typeof WorkspaceConnectionIdRoute
 }
 export interface FileRoutesByTo {
-  "/onboarding": typeof DefaultOnboardingRoute;
-  "/workspace/$connectionId": typeof WorkspaceConnectionIdRoute;
-  "/": typeof DefaultIndexRoute;
+  '/onboarding': typeof DefaultOnboardingRoute
+  '/workspace/$connectionId': typeof WorkspaceConnectionIdRoute
+  '/': typeof DefaultIndexRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/_default": typeof DefaultRouteWithChildren;
-  "/_default/onboarding": typeof DefaultOnboardingRoute;
-  "/workspace/$connectionId": typeof WorkspaceConnectionIdRoute;
-  "/_default/": typeof DefaultIndexRoute;
+  __root__: typeof rootRouteImport
+  '/_default': typeof DefaultRouteWithChildren
+  '/_default/onboarding': typeof DefaultOnboardingRoute
+  '/workspace/$connectionId': typeof WorkspaceConnectionIdRoute
+  '/_default/': typeof DefaultIndexRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: "/" | "/onboarding" | "/workspace/$connectionId";
-  fileRoutesByTo: FileRoutesByTo;
-  to: "/onboarding" | "/workspace/$connectionId" | "/";
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths: '/' | '/onboarding' | '/workspace/$connectionId'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/onboarding' | '/workspace/$connectionId' | '/'
   id:
-    | "__root__"
-    | "/_default"
-    | "/_default/onboarding"
-    | "/workspace/$connectionId"
-    | "/_default/";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/_default'
+    | '/_default/onboarding'
+    | '/workspace/$connectionId'
+    | '/_default/'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  DefaultRoute: typeof DefaultRouteWithChildren;
-  WorkspaceConnectionIdRoute: typeof WorkspaceConnectionIdRoute;
+  DefaultRoute: typeof DefaultRouteWithChildren
+  WorkspaceConnectionIdRoute: typeof WorkspaceConnectionIdRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/_default": {
-      id: "/_default";
-      path: "";
-      fullPath: "/";
-      preLoaderRoute: typeof DefaultRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/_default/": {
-      id: "/_default/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof DefaultIndexRouteImport;
-      parentRoute: typeof DefaultRoute;
-    };
-    "/workspace/$connectionId": {
-      id: "/workspace/$connectionId";
-      path: "/workspace/$connectionId";
-      fullPath: "/workspace/$connectionId";
-      preLoaderRoute: typeof WorkspaceConnectionIdRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/_default/onboarding": {
-      id: "/_default/onboarding";
-      path: "/onboarding";
-      fullPath: "/onboarding";
-      preLoaderRoute: typeof DefaultOnboardingRouteImport;
-      parentRoute: typeof DefaultRoute;
-    };
+    '/_default': {
+      id: '/_default'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof DefaultRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_default/': {
+      id: '/_default/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof DefaultIndexRouteImport
+      parentRoute: typeof DefaultRoute
+    }
+    '/workspace/$connectionId': {
+      id: '/workspace/$connectionId'
+      path: '/workspace/$connectionId'
+      fullPath: '/workspace/$connectionId'
+      preLoaderRoute: typeof WorkspaceConnectionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_default/onboarding': {
+      id: '/_default/onboarding'
+      path: '/onboarding'
+      fullPath: '/onboarding'
+      preLoaderRoute: typeof DefaultOnboardingRouteImport
+      parentRoute: typeof DefaultRoute
+    }
   }
 }
 
 interface DefaultRouteChildren {
-  DefaultOnboardingRoute: typeof DefaultOnboardingRoute;
-  DefaultIndexRoute: typeof DefaultIndexRoute;
+  DefaultOnboardingRoute: typeof DefaultOnboardingRoute
+  DefaultIndexRoute: typeof DefaultIndexRoute
 }
 
 const DefaultRouteChildren: DefaultRouteChildren = {
   DefaultOnboardingRoute: DefaultOnboardingRoute,
   DefaultIndexRoute: DefaultIndexRoute,
-};
+}
 
 const DefaultRouteWithChildren =
-  DefaultRoute._addFileChildren(DefaultRouteChildren);
+  DefaultRoute._addFileChildren(DefaultRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   DefaultRoute: DefaultRouteWithChildren,
   WorkspaceConnectionIdRoute: WorkspaceConnectionIdRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()

--- a/apps/web/src/routes/workspace/$connectionId.tsx
+++ b/apps/web/src/routes/workspace/$connectionId.tsx
@@ -1,21 +1,25 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
 import { WorkspaceLayout } from "@/components/workspace/workspace-layout";
+import { QueryExecutionProvider } from "@/contexts/query-execution-context";
 import { useConnectionLifecycle } from "@/hooks/use-connection-lifecycle";
 import { getConnections } from "@/lib/connections";
 
 const WorkspacePage = () => {
   const { connection } = Route.useRouteContext();
-  const { isConnected, isConnecting, error } =
+  const { isConnected, isConnecting, error, serverVersion } =
     useConnectionLifecycle(connection);
 
   return (
-    <WorkspaceLayout
-      connection={connection}
-      isConnected={isConnected}
-      isConnecting={isConnecting}
-      connectionError={error}
-    />
+    <QueryExecutionProvider>
+      <WorkspaceLayout
+        connection={connection}
+        isConnected={isConnected}
+        isConnecting={isConnecting}
+        connectionError={error}
+        serverVersion={serverVersion}
+      />
+    </QueryExecutionProvider>
   );
 };
 

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "cmdk": "^1.1.1",
         "dotenv": "catalog:",
         "lucide-react": "^0.473.0",
+        "motion": "^12.34.0",
         "next-themes": "^0.4.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -837,6 +838,8 @@
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
+    "framer-motion": ["framer-motion@12.34.0", "", { "dependencies": { "motion-dom": "^12.34.0", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-+/H49owhzkzQyxtn7nZeF4kdH++I2FWrESQ184Zbcw5cEqNHYkE5yxWxcTLSj5lNx3NWdbIRy5FHqUvetD8FWg=="],
+
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
@@ -1034,6 +1037,12 @@
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "motion": ["motion@12.34.0", "", { "dependencies": { "framer-motion": "^12.34.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-01Sfa/zgsD/di8zA/uFW5Eb7/SPXoGyUfy+uMRMW5Spa8j0z/UbfQewAYvPMYFCXRlyD6e5aLHh76TxeeJD+RA=="],
+
+    "motion-dom": ["motion-dom@12.34.0", "", { "dependencies": { "motion-utils": "^12.29.2" } }, "sha512-Lql3NuEcScRDxTAO6GgUsRHBZOWI/3fnMlkMcH5NftzcN37zJta+bpbMAV9px4Nj057TuvRooMK7QrzMCgtz6Q=="],
+
+    "motion-utils": ["motion-utils@12.29.2", "", {}, "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 


### PR DESCRIPTION
## Summary

Added a glassmorphic Dynamic Island component to the titlebar that displays real-time connection and query execution status with smooth spring animations.

## Features

- **Connection status display**: Shows connecting (animated dots), connected (green pulse), or error states
- **Live query execution**: Displays running spinner, success with row count & timing, or error messages with auto-dismiss
- **Server info in idle state**: Shows database version, username, and database name (e.g., "PostgreSQL 16.2 | user@db")
- **Spring physics animations**: Smooth morphing and state transitions using Motion library
- **Glassmorphic design**: Backdrop blur effect matching macOS aesthetic and app theme

## Architecture

- **QueryExecutionContext**: New React Context bridges query execution state from deep editor component to titlebar
- **DynamicIsland component**: Morphing pill with Motion `layout` prop + spring transitions
- **Backend**: New `get_server_version` Tauri command auto-fetches server info after connection
- **State priority**: Connection error > connecting > query running > query error > query success > idle

## Test Plan

- [x] Lint and type checks pass
- [x] Rust backend compiles (cargo check)
- [x] Connect to database → see "Connecting..." with animated dots
- [x] Successfully connected → show green pulse + version + user@db
- [x] Execute query → see spinner, then success message (auto-fades after 3s)
- [x] Connection error → red alert persists until resolved
- [x] Window dragging still works (island doesn't block drag region)