### PR TITLE
Implement database selector in schema explorer

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -20,4 +20,5 @@
     "newlinesBetween": true,
     "order": "asc",
   },
+  "ignorePatterns": ["**/*.gen.ts"],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": "oxc.oxc-vscode",
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,

--- a/apps/web/src-tauri/src/commands.rs
+++ b/apps/web/src-tauri/src/commands.rs
@@ -5,8 +5,9 @@ use tauri::State;
 use crate::db::driver::get_driver;
 use crate::db::error::DbError;
 use crate::db::pool::{ConnectionPoolManager, DatabasePool};
+use crate::db::schema::{fetch_schema, list_databases};
 use crate::db::types::{
-    ColumnInfo, ConnectionParams, QueryParams, QueryResult, TestConnectionResult,
+    ColumnInfo, ConnectionParams, QueryParams, QueryResult, SchemaInfo, TestConnectionResult,
 };
 
 const DEFAULT_MAX_ROWS: u64 = 10_000;
@@ -42,6 +43,25 @@ pub async fn get_server_version(
 ) -> Result<String, DbError> {
     let pool = state.get_pool(&connection_id).await?;
     fetch_version(&pool).await
+}
+
+#[tauri::command]
+pub async fn list_connection_databases(
+    connection_id: String,
+    state: State<'_, ConnectionPoolManager>,
+) -> Result<Vec<String>, DbError> {
+    let pool = state.get_pool(&connection_id).await?;
+    list_databases(&pool).await
+}
+
+#[tauri::command]
+pub async fn get_schema(
+    connection_id: String,
+    database_name: String,
+    state: State<'_, ConnectionPoolManager>,
+) -> Result<SchemaInfo, DbError> {
+    let pool = state.get_pool(&connection_id).await?;
+    fetch_schema(&pool, &database_name).await
 }
 
 #[tauri::command]

--- a/apps/web/src-tauri/src/db/mod.rs
+++ b/apps/web/src-tauri/src/db/mod.rs
@@ -3,5 +3,6 @@ pub mod error;
 pub mod mysql;
 pub mod pool;
 pub mod postgres;
+pub mod schema;
 pub mod sqlite;
 pub mod types;

--- a/apps/web/src-tauri/src/db/schema.rs
+++ b/apps/web/src-tauri/src/db/schema.rs
@@ -1,0 +1,645 @@
+use sqlx::Row;
+
+use crate::db::error::DbError;
+use crate::db::pool::DatabasePool;
+use crate::db::types::{
+    ColumnDetail, ForeignKeyItem, IndexItem, SchemaInfo, SchemaItem, TableItem, ViewItem,
+};
+
+pub async fn list_databases(pool: &DatabasePool) -> Result<Vec<String>, DbError> {
+    match pool {
+        DatabasePool::Postgres(pool) => list_databases_postgres(pool).await,
+        DatabasePool::MySql(pool) => list_databases_mysql(pool).await,
+        DatabasePool::Sqlite(_) => Ok(vec!["main".to_string()]),
+    }
+}
+
+pub async fn fetch_schema(
+    pool: &DatabasePool,
+    database_name: &str,
+) -> Result<SchemaInfo, DbError> {
+    match pool {
+        DatabasePool::Postgres(pool) => fetch_schema_postgres(pool, database_name).await,
+        DatabasePool::MySql(pool) => fetch_schema_mysql(pool, database_name).await,
+        DatabasePool::Sqlite(pool) => fetch_schema_sqlite(pool).await,
+    }
+}
+
+async fn list_databases_postgres(pool: &sqlx::PgPool) -> Result<Vec<String>, DbError> {
+    let rows = sqlx::query(
+        "SELECT schema_name FROM information_schema.schemata \
+         WHERE schema_name NOT IN ('pg_catalog', 'information_schema', 'pg_toast') \
+         ORDER BY schema_name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    Ok(rows
+        .iter()
+        .map(|row| row.try_get("schema_name").unwrap_or_default())
+        .collect())
+}
+
+async fn fetch_schema_postgres(
+    pool: &sqlx::PgPool,
+    schema_name: &str,
+) -> Result<SchemaInfo, DbError> {
+    let tables = fetch_tables_postgres(pool, schema_name).await?;
+    let views = fetch_views_postgres(pool, schema_name).await?;
+
+    Ok(SchemaInfo {
+        schemas: vec![SchemaItem {
+            name: schema_name.to_string(),
+            tables,
+            views,
+        }],
+    })
+}
+
+async fn fetch_tables_postgres(
+    pool: &sqlx::PgPool,
+    schema_name: &str,
+) -> Result<Vec<TableItem>, DbError> {
+    let table_rows = sqlx::query(
+        "SELECT table_name FROM information_schema.tables \
+         WHERE table_schema = $1 AND table_type = 'BASE TABLE' \
+         ORDER BY table_name",
+    )
+    .bind(schema_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut tables = Vec::with_capacity(table_rows.len());
+
+    for table_row in &table_rows {
+        let table_name: String = table_row.try_get("table_name").unwrap_or_default();
+
+        let columns = fetch_columns_postgres(pool, schema_name, &table_name).await?;
+        let indexes = fetch_indexes_postgres(pool, schema_name, &table_name).await?;
+        let foreign_keys = fetch_fks_postgres(pool, schema_name, &table_name).await?;
+
+        tables.push(TableItem {
+            name: table_name,
+            columns,
+            indexes,
+            foreign_keys,
+        });
+    }
+
+    Ok(tables)
+}
+
+async fn fetch_views_postgres(
+    pool: &sqlx::PgPool,
+    schema_name: &str,
+) -> Result<Vec<ViewItem>, DbError> {
+    let view_rows = sqlx::query(
+        "SELECT table_name FROM information_schema.tables \
+         WHERE table_schema = $1 AND table_type = 'VIEW' \
+         ORDER BY table_name",
+    )
+    .bind(schema_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut views = Vec::with_capacity(view_rows.len());
+
+    for view_row in &view_rows {
+        let view_name: String = view_row.try_get("table_name").unwrap_or_default();
+        let columns = fetch_columns_postgres(pool, schema_name, &view_name).await?;
+
+        views.push(ViewItem {
+            name: view_name,
+            columns,
+        });
+    }
+
+    Ok(views)
+}
+
+async fn fetch_columns_postgres(
+    pool: &sqlx::PgPool,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<Vec<ColumnDetail>, DbError> {
+    let rows = sqlx::query(
+        "SELECT c.column_name, c.data_type, c.is_nullable, c.column_default, \
+         CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as is_pk \
+         FROM information_schema.columns c \
+         LEFT JOIN ( \
+             SELECT kcu.column_name \
+             FROM information_schema.table_constraints tc \
+             JOIN information_schema.key_column_usage kcu \
+                 ON tc.constraint_name = kcu.constraint_name \
+                 AND tc.table_schema = kcu.table_schema \
+             WHERE tc.constraint_type = 'PRIMARY KEY' \
+                 AND tc.table_schema = $1 AND tc.table_name = $2 \
+         ) pk ON c.column_name = pk.column_name \
+         WHERE c.table_schema = $1 AND c.table_name = $2 \
+         ORDER BY c.ordinal_position",
+    )
+    .bind(schema_name)
+    .bind(table_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    Ok(rows
+        .iter()
+        .map(|row| {
+            let nullable: String = row.try_get("is_nullable").unwrap_or_default();
+            ColumnDetail {
+                name: row.try_get("column_name").unwrap_or_default(),
+                data_type: row.try_get("data_type").unwrap_or_default(),
+                is_nullable: nullable == "YES",
+                is_primary_key: row.try_get("is_pk").unwrap_or(false),
+                default_value: row.try_get("column_default").ok(),
+            }
+        })
+        .collect())
+}
+
+async fn fetch_indexes_postgres(
+    pool: &sqlx::PgPool,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<Vec<IndexItem>, DbError> {
+    let rows = sqlx::query(
+        "SELECT i.relname AS index_name, \
+                ix.indisunique AS is_unique, \
+                array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) AS columns \
+         FROM pg_index ix \
+         JOIN pg_class t ON t.oid = ix.indrelid \
+         JOIN pg_class i ON i.oid = ix.indexrelid \
+         JOIN pg_namespace n ON n.oid = t.relnamespace \
+         JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey) \
+         WHERE n.nspname = $1 AND t.relname = $2 \
+         GROUP BY i.relname, ix.indisunique \
+         ORDER BY i.relname",
+    )
+    .bind(schema_name)
+    .bind(table_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    Ok(rows
+        .iter()
+        .map(|row| {
+            let columns: Vec<String> = row.try_get("columns").unwrap_or_default();
+            IndexItem {
+                name: row.try_get("index_name").unwrap_or_default(),
+                columns,
+                is_unique: row.try_get("is_unique").unwrap_or(false),
+            }
+        })
+        .collect())
+}
+
+async fn fetch_fks_postgres(
+    pool: &sqlx::PgPool,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<Vec<ForeignKeyItem>, DbError> {
+    let rows = sqlx::query(
+        "SELECT tc.constraint_name, \
+                kcu.column_name, \
+                ccu.table_name AS referenced_table, \
+                ccu.column_name AS referenced_column \
+         FROM information_schema.table_constraints tc \
+         JOIN information_schema.key_column_usage kcu \
+             ON tc.constraint_name = kcu.constraint_name \
+             AND tc.table_schema = kcu.table_schema \
+         JOIN information_schema.constraint_column_usage ccu \
+             ON ccu.constraint_name = tc.constraint_name \
+             AND ccu.table_schema = tc.table_schema \
+         WHERE tc.constraint_type = 'FOREIGN KEY' \
+             AND tc.table_schema = $1 AND tc.table_name = $2 \
+         ORDER BY tc.constraint_name, kcu.ordinal_position",
+    )
+    .bind(schema_name)
+    .bind(table_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut fk_map: std::collections::HashMap<String, ForeignKeyItem> =
+        std::collections::HashMap::new();
+
+    for row in &rows {
+        let name: String = row.try_get("constraint_name").unwrap_or_default();
+        let column: String = row.try_get("column_name").unwrap_or_default();
+        let ref_table: String = row.try_get("referenced_table").unwrap_or_default();
+        let ref_column: String = row.try_get("referenced_column").unwrap_or_default();
+
+        let entry = fk_map.entry(name.clone()).or_insert_with(|| ForeignKeyItem {
+            name,
+            columns: Vec::new(),
+            referenced_table: ref_table,
+            referenced_columns: Vec::new(),
+        });
+        if !entry.columns.contains(&column) {
+            entry.columns.push(column);
+        }
+        if !entry.referenced_columns.contains(&ref_column) {
+            entry.referenced_columns.push(ref_column);
+        }
+    }
+
+    Ok(fk_map.into_values().collect())
+}
+
+// MySQL introspection
+
+async fn list_databases_mysql(pool: &sqlx::MySqlPool) -> Result<Vec<String>, DbError> {
+    let rows = sqlx::query(
+        "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA \
+         WHERE SCHEMA_NAME NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys') \
+         ORDER BY SCHEMA_NAME",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    Ok(rows
+        .iter()
+        .map(|row| row.try_get("SCHEMA_NAME").unwrap_or_default())
+        .collect())
+}
+
+async fn fetch_schema_mysql(
+    pool: &sqlx::MySqlPool,
+    schema_name: &str,
+) -> Result<SchemaInfo, DbError> {
+    let tables = fetch_tables_mysql(pool, schema_name).await?;
+    let views = fetch_views_mysql(pool, schema_name).await?;
+
+    Ok(SchemaInfo {
+        schemas: vec![SchemaItem {
+            name: schema_name.to_string(),
+            tables,
+            views,
+        }],
+    })
+}
+
+async fn fetch_tables_mysql(
+    pool: &sqlx::MySqlPool,
+    schema_name: &str,
+) -> Result<Vec<TableItem>, DbError> {
+    let table_rows = sqlx::query(
+        "SELECT TABLE_NAME FROM information_schema.TABLES \
+         WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'BASE TABLE' \
+         ORDER BY TABLE_NAME",
+    )
+    .bind(schema_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut tables = Vec::with_capacity(table_rows.len());
+
+    for table_row in &table_rows {
+        let table_name: String = table_row.try_get("TABLE_NAME").unwrap_or_default();
+
+        let columns = fetch_columns_mysql(pool, schema_name, &table_name).await?;
+        let indexes = fetch_indexes_mysql(pool, schema_name, &table_name).await?;
+        let foreign_keys = fetch_fks_mysql(pool, schema_name, &table_name).await?;
+
+        tables.push(TableItem {
+            name: table_name,
+            columns,
+            indexes,
+            foreign_keys,
+        });
+    }
+
+    Ok(tables)
+}
+
+async fn fetch_views_mysql(
+    pool: &sqlx::MySqlPool,
+    schema_name: &str,
+) -> Result<Vec<ViewItem>, DbError> {
+    let view_rows = sqlx::query(
+        "SELECT TABLE_NAME FROM information_schema.TABLES \
+         WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'VIEW' \
+         ORDER BY TABLE_NAME",
+    )
+    .bind(schema_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut views = Vec::with_capacity(view_rows.len());
+
+    for view_row in &view_rows {
+        let view_name: String = view_row.try_get("TABLE_NAME").unwrap_or_default();
+        let columns = fetch_columns_mysql(pool, schema_name, &view_name).await?;
+
+        views.push(ViewItem {
+            name: view_name,
+            columns,
+        });
+    }
+
+    Ok(views)
+}
+
+async fn fetch_columns_mysql(
+    pool: &sqlx::MySqlPool,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<Vec<ColumnDetail>, DbError> {
+    let rows = sqlx::query(
+        "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, COLUMN_KEY \
+         FROM information_schema.COLUMNS \
+         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? \
+         ORDER BY ORDINAL_POSITION",
+    )
+    .bind(schema_name)
+    .bind(table_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    Ok(rows
+        .iter()
+        .map(|row| {
+            let nullable: String = row.try_get("IS_NULLABLE").unwrap_or_default();
+            let column_key: String = row.try_get("COLUMN_KEY").unwrap_or_default();
+            ColumnDetail {
+                name: row.try_get("COLUMN_NAME").unwrap_or_default(),
+                data_type: row.try_get("DATA_TYPE").unwrap_or_default(),
+                is_nullable: nullable == "YES",
+                is_primary_key: column_key == "PRI",
+                default_value: row.try_get("COLUMN_DEFAULT").ok(),
+            }
+        })
+        .collect())
+}
+
+async fn fetch_indexes_mysql(
+    pool: &sqlx::MySqlPool,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<Vec<IndexItem>, DbError> {
+    let rows = sqlx::query(
+        "SELECT INDEX_NAME, NON_UNIQUE, COLUMN_NAME \
+         FROM information_schema.STATISTICS \
+         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? \
+         ORDER BY INDEX_NAME, SEQ_IN_INDEX",
+    )
+    .bind(schema_name)
+    .bind(table_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut index_map: std::collections::HashMap<String, IndexItem> =
+        std::collections::HashMap::new();
+
+    for row in &rows {
+        let name: String = row.try_get("INDEX_NAME").unwrap_or_default();
+        let non_unique: i64 = row.try_get("NON_UNIQUE").unwrap_or(1);
+        let column: String = row.try_get("COLUMN_NAME").unwrap_or_default();
+
+        let entry = index_map.entry(name.clone()).or_insert_with(|| IndexItem {
+            name,
+            columns: Vec::new(),
+            is_unique: non_unique == 0,
+        });
+        entry.columns.push(column);
+    }
+
+    Ok(index_map.into_values().collect())
+}
+
+async fn fetch_fks_mysql(
+    pool: &sqlx::MySqlPool,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<Vec<ForeignKeyItem>, DbError> {
+    let rows = sqlx::query(
+        "SELECT CONSTRAINT_NAME, COLUMN_NAME, \
+                REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME \
+         FROM information_schema.KEY_COLUMN_USAGE \
+         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? \
+             AND REFERENCED_TABLE_NAME IS NOT NULL \
+         ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
+    )
+    .bind(schema_name)
+    .bind(table_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut fk_map: std::collections::HashMap<String, ForeignKeyItem> =
+        std::collections::HashMap::new();
+
+    for row in &rows {
+        let name: String = row.try_get("CONSTRAINT_NAME").unwrap_or_default();
+        let column: String = row.try_get("COLUMN_NAME").unwrap_or_default();
+        let ref_table: String = row.try_get("REFERENCED_TABLE_NAME").unwrap_or_default();
+        let ref_column: String = row.try_get("REFERENCED_COLUMN_NAME").unwrap_or_default();
+
+        let entry = fk_map.entry(name.clone()).or_insert_with(|| ForeignKeyItem {
+            name,
+            columns: Vec::new(),
+            referenced_table: ref_table,
+            referenced_columns: Vec::new(),
+        });
+        entry.columns.push(column);
+        entry.referenced_columns.push(ref_column);
+    }
+
+    Ok(fk_map.into_values().collect())
+}
+
+// SQLite introspection
+
+fn is_safe_identifier(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.')
+}
+
+async fn fetch_schema_sqlite(pool: &sqlx::SqlitePool) -> Result<SchemaInfo, DbError> {
+    let tables = fetch_tables_sqlite(pool).await?;
+    let views = fetch_views_sqlite(pool).await?;
+
+    Ok(SchemaInfo {
+        schemas: vec![SchemaItem {
+            name: "main".to_string(),
+            tables,
+            views,
+        }],
+    })
+}
+
+async fn fetch_tables_sqlite(pool: &sqlx::SqlitePool) -> Result<Vec<TableItem>, DbError> {
+    let table_rows = sqlx::query(
+        "SELECT name FROM sqlite_master \
+         WHERE type = 'table' AND name NOT LIKE 'sqlite_%' \
+         ORDER BY name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut tables = Vec::with_capacity(table_rows.len());
+
+    for table_row in &table_rows {
+        let table_name: String = table_row.try_get("name").unwrap_or_default();
+
+        if !is_safe_identifier(&table_name) {
+            continue;
+        }
+
+        let columns = fetch_columns_sqlite(pool, &table_name).await?;
+        let indexes = fetch_indexes_sqlite(pool, &table_name).await?;
+        let foreign_keys = fetch_fks_sqlite(pool, &table_name).await?;
+
+        tables.push(TableItem {
+            name: table_name,
+            columns,
+            indexes,
+            foreign_keys,
+        });
+    }
+
+    Ok(tables)
+}
+
+async fn fetch_views_sqlite(pool: &sqlx::SqlitePool) -> Result<Vec<ViewItem>, DbError> {
+    let view_rows = sqlx::query(
+        "SELECT name FROM sqlite_master \
+         WHERE type = 'view' \
+         ORDER BY name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut views = Vec::with_capacity(view_rows.len());
+
+    for view_row in &view_rows {
+        let view_name: String = view_row.try_get("name").unwrap_or_default();
+
+        if !is_safe_identifier(&view_name) {
+            continue;
+        }
+
+        let columns = fetch_columns_sqlite(pool, &view_name).await?;
+
+        views.push(ViewItem {
+            name: view_name,
+            columns,
+        });
+    }
+
+    Ok(views)
+}
+
+async fn fetch_columns_sqlite(
+    pool: &sqlx::SqlitePool,
+    table_name: &str,
+) -> Result<Vec<ColumnDetail>, DbError> {
+    let query = format!("PRAGMA table_info('{table_name}')");
+    let rows = sqlx::query(&query)
+        .fetch_all(pool)
+        .await
+        .map_err(DbError::from)?;
+
+    Ok(rows
+        .iter()
+        .map(|row| {
+            let notnull: i32 = row.try_get("notnull").unwrap_or(0);
+            let pk: i32 = row.try_get("pk").unwrap_or(0);
+            ColumnDetail {
+                name: row.try_get("name").unwrap_or_default(),
+                data_type: row.try_get("type").unwrap_or_default(),
+                is_nullable: notnull == 0,
+                is_primary_key: pk > 0,
+                default_value: row.try_get("dflt_value").ok(),
+            }
+        })
+        .collect())
+}
+
+async fn fetch_indexes_sqlite(
+    pool: &sqlx::SqlitePool,
+    table_name: &str,
+) -> Result<Vec<IndexItem>, DbError> {
+    let list_query = format!("PRAGMA index_list('{table_name}')");
+    let index_rows = sqlx::query(&list_query)
+        .fetch_all(pool)
+        .await
+        .map_err(DbError::from)?;
+
+    let mut indexes = Vec::with_capacity(index_rows.len());
+
+    for index_row in &index_rows {
+        let index_name: String = index_row.try_get("name").unwrap_or_default();
+        let unique: i32 = index_row.try_get("unique").unwrap_or(0);
+
+        if !is_safe_identifier(&index_name) {
+            continue;
+        }
+
+        let info_query = format!("PRAGMA index_info('{index_name}')");
+        let col_rows = sqlx::query(&info_query)
+            .fetch_all(pool)
+            .await
+            .map_err(DbError::from)?;
+
+        let columns: Vec<String> = col_rows
+            .iter()
+            .map(|r| r.try_get("name").unwrap_or_default())
+            .collect();
+
+        indexes.push(IndexItem {
+            name: index_name,
+            columns,
+            is_unique: unique != 0,
+        });
+    }
+
+    Ok(indexes)
+}
+
+async fn fetch_fks_sqlite(
+    pool: &sqlx::SqlitePool,
+    table_name: &str,
+) -> Result<Vec<ForeignKeyItem>, DbError> {
+    let query = format!("PRAGMA foreign_key_list('{table_name}')");
+    let rows = sqlx::query(&query)
+        .fetch_all(pool)
+        .await
+        .map_err(DbError::from)?;
+
+    let mut fk_map: std::collections::HashMap<i32, ForeignKeyItem> =
+        std::collections::HashMap::new();
+
+    for row in &rows {
+        let id: i32 = row.try_get("id").unwrap_or(0);
+        let from: String = row.try_get("from").unwrap_or_default();
+        let table: String = row.try_get("table").unwrap_or_default();
+        let to: String = row.try_get("to").unwrap_or_default();
+
+        let entry = fk_map.entry(id).or_insert_with(|| ForeignKeyItem {
+            name: format!("fk_{table_name}_{id}"),
+            columns: Vec::new(),
+            referenced_table: table,
+            referenced_columns: Vec::new(),
+        });
+        entry.columns.push(from);
+        entry.referenced_columns.push(to);
+    }
+
+    Ok(fk_map.into_values().collect())
+}

--- a/apps/web/src-tauri/src/db/types.rs
+++ b/apps/web/src-tauri/src/db/types.rs
@@ -1,5 +1,62 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaInfo {
+    pub schemas: Vec<SchemaItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaItem {
+    pub name: String,
+    pub tables: Vec<TableItem>,
+    pub views: Vec<ViewItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TableItem {
+    pub name: String,
+    pub columns: Vec<ColumnDetail>,
+    pub indexes: Vec<IndexItem>,
+    pub foreign_keys: Vec<ForeignKeyItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ViewItem {
+    pub name: String,
+    pub columns: Vec<ColumnDetail>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnDetail {
+    pub name: String,
+    pub data_type: String,
+    pub is_nullable: bool,
+    pub is_primary_key: bool,
+    pub default_value: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexItem {
+    pub name: String,
+    pub columns: Vec<String>,
+    pub is_unique: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForeignKeyItem {
+    pub name: String,
+    pub columns: Vec<String>,
+    pub referenced_table: String,
+    pub referenced_columns: Vec<String>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectionParams {

--- a/apps/web/src-tauri/src/lib.rs
+++ b/apps/web/src-tauri/src/lib.rs
@@ -18,6 +18,8 @@ pub fn run() {
             commands::disconnect_from_database,
             commands::get_server_version,
             commands::execute_query,
+            commands::list_connection_databases,
+            commands::get_schema,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/web/src/components/ui/collapsible.tsx
+++ b/apps/web/src/components/ui/collapsible.tsx
@@ -1,0 +1,19 @@
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible";
+
+function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({ ...props }: CollapsiblePrimitive.Trigger.Props) {
+  return (
+    <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+  );
+}
+
+function CollapsibleContent({ ...props }: CollapsiblePrimitive.Panel.Props) {
+  return (
+    <CollapsiblePrimitive.Panel data-slot="collapsible-content" {...props} />
+  );
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/apps/web/src/components/ui/scroll-area.tsx
+++ b/apps/web/src/components/ui/scroll-area.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: ScrollAreaPrimitive.Root.Props) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: ScrollAreaPrimitive.Scrollbar.Props) {
+  return (
+    <ScrollAreaPrimitive.Scrollbar
+      data-slot="scroll-area-scrollbar"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent flex touch-none p-px transition-colors select-none",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Thumb
+        data-slot="scroll-area-thumb"
+        className="rounded-full bg-border relative flex-1"
+      />
+    </ScrollAreaPrimitive.Scrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar };

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,64 @@
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-md px-3 py-1.5 text-xs **:data-[slot=kbd]:rounded-md data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 bg-foreground text-background z-50 w-fit max-w-xs origin-(--transform-origin)",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 bg-foreground fill-foreground z-50 data-[side=bottom]:top-1 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/apps/web/src/components/workspace/column-node.tsx
+++ b/apps/web/src/components/workspace/column-node.tsx
@@ -1,0 +1,54 @@
+import { Columns3, KeyRound } from "lucide-react";
+import { useCallback } from "react";
+
+import type { ColumnDetail } from "@/lib/tauri";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useEditorInsert } from "@/contexts/editor-insert-context";
+
+interface ColumnNodeProps {
+  column: ColumnDetail;
+}
+
+export const ColumnNode = ({ column }: ColumnNodeProps) => {
+  const { insertAtCursor } = useEditorInsert();
+
+  const handleClick = useCallback(() => {
+    insertAtCursor(column.name);
+  }, [insertAtCursor, column.name]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-xs hover:bg-sidebar-accent/50"
+            onClick={handleClick}
+          />
+        }
+      >
+        {column.isPrimaryKey ? (
+          <KeyRound className="size-3 shrink-0 text-amber-500" />
+        ) : (
+          <Columns3 className="size-3 shrink-0 text-muted-foreground" />
+        )}
+        <span className="truncate">{column.name}</span>
+        <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
+          {column.dataType}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        <p>
+          {column.dataType}
+          {column.isNullable ? " (nullable)" : " (not null)"}
+        </p>
+        {column.defaultValue && <p>Default: {column.defaultValue}</p>}
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/apps/web/src/components/workspace/schema-tree.tsx
+++ b/apps/web/src/components/workspace/schema-tree.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from "react";
+
+import type { SchemaInfo, SchemaItem } from "@/lib/tauri";
+
+import { TableNode } from "./table-node";
+
+interface SchemaTreeProps {
+  schema: SchemaInfo;
+  filter: string;
+}
+
+const filterSchema = (schema: SchemaItem, query: string): SchemaItem => {
+  const lower = query.toLowerCase();
+  return {
+    ...schema,
+    tables: schema.tables.filter((t) => t.name.toLowerCase().includes(lower)),
+    views: schema.views.filter((v) => v.name.toLowerCase().includes(lower)),
+  };
+};
+
+export const SchemaTree = ({ schema, filter }: SchemaTreeProps) => {
+  const filtered = useMemo(() => {
+    const [first] = schema.schemas;
+    if (!first) {
+      return null;
+    }
+    return filter ? filterSchema(first, filter) : first;
+  }, [schema, filter]);
+
+  if (
+    !filtered ||
+    (filtered.tables.length === 0 && filtered.views.length === 0)
+  ) {
+    return (
+      <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+        No tables or views found
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-1 py-1">
+      {filtered.tables.length > 0 && (
+        <>
+          <div className="mb-0.5 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            Tables ({filtered.tables.length})
+          </div>
+          {filtered.tables.map((table) => (
+            <TableNode key={table.name} table={table} />
+          ))}
+        </>
+      )}
+
+      {filtered.views.length > 0 && (
+        <>
+          <div className="mb-0.5 mt-3 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            Views ({filtered.views.length})
+          </div>
+          {filtered.views.map((view) => (
+            <TableNode key={view.name} table={view} isView />
+          ))}
+        </>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/components/workspace/sql-editor.tsx
+++ b/apps/web/src/components/workspace/sql-editor.tsx
@@ -1,10 +1,14 @@
+import type { EditorView } from "@codemirror/view";
+
 import { sql, PostgreSQL, MySQL, SQLite } from "@codemirror/lang-sql";
 import { keymap } from "@codemirror/view";
 import { githubDark } from "@uiw/codemirror-theme-github";
 import CodeMirror from "@uiw/react-codemirror";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import type { DatabaseType } from "@/lib/connections";
+
+import { useEditorInsert } from "@/contexts/editor-insert-context";
 
 const DIALECT_MAP = {
   mysql: MySQL,
@@ -27,6 +31,15 @@ export const SqlEditor = ({
   databaseType,
   readOnly = false,
 }: SqlEditorProps) => {
+  const { registerEditor } = useEditorInsert();
+
+  const handleCreateEditor = useCallback(
+    (view: EditorView) => {
+      registerEditor(view);
+    },
+    [registerEditor]
+  );
+
   const extensions = useMemo(
     () => [
       sql({ dialect: DIALECT_MAP[databaseType] }),
@@ -47,6 +60,7 @@ export const SqlEditor = ({
     <CodeMirror
       value={value}
       onChange={onChange}
+      onCreateEditor={handleCreateEditor}
       extensions={extensions}
       theme={githubDark}
       placeholder="Write your SQL query here..."

--- a/apps/web/src/components/workspace/table-node.tsx
+++ b/apps/web/src/components/workspace/table-node.tsx
@@ -1,0 +1,106 @@
+import { ChevronRight, Eye, Link, ListOrdered, Table2 } from "lucide-react";
+import { useCallback } from "react";
+
+import type { TableItem, ViewItem } from "@/lib/tauri";
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { useEditorInsert } from "@/contexts/editor-insert-context";
+
+import { ColumnNode } from "./column-node";
+
+interface TableNodeProps {
+  table: TableItem | ViewItem;
+  isView?: boolean;
+}
+
+const isTableItem = (item: TableItem | ViewItem): item is TableItem =>
+  "indexes" in item;
+
+export const TableNode = ({ table, isView = false }: TableNodeProps) => {
+  const { insertAtCursor } = useEditorInsert();
+  const hasIndexes = isTableItem(table) && table.indexes.length > 0;
+  const hasForeignKeys = isTableItem(table) && table.foreignKeys.length > 0;
+
+  const handleInsert = useCallback(() => {
+    insertAtCursor(table.name);
+  }, [insertAtCursor, table.name]);
+
+  return (
+    <Collapsible className="group/table">
+      <div className="flex items-center">
+        <CollapsibleTrigger className="flex flex-1 items-center gap-1.5 rounded-md px-2 py-1 text-xs hover:bg-sidebar-accent/50 [&[data-panel-open]>svg:first-child]:rotate-90">
+          <ChevronRight className="size-3 shrink-0 text-muted-foreground transition-transform" />
+          {isView ? (
+            <Eye className="size-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <Table2 className="size-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <span className="truncate">{table.name}</span>
+        </CollapsibleTrigger>
+        <button
+          type="button"
+          className="mr-1 rounded p-0.5 text-muted-foreground opacity-0 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground group-hover/table:opacity-100"
+          onClick={handleInsert}
+          aria-label={`Insert ${table.name}`}
+        >
+          <Table2 className="size-3" />
+        </button>
+      </div>
+      <CollapsibleContent>
+        <div className="ml-3 border-l border-sidebar-border pl-2">
+          <div className="mb-0.5 mt-1 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            Columns ({table.columns.length})
+          </div>
+          {table.columns.map((col) => (
+            <ColumnNode key={col.name} column={col} />
+          ))}
+
+          {hasIndexes && (
+            <>
+              <div className="mb-0.5 mt-2 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                Indexes ({table.indexes.length})
+              </div>
+              {table.indexes.map((idx) => (
+                <div
+                  key={idx.name}
+                  className="flex items-center gap-2 px-2 py-1 text-xs text-muted-foreground"
+                >
+                  <ListOrdered className="size-3 shrink-0" />
+                  <span className="truncate">{idx.name}</span>
+                  {idx.isUnique && (
+                    <span className="ml-auto shrink-0 text-[10px] text-amber-500/70">
+                      unique
+                    </span>
+                  )}
+                </div>
+              ))}
+            </>
+          )}
+
+          {hasForeignKeys && (
+            <>
+              <div className="mb-0.5 mt-2 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                Foreign Keys ({table.foreignKeys.length})
+              </div>
+              {table.foreignKeys.map((fk) => (
+                <div
+                  key={fk.name}
+                  className="flex items-center gap-2 px-2 py-1 text-xs text-muted-foreground"
+                >
+                  <Link className="size-3 shrink-0" />
+                  <span className="truncate">
+                    {fk.columns.join(", ")} &rarr; {fk.referencedTable}
+                  </span>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};

--- a/apps/web/src/components/workspace/workspace-layout.tsx
+++ b/apps/web/src/components/workspace/workspace-layout.tsx
@@ -106,7 +106,7 @@ export const WorkspaceLayout = ({
           collapsedSize="0%"
           onResize={handleResize}
         >
-          <WorkspaceSidebar connection={connection} />
+          <WorkspaceSidebar connection={connection} isConnected={isConnected} />
         </ResizablePanel>
 
         <ResizableHandle withHandle />

--- a/apps/web/src/components/workspace/workspace-sidebar.tsx
+++ b/apps/web/src/components/workspace/workspace-sidebar.tsx
@@ -1,59 +1,199 @@
-import { Eye, Table2 } from "lucide-react";
+import { AlertCircle, Database, RefreshCw, Search } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { DatabaseConnection } from "@/lib/connections";
 
+import { Button } from "@/components/ui/button";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+} from "@/components/ui/input-group";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useSchema } from "@/hooks/use-schema";
 import { isTauri } from "@/lib/tauri";
 import { cn } from "@/lib/utils";
 
+import { SchemaTree } from "./schema-tree";
+
 interface WorkspaceSidebarProps {
   connection: DatabaseConnection;
+  isConnected: boolean;
 }
 
-const PLACEHOLDER_TABLES = ["users", "orders", "products", "categories"];
-const PLACEHOLDER_VIEWS = ["active_users", "order_summary"];
+const SKELETON_ITEMS = [
+  { id: "s1", width: "w-3/4" },
+  { id: "s2", width: "w-1/2" },
+  { id: "s3", width: "w-5/6" },
+  { id: "s4", width: "w-2/3" },
+  { id: "s5", width: "w-3/5" },
+  { id: "s6", width: "w-1/2" },
+];
 
-export const WorkspaceSidebar = ({ connection }: WorkspaceSidebarProps) => (
-  <div
-    className={cn(
-      "flex h-full flex-col text-sidebar-foreground",
-      isTauri() ? "bg-transparent" : "bg-sidebar"
-    )}
-  >
-    <div className="px-3 py-2">
-      <span className="truncate text-sm font-medium">{connection.name}</span>
-    </div>
-
-    <Separator className="bg-sidebar-border" />
-
-    <div className="flex-1 overflow-y-auto px-2 py-2">
-      <div className="mb-2 px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-        Tables
-      </div>
-      {PLACEHOLDER_TABLES.map((table) => (
-        <button
-          key={table}
-          type="button"
-          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground"
-        >
-          <Table2 className="size-3.5 text-muted-foreground" />
-          {table}
-        </button>
-      ))}
-
-      <div className="mb-2 mt-4 px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-        Views
-      </div>
-      {PLACEHOLDER_VIEWS.map((view) => (
-        <button
-          key={view}
-          type="button"
-          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground"
-        >
-          <Eye className="size-3.5 text-muted-foreground" />
-          {view}
-        </button>
-      ))}
-    </div>
+const SchemaLoadingState = () => (
+  <div className="space-y-2 px-3 py-2">
+    {SKELETON_ITEMS.map((item) => (
+      <Skeleton key={item.id} className={cn("h-5", item.width)} />
+    ))}
   </div>
 );
+
+interface SchemaErrorStateProps {
+  error: string;
+  onRetry: () => void;
+}
+
+const SchemaErrorState = ({ error, onRetry }: SchemaErrorStateProps) => (
+  <div className="flex flex-col items-center gap-2 px-3 py-6 text-center">
+    <AlertCircle className="size-5 text-destructive" />
+    <p className="text-xs text-muted-foreground">{error}</p>
+    <Button variant="outline" size="sm" onClick={onRetry}>
+      <RefreshCw className="mr-1.5 size-3" />
+      Retry
+    </Button>
+  </div>
+);
+
+interface DatabaseSelectorProps {
+  databases: string[];
+  selected: string;
+  onSelect: (value: string) => void;
+}
+
+const DatabaseSelector = ({
+  databases,
+  selected,
+  onSelect,
+}: DatabaseSelectorProps) => {
+  const handleChange = useCallback(
+    (value: string | null) => {
+      if (value) {
+        onSelect(value);
+      }
+    },
+    [onSelect]
+  );
+
+  return (
+    <div className="border-t border-sidebar-border px-2 py-2">
+      <Select value={selected} onValueChange={handleChange}>
+        <SelectTrigger size="sm" className="w-full">
+          <Database className="size-3 text-muted-foreground" />
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent side="top">
+          {databases.map((db) => (
+            <SelectItem key={db} value={db}>
+              {db}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};
+
+export const WorkspaceSidebar = ({
+  connection,
+  isConnected,
+}: WorkspaceSidebarProps) => {
+  const {
+    schema,
+    isLoading,
+    error,
+    refresh,
+    databases,
+    selectedDatabase,
+    setSelectedDatabase,
+  } = useSchema(connection.id, isConnected);
+  const [filter, setFilter] = useState("");
+
+  const handleFilterChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFilter(e.target.value);
+    },
+    []
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "F5") {
+        e.preventDefault();
+        refresh();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [refresh]);
+
+  const showDatabaseSelector =
+    databases && databases.length > 1 && selectedDatabase;
+
+  return (
+    <div
+      className={cn(
+        "flex h-full flex-col text-sidebar-foreground",
+        isTauri() ? "bg-transparent" : "bg-sidebar"
+      )}
+    >
+      <div className="flex items-center justify-between px-3 py-2">
+        <span className="truncate text-sm font-medium">{connection.name}</span>
+        {schema && (
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={refresh}
+            aria-label="Refresh schema"
+            disabled={isLoading}
+          >
+            <RefreshCw className={cn("size-3", isLoading && "animate-spin")} />
+          </Button>
+        )}
+      </div>
+
+      <Separator className="bg-sidebar-border" />
+
+      {schema && (
+        <div className="px-2 py-2">
+          <InputGroup>
+            <InputGroupAddon>
+              <InputGroupText>
+                <Search />
+              </InputGroupText>
+            </InputGroupAddon>
+            <InputGroupInput
+              placeholder="Filter tables..."
+              value={filter}
+              onChange={handleFilterChange}
+            />
+          </InputGroup>
+        </div>
+      )}
+
+      <ScrollArea className="min-h-0 flex-1">
+        {isLoading && !schema && <SchemaLoadingState />}
+        {error && <SchemaErrorState error={error} onRetry={refresh} />}
+        {schema && <SchemaTree schema={schema} filter={filter} />}
+      </ScrollArea>
+
+      {showDatabaseSelector && (
+        <DatabaseSelector
+          databases={databases}
+          selected={selectedDatabase}
+          onSelect={setSelectedDatabase}
+        />
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/contexts/editor-insert-context.tsx
+++ b/apps/web/src/contexts/editor-insert-context.tsx
@@ -1,0 +1,51 @@
+import type { EditorView } from "@codemirror/view";
+import type { ReactNode } from "react";
+
+import { createContext, use, useCallback, useRef } from "react";
+
+interface EditorInsertContextValue {
+  insertAtCursor: (text: string) => void;
+  registerEditor: (view: EditorView | null) => void;
+}
+
+const EditorInsertContext = createContext<EditorInsertContextValue | null>(
+  null
+);
+
+export const EditorInsertProvider = ({ children }: { children: ReactNode }) => {
+  const editorRef = useRef<EditorView | null>(null);
+
+  const registerEditor = useCallback((view: EditorView | null) => {
+    editorRef.current = view;
+  }, []);
+
+  const insertAtCursor = useCallback((text: string) => {
+    const view = editorRef.current;
+    if (!view) {
+      return;
+    }
+
+    const { from } = view.state.selection.main;
+    view.dispatch({
+      changes: { from, insert: text },
+      selection: { anchor: from + text.length },
+    });
+    view.focus();
+  }, []);
+
+  return (
+    <EditorInsertContext value={{ insertAtCursor, registerEditor }}>
+      {children}
+    </EditorInsertContext>
+  );
+};
+
+export const useEditorInsert = (): EditorInsertContextValue => {
+  const ctx = use(EditorInsertContext);
+  if (!ctx) {
+    throw new Error(
+      "useEditorInsert must be used within an EditorInsertProvider"
+    );
+  }
+  return ctx;
+};

--- a/apps/web/src/hooks/use-schema.ts
+++ b/apps/web/src/hooks/use-schema.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { SchemaInfo } from "@/lib/tauri";
+
+import { getSchema, listDatabases } from "@/lib/tauri";
+
+interface SchemaState {
+  databases: string[] | null;
+  selectedDatabase: string | null;
+  schema: SchemaInfo | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const useSchema = (connectionId: string, isConnected: boolean) => {
+  const [state, setState] = useState<SchemaState>({
+    databases: null,
+    error: null,
+    isLoading: false,
+    schema: null,
+    selectedDatabase: null,
+  });
+
+  const fetchDatabases = useCallback(async () => {
+    setState((prev) => ({ ...prev, error: null, isLoading: true }));
+
+    try {
+      const databases = await listDatabases(connectionId);
+      const selected =
+        databases.find((db) => db === "public") ?? databases[0] ?? null;
+
+      setState((prev) => ({
+        ...prev,
+        databases,
+        isLoading: false,
+        selectedDatabase: selected,
+      }));
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to list databases";
+      setState((prev) => ({ ...prev, error: message, isLoading: false }));
+    }
+  }, [connectionId]);
+
+  const fetchSchema = useCallback(
+    async (databaseName: string) => {
+      setState((prev) => ({ ...prev, error: null, isLoading: true }));
+
+      try {
+        const schema = await getSchema(connectionId, databaseName);
+        setState((prev) => ({
+          ...prev,
+          error: null,
+          isLoading: false,
+          schema,
+        }));
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Failed to load schema";
+        setState((prev) => ({
+          ...prev,
+          error: message,
+          isLoading: false,
+          schema: null,
+        }));
+      }
+    },
+    [connectionId]
+  );
+
+  const setSelectedDatabase = useCallback((database: string) => {
+    setState((prev) => ({ ...prev, schema: null, selectedDatabase: database }));
+  }, []);
+
+  const refresh = useCallback(() => {
+    if (state.selectedDatabase) {
+      fetchSchema(state.selectedDatabase);
+    }
+  }, [state.selectedDatabase, fetchSchema]);
+
+  useEffect(() => {
+    if (isConnected) {
+      fetchDatabases();
+    }
+  }, [isConnected, fetchDatabases]);
+
+  useEffect(() => {
+    if (state.selectedDatabase) {
+      fetchSchema(state.selectedDatabase);
+    }
+  }, [state.selectedDatabase, fetchSchema]);
+
+  return {
+    databases: state.databases,
+    error: state.error,
+    isLoading: state.isLoading,
+    refresh,
+    schema: state.schema,
+    selectedDatabase: state.selectedDatabase,
+    setSelectedDatabase,
+  };
+};

--- a/apps/web/src/lib/tauri.ts
+++ b/apps/web/src/lib/tauri.ts
@@ -55,6 +55,49 @@ export interface QueryResult {
   isTruncated: boolean;
 }
 
+export interface SchemaInfo {
+  schemas: SchemaItem[];
+}
+
+export interface SchemaItem {
+  name: string;
+  tables: TableItem[];
+  views: ViewItem[];
+}
+
+export interface TableItem {
+  name: string;
+  columns: ColumnDetail[];
+  indexes: IndexItem[];
+  foreignKeys: ForeignKeyItem[];
+}
+
+export interface ViewItem {
+  name: string;
+  columns: ColumnDetail[];
+}
+
+export interface ColumnDetail {
+  name: string;
+  dataType: string;
+  isNullable: boolean;
+  isPrimaryKey: boolean;
+  defaultValue: string | null;
+}
+
+export interface IndexItem {
+  name: string;
+  columns: string[];
+  isUnique: boolean;
+}
+
+export interface ForeignKeyItem {
+  name: string;
+  columns: string[];
+  referencedTable: string;
+  referencedColumns: string[];
+}
+
 export const connectToDatabase = async (
   connectionId: string,
   connection: Omit<DatabaseConnection, "id" | "name" | "createdAt">
@@ -126,4 +169,257 @@ export const executeQuery = async (
   const { invoke } = await import("@tauri-apps/api/core");
 
   return invoke<QueryResult>("execute_query", { params });
+};
+
+const MOCK_SCHEMA: SchemaInfo = {
+  schemas: [
+    {
+      name: "public",
+      tables: [
+        {
+          columns: [
+            {
+              dataType: "integer",
+              defaultValue: "nextval('users_id_seq')",
+              isNullable: false,
+              isPrimaryKey: true,
+              name: "id",
+            },
+            {
+              dataType: "text",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "name",
+            },
+            {
+              dataType: "text",
+              defaultValue: null,
+              isNullable: true,
+              isPrimaryKey: false,
+              name: "email",
+            },
+            {
+              dataType: "boolean",
+              defaultValue: "true",
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "active",
+            },
+            {
+              dataType: "timestamp",
+              defaultValue: "now()",
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "created_at",
+            },
+          ],
+          foreignKeys: [],
+          indexes: [
+            { columns: ["id"], isUnique: true, name: "users_pkey" },
+            { columns: ["email"], isUnique: true, name: "users_email_idx" },
+          ],
+          name: "users",
+        },
+        {
+          columns: [
+            {
+              dataType: "integer",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: true,
+              name: "id",
+            },
+            {
+              dataType: "integer",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "user_id",
+            },
+            {
+              dataType: "numeric",
+              defaultValue: "0",
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "total",
+            },
+            {
+              dataType: "text",
+              defaultValue: "'pending'",
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "status",
+            },
+            {
+              dataType: "timestamp",
+              defaultValue: "now()",
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "created_at",
+            },
+          ],
+          foreignKeys: [
+            {
+              columns: ["user_id"],
+              name: "orders_user_id_fkey",
+              referencedColumns: ["id"],
+              referencedTable: "users",
+            },
+          ],
+          indexes: [
+            { columns: ["id"], isUnique: true, name: "orders_pkey" },
+            {
+              columns: ["user_id"],
+              isUnique: false,
+              name: "orders_user_id_idx",
+            },
+          ],
+          name: "orders",
+        },
+        {
+          columns: [
+            {
+              dataType: "integer",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: true,
+              name: "id",
+            },
+            {
+              dataType: "text",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "name",
+            },
+            {
+              dataType: "numeric",
+              defaultValue: "0",
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "price",
+            },
+            {
+              dataType: "integer",
+              defaultValue: null,
+              isNullable: true,
+              isPrimaryKey: false,
+              name: "category_id",
+            },
+          ],
+          foreignKeys: [
+            {
+              columns: ["category_id"],
+              name: "products_category_id_fkey",
+              referencedColumns: ["id"],
+              referencedTable: "categories",
+            },
+          ],
+          indexes: [{ columns: ["id"], isUnique: true, name: "products_pkey" }],
+          name: "products",
+        },
+        {
+          columns: [
+            {
+              dataType: "integer",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: true,
+              name: "id",
+            },
+            {
+              dataType: "text",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "name",
+            },
+          ],
+          foreignKeys: [],
+          indexes: [
+            { columns: ["id"], isUnique: true, name: "categories_pkey" },
+          ],
+          name: "categories",
+        },
+      ],
+      views: [
+        {
+          columns: [
+            {
+              dataType: "integer",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "id",
+            },
+            {
+              dataType: "text",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "name",
+            },
+            {
+              dataType: "text",
+              defaultValue: null,
+              isNullable: true,
+              isPrimaryKey: false,
+              name: "email",
+            },
+          ],
+          name: "active_users",
+        },
+        {
+          columns: [
+            {
+              dataType: "integer",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "user_id",
+            },
+            {
+              dataType: "bigint",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "total_orders",
+            },
+            {
+              dataType: "numeric",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "total_amount",
+            },
+          ],
+          name: "order_summary",
+        },
+      ],
+    },
+  ],
+};
+
+export const listDatabases = async (
+  connectionId: string
+): Promise<string[]> => {
+  if (!isTauri()) {
+    return ["public"];
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<string[]>("list_connection_databases", { connectionId });
+};
+
+export const getSchema = async (
+  connectionId: string,
+  databaseName: string
+): Promise<SchemaInfo> => {
+  if (!isTauri()) {
+    return MOCK_SCHEMA;
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<SchemaInfo>("get_schema", { connectionId, databaseName });
 };

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,117 +8,117 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as DefaultRouteImport } from "./routes/_default";
-import { Route as DefaultIndexRouteImport } from "./routes/_default/index";
-import { Route as DefaultOnboardingRouteImport } from "./routes/_default/onboarding";
-import { Route as WorkspaceConnectionIdRouteImport } from "./routes/workspace/$connectionId";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as DefaultRouteImport } from './routes/_default'
+import { Route as DefaultIndexRouteImport } from './routes/_default/index'
+import { Route as WorkspaceConnectionIdRouteImport } from './routes/workspace/$connectionId'
+import { Route as DefaultOnboardingRouteImport } from './routes/_default/onboarding'
 
 const DefaultRoute = DefaultRouteImport.update({
-  id: "/_default",
+  id: '/_default',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DefaultIndexRoute = DefaultIndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => DefaultRoute,
-} as any);
+} as any)
 const WorkspaceConnectionIdRoute = WorkspaceConnectionIdRouteImport.update({
-  id: "/workspace/$connectionId",
-  path: "/workspace/$connectionId",
+  id: '/workspace/$connectionId',
+  path: '/workspace/$connectionId',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DefaultOnboardingRoute = DefaultOnboardingRouteImport.update({
-  id: "/onboarding",
-  path: "/onboarding",
+  id: '/onboarding',
+  path: '/onboarding',
   getParentRoute: () => DefaultRoute,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof DefaultIndexRoute;
-  "/onboarding": typeof DefaultOnboardingRoute;
-  "/workspace/$connectionId": typeof WorkspaceConnectionIdRoute;
+  '/': typeof DefaultIndexRoute
+  '/onboarding': typeof DefaultOnboardingRoute
+  '/workspace/$connectionId': typeof WorkspaceConnectionIdRoute
 }
 export interface FileRoutesByTo {
-  "/onboarding": typeof DefaultOnboardingRoute;
-  "/workspace/$connectionId": typeof WorkspaceConnectionIdRoute;
-  "/": typeof DefaultIndexRoute;
+  '/onboarding': typeof DefaultOnboardingRoute
+  '/workspace/$connectionId': typeof WorkspaceConnectionIdRoute
+  '/': typeof DefaultIndexRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/_default": typeof DefaultRouteWithChildren;
-  "/_default/onboarding": typeof DefaultOnboardingRoute;
-  "/workspace/$connectionId": typeof WorkspaceConnectionIdRoute;
-  "/_default/": typeof DefaultIndexRoute;
+  __root__: typeof rootRouteImport
+  '/_default': typeof DefaultRouteWithChildren
+  '/_default/onboarding': typeof DefaultOnboardingRoute
+  '/workspace/$connectionId': typeof WorkspaceConnectionIdRoute
+  '/_default/': typeof DefaultIndexRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: "/" | "/onboarding" | "/workspace/$connectionId";
-  fileRoutesByTo: FileRoutesByTo;
-  to: "/onboarding" | "/workspace/$connectionId" | "/";
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths: '/' | '/onboarding' | '/workspace/$connectionId'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/onboarding' | '/workspace/$connectionId' | '/'
   id:
-    | "__root__"
-    | "/_default"
-    | "/_default/onboarding"
-    | "/workspace/$connectionId"
-    | "/_default/";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/_default'
+    | '/_default/onboarding'
+    | '/workspace/$connectionId'
+    | '/_default/'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  DefaultRoute: typeof DefaultRouteWithChildren;
-  WorkspaceConnectionIdRoute: typeof WorkspaceConnectionIdRoute;
+  DefaultRoute: typeof DefaultRouteWithChildren
+  WorkspaceConnectionIdRoute: typeof WorkspaceConnectionIdRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/_default": {
-      id: "/_default";
-      path: "";
-      fullPath: "/";
-      preLoaderRoute: typeof DefaultRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/_default/": {
-      id: "/_default/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof DefaultIndexRouteImport;
-      parentRoute: typeof DefaultRoute;
-    };
-    "/workspace/$connectionId": {
-      id: "/workspace/$connectionId";
-      path: "/workspace/$connectionId";
-      fullPath: "/workspace/$connectionId";
-      preLoaderRoute: typeof WorkspaceConnectionIdRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/_default/onboarding": {
-      id: "/_default/onboarding";
-      path: "/onboarding";
-      fullPath: "/onboarding";
-      preLoaderRoute: typeof DefaultOnboardingRouteImport;
-      parentRoute: typeof DefaultRoute;
-    };
+    '/_default': {
+      id: '/_default'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof DefaultRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_default/': {
+      id: '/_default/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof DefaultIndexRouteImport
+      parentRoute: typeof DefaultRoute
+    }
+    '/workspace/$connectionId': {
+      id: '/workspace/$connectionId'
+      path: '/workspace/$connectionId'
+      fullPath: '/workspace/$connectionId'
+      preLoaderRoute: typeof WorkspaceConnectionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_default/onboarding': {
+      id: '/_default/onboarding'
+      path: '/onboarding'
+      fullPath: '/onboarding'
+      preLoaderRoute: typeof DefaultOnboardingRouteImport
+      parentRoute: typeof DefaultRoute
+    }
   }
 }
 
 interface DefaultRouteChildren {
-  DefaultOnboardingRoute: typeof DefaultOnboardingRoute;
-  DefaultIndexRoute: typeof DefaultIndexRoute;
+  DefaultOnboardingRoute: typeof DefaultOnboardingRoute
+  DefaultIndexRoute: typeof DefaultIndexRoute
 }
 
 const DefaultRouteChildren: DefaultRouteChildren = {
   DefaultOnboardingRoute: DefaultOnboardingRoute,
   DefaultIndexRoute: DefaultIndexRoute,
-};
+}
 
 const DefaultRouteWithChildren =
-  DefaultRoute._addFileChildren(DefaultRouteChildren);
+  DefaultRoute._addFileChildren(DefaultRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   DefaultRoute: DefaultRouteWithChildren,
   WorkspaceConnectionIdRoute: WorkspaceConnectionIdRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
 
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import "@/index.css";
 
 export interface RouterAppContext {
@@ -43,8 +44,10 @@ function RootComponent() {
         disableTransitionOnChange
         storageKey="vite-ui-theme"
       >
-        <Outlet />
-        <Toaster richColors />
+        <TooltipProvider>
+          <Outlet />
+          <Toaster richColors />
+        </TooltipProvider>
       </ThemeProvider>
     </>
   );

--- a/apps/web/src/routes/workspace/$connectionId.tsx
+++ b/apps/web/src/routes/workspace/$connectionId.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
 import { WorkspaceLayout } from "@/components/workspace/workspace-layout";
+import { EditorInsertProvider } from "@/contexts/editor-insert-context";
 import { QueryExecutionProvider } from "@/contexts/query-execution-context";
 import { useConnectionLifecycle } from "@/hooks/use-connection-lifecycle";
 import { getConnections } from "@/lib/connections";
@@ -12,13 +13,15 @@ const WorkspacePage = () => {
 
   return (
     <QueryExecutionProvider>
-      <WorkspaceLayout
-        connection={connection}
-        isConnected={isConnected}
-        isConnecting={isConnecting}
-        connectionError={error}
-        serverVersion={serverVersion}
-      />
+      <EditorInsertProvider>
+        <WorkspaceLayout
+          connection={connection}
+          isConnected={isConnected}
+          isConnecting={isConnecting}
+          connectionError={error}
+          serverVersion={serverVersion}
+        />
+      </EditorInsertProvider>
     </QueryExecutionProvider>
   );
 };


### PR DESCRIPTION
## Summary
Add a database/schema selector dropdown to the sidebar for better performance on servers with many databases. The sidebar now lists databases via a fast `list_databases` call and loads only the selected database's schema. Default selection is "public" for PostgreSQL. Simplify the schema tree to always render a single flat layout.

## Changes
- **Rust backend**: Add `list_databases` command and modify `get_schema` to accept a database name parameter for single-schema loading
- **TypeScript frontend**: Add `useSchema` hook with two-step loading (list → fetch selected), prefer "public" schema by default
- **Components**: Create database selector dropdown (hidden for single-schema DBs), simplify schema tree rendering, fix ScrollArea with `min-h-0` for proper scrolling
- **Editor integration**: Add React Context (`EditorInsertProvider`) to enable click-to-insert table/column names into CodeMirror with F5 refresh hotkey

## Testing
1. Browser mode shows mock schema with "public" selected by default
2. Real multi-schema databases show the selector dropdown
3. Clicking tables/columns inserts into editor at cursor
4. F5 refreshes the schema for the selected database