### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.9"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint & format
+        run: bun run check
+
+      - name: Type-check
+        run: bun run check-types
+
+      - name: Build
+        run: bun run build
+
+  rust:
+    name: Rust
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.9"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build frontend
+        run: bun run build
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "apps/web/src-tauri -> target"
+
+      - name: Cargo check
+        run: cargo check --manifest-path apps/web/src-tauri/Cargo.toml
+
+      - name: Clippy
+        run: cargo clippy --manifest-path apps/web/src-tauri/Cargo.toml -- -D warnings
+
+      - name: Rustfmt
+        run: cargo fmt --manifest-path apps/web/src-tauri/Cargo.toml --check

--- a/apps/web/src-tauri/build.rs
+++ b/apps/web/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/apps/web/src-tauri/src/commands.rs
+++ b/apps/web/src-tauri/src/commands.rs
@@ -106,9 +106,7 @@ async fn execute_for_pool(
     max_rows: usize,
 ) -> Result<ExecuteResult, DbError> {
     match pool {
-        DatabasePool::Postgres(_)
-        | DatabasePool::MySql(_)
-        | DatabasePool::Sqlite(_) => {
+        DatabasePool::Postgres(_) | DatabasePool::MySql(_) | DatabasePool::Sqlite(_) => {
             let (columns, rows, is_truncated) = fetch_sql_rows(pool, command, max_rows).await?;
             Ok(ExecuteResult::Tabular {
                 row_count: rows.len() as u64,
@@ -118,12 +116,8 @@ async fn execute_for_pool(
                 is_truncated,
             })
         }
-        DatabasePool::MongoDB(client) => {
-            execute_mongodb(client, command, max_rows).await
-        }
-        DatabasePool::Redis(conn) => {
-            execute_redis(&mut conn.clone(), command).await
-        }
+        DatabasePool::MongoDB(client) => execute_mongodb(client, command, max_rows).await,
+        DatabasePool::Redis(conn) => execute_redis(&mut conn.clone(), command).await,
     }
 }
 
@@ -298,11 +292,10 @@ fn split_json_args(input: &str) -> Vec<String> {
 }
 
 fn parse_bson_doc(json_str: &str) -> Result<mongodb::bson::Document, DbError> {
-    let value: serde_json::Value =
-        serde_json::from_str(json_str).map_err(|e| DbError {
-            code: "PARSE_ERROR".to_string(),
-            message: format!("Invalid JSON: {e}"),
-        })?;
+    let value: serde_json::Value = serde_json::from_str(json_str).map_err(|e| DbError {
+        code: "PARSE_ERROR".to_string(),
+        message: format!("Invalid JSON: {e}"),
+    })?;
     let bson = mongodb::bson::to_bson(&value).map_err(|e| DbError {
         code: "PARSE_ERROR".to_string(),
         message: format!("Cannot convert to BSON: {e}"),
@@ -624,11 +617,7 @@ async fn execute_redis(
     Ok(redis_value_to_result(&value, &cmd_name, is_hash_command))
 }
 
-fn redis_value_to_result(
-    value: &redis::Value,
-    cmd_name: &str,
-    is_hash: bool,
-) -> ExecuteResult {
+fn redis_value_to_result(value: &redis::Value, cmd_name: &str, is_hash: bool) -> ExecuteResult {
     match value {
         redis::Value::Nil => ExecuteResult::Tabular {
             columns: vec![ColumnInfo {
@@ -770,7 +759,11 @@ async fn fetch_version(pool: &DatabasePool) -> Result<String, DbError> {
                 .await
                 .map_err(DbError::from)?;
             let full: String = row.try_get(0).unwrap_or_default();
-            Ok(full.split_whitespace().take(2).collect::<Vec<_>>().join(" "))
+            Ok(full
+                .split_whitespace()
+                .take(2)
+                .collect::<Vec<_>>()
+                .join(" "))
         }
         DatabasePool::MySql(pool) => {
             let row = sqlx::query("SELECT VERSION()")
@@ -794,9 +787,7 @@ async fn fetch_version(pool: &DatabasePool) -> Result<String, DbError> {
                 .run_command(mongodb::bson::doc! { "buildInfo": 1 })
                 .await
                 .map_err(DbError::from)?;
-            let version = result
-                .get_str("version")
-                .unwrap_or("unknown");
+            let version = result.get_str("version").unwrap_or("unknown");
             Ok(format!("MongoDB {version}"))
         }
         DatabasePool::Redis(conn) => {

--- a/apps/web/src-tauri/src/db/driver.rs
+++ b/apps/web/src-tauri/src/db/driver.rs
@@ -14,7 +14,6 @@ pub trait DatabaseDriver: Send + Sync {
         &self,
         params: &ConnectionParams,
     ) -> Result<TestConnectionResult, DbError>;
-
 }
 
 pub fn get_driver(db_type: &str) -> Result<Box<dyn DatabaseDriver>, DbError> {

--- a/apps/web/src-tauri/src/db/driver.rs
+++ b/apps/web/src-tauri/src/db/driver.rs
@@ -15,8 +15,6 @@ pub trait DatabaseDriver: Send + Sync {
         params: &ConnectionParams,
     ) -> Result<TestConnectionResult, DbError>;
 
-    #[allow(dead_code)]
-    fn driver_name(&self) -> &'static str;
 }
 
 pub fn get_driver(db_type: &str) -> Result<Box<dyn DatabaseDriver>, DbError> {

--- a/apps/web/src-tauri/src/db/driver.rs
+++ b/apps/web/src-tauri/src/db/driver.rs
@@ -15,6 +15,7 @@ pub trait DatabaseDriver: Send + Sync {
         params: &ConnectionParams,
     ) -> Result<TestConnectionResult, DbError>;
 
+    #[allow(dead_code)]
     fn driver_name(&self) -> &'static str;
 }
 

--- a/apps/web/src-tauri/src/db/mongodb_driver.rs
+++ b/apps/web/src-tauri/src/db/mongodb_driver.rs
@@ -61,7 +61,4 @@ impl DatabaseDriver for MongoDbDriver {
         })
     }
 
-    fn driver_name(&self) -> &'static str {
-        "MongoDB"
-    }
 }

--- a/apps/web/src-tauri/src/db/mongodb_driver.rs
+++ b/apps/web/src-tauri/src/db/mongodb_driver.rs
@@ -36,15 +36,13 @@ impl DatabaseDriver for MongoDbDriver {
         let start = Instant::now();
 
         let uri = build_mongodb_uri(params);
-        let mut client_options =
-            mongodb::options::ClientOptions::parse(uri)
-                .await
-                .map_err(DbError::from)?;
+        let mut client_options = mongodb::options::ClientOptions::parse(uri)
+            .await
+            .map_err(DbError::from)?;
         client_options.connect_timeout = Some(std::time::Duration::from_secs(10));
         client_options.server_selection_timeout = Some(std::time::Duration::from_secs(10));
 
-        let client =
-            mongodb::Client::with_options(client_options).map_err(DbError::from)?;
+        let client = mongodb::Client::with_options(client_options).map_err(DbError::from)?;
 
         client
             .database("admin")
@@ -60,5 +58,4 @@ impl DatabaseDriver for MongoDbDriver {
             latency_ms,
         })
     }
-
 }

--- a/apps/web/src-tauri/src/db/mysql.rs
+++ b/apps/web/src-tauri/src/db/mysql.rs
@@ -44,5 +44,4 @@ impl DatabaseDriver for MysqlDriver {
             latency_ms: latency,
         })
     }
-
 }

--- a/apps/web/src-tauri/src/db/mysql.rs
+++ b/apps/web/src-tauri/src/db/mysql.rs
@@ -45,7 +45,4 @@ impl DatabaseDriver for MysqlDriver {
         })
     }
 
-    fn driver_name(&self) -> &'static str {
-        "MySQL"
-    }
 }

--- a/apps/web/src-tauri/src/db/pool.rs
+++ b/apps/web/src-tauri/src/db/pool.rs
@@ -107,8 +107,7 @@ async fn connect_native(params: &ConnectionParams) -> Result<DatabasePool, DbErr
                 .map_err(DbError::from)?;
             client_options.connect_timeout = Some(std::time::Duration::from_secs(10));
             client_options.server_selection_timeout = Some(std::time::Duration::from_secs(10));
-            let client =
-                mongodb::Client::with_options(client_options).map_err(DbError::from)?;
+            let client = mongodb::Client::with_options(client_options).map_err(DbError::from)?;
             Ok(DatabasePool::MongoDB(client))
         }
         "redis" => {

--- a/apps/web/src-tauri/src/db/postgres.rs
+++ b/apps/web/src-tauri/src/db/postgres.rs
@@ -45,7 +45,4 @@ impl DatabaseDriver for PostgresDriver {
         })
     }
 
-    fn driver_name(&self) -> &'static str {
-        "PostgreSQL"
-    }
 }

--- a/apps/web/src-tauri/src/db/postgres.rs
+++ b/apps/web/src-tauri/src/db/postgres.rs
@@ -44,5 +44,4 @@ impl DatabaseDriver for PostgresDriver {
             latency_ms: latency,
         })
     }
-
 }

--- a/apps/web/src-tauri/src/db/redis_driver.rs
+++ b/apps/web/src-tauri/src/db/redis_driver.rs
@@ -52,7 +52,4 @@ impl DatabaseDriver for RedisDriver {
         })
     }
 
-    fn driver_name(&self) -> &'static str {
-        "Redis"
-    }
 }

--- a/apps/web/src-tauri/src/db/redis_driver.rs
+++ b/apps/web/src-tauri/src/db/redis_driver.rs
@@ -51,5 +51,4 @@ impl DatabaseDriver for RedisDriver {
             latency_ms,
         })
     }
-
 }

--- a/apps/web/src-tauri/src/db/schema.rs
+++ b/apps/web/src-tauri/src/db/schema.rs
@@ -19,10 +19,7 @@ pub async fn list_databases(pool: &DatabasePool) -> Result<Vec<String>, DbError>
     }
 }
 
-pub async fn fetch_schema(
-    pool: &DatabasePool,
-    database_name: &str,
-) -> Result<SchemaInfo, DbError> {
+pub async fn fetch_schema(pool: &DatabasePool, database_name: &str) -> Result<SchemaInfo, DbError> {
     match pool {
         DatabasePool::Postgres(pool) => fetch_schema_postgres(pool, database_name).await,
         DatabasePool::MySql(pool) => fetch_schema_mysql(pool, database_name).await,
@@ -248,12 +245,14 @@ async fn fetch_fks_postgres(
         let ref_table: String = row.try_get("referenced_table").unwrap_or_default();
         let ref_column: String = row.try_get("referenced_column").unwrap_or_default();
 
-        let entry = fk_map.entry(name.clone()).or_insert_with(|| ForeignKeyItem {
-            name,
-            columns: Vec::new(),
-            referenced_table: ref_table,
-            referenced_columns: Vec::new(),
-        });
+        let entry = fk_map
+            .entry(name.clone())
+            .or_insert_with(|| ForeignKeyItem {
+                name,
+                columns: Vec::new(),
+                referenced_table: ref_table,
+                referenced_columns: Vec::new(),
+            });
         if !entry.columns.contains(&column) {
             entry.columns.push(column);
         }
@@ -459,12 +458,14 @@ async fn fetch_fks_mysql(
         let ref_table: String = row.try_get("REFERENCED_TABLE_NAME").unwrap_or_default();
         let ref_column: String = row.try_get("REFERENCED_COLUMN_NAME").unwrap_or_default();
 
-        let entry = fk_map.entry(name.clone()).or_insert_with(|| ForeignKeyItem {
-            name,
-            columns: Vec::new(),
-            referenced_table: ref_table,
-            referenced_columns: Vec::new(),
-        });
+        let entry = fk_map
+            .entry(name.clone())
+            .or_insert_with(|| ForeignKeyItem {
+                name,
+                columns: Vec::new(),
+                referenced_table: ref_table,
+                referenced_columns: Vec::new(),
+            });
         entry.columns.push(column);
         entry.referenced_columns.push(ref_column);
     }

--- a/apps/web/src-tauri/src/db/sqlite.rs
+++ b/apps/web/src-tauri/src/db/sqlite.rs
@@ -38,7 +38,4 @@ impl DatabaseDriver for SqliteDriver {
         })
     }
 
-    fn driver_name(&self) -> &'static str {
-        "SQLite"
-    }
 }

--- a/apps/web/src-tauri/src/db/sqlite.rs
+++ b/apps/web/src-tauri/src/db/sqlite.rs
@@ -37,5 +37,4 @@ impl DatabaseDriver for SqliteDriver {
             latency_ms: latency,
         })
     }
-
 }

--- a/apps/web/src-tauri/src/db/types.rs
+++ b/apps/web/src-tauri/src/db/types.rs
@@ -134,4 +134,3 @@ impl From<QueryResult> for ExecuteResult {
         }
     }
 }
-

--- a/apps/web/src-tauri/src/main.rs
+++ b/apps/web/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-  app_lib::run();
+    app_lib::run();
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -10,7 +10,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import "@/index.css";
 
 export interface RouterAppContext {
-  noop: () => void;
+  noop?: () => void;
 }
 
 export const Route = createRootRouteWithContext<RouterAppContext>()({


### PR DESCRIPTION
Adds GitHub Actions CI validation for all PRs to main.

Two parallel jobs run on every PR and push to main:
- **Frontend**: Lints & formats with Ultracite, type-checks with TypeScript, builds React/Vite app
- **Rust**: Validates Tauri backend with cargo check, clippy (strict), and rustfmt

Uses bun@1.3.9 with frozen lockfile, Rust stable toolchain, and caches dependencies for fast re-runs. Concurrency groups cancel redundant runs on rapid pushes.