### PR TITLE
Add edit and delete options to connection list

### DIFF
--- a/apps/web/src/components/connection-form.tsx
+++ b/apps/web/src/components/connection-form.tsx
@@ -14,10 +14,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { DEFAULT_PORTS, saveConnection } from "@/lib/connections";
+import {
+  DEFAULT_PORTS,
+  saveConnection,
+  updateConnection,
+} from "@/lib/connections";
 import { testConnection } from "@/lib/tauri";
 
 interface ConnectionFormProps {
+  connection?: DatabaseConnection;
   onSuccess?: (connection: DatabaseConnection) => void;
 }
 
@@ -46,6 +51,16 @@ const INITIAL_STATE: FormState = {
   type: "postgresql",
   username: "",
 };
+
+const connectionToFormState = (conn: DatabaseConnection): FormState => ({
+  database: conn.database,
+  host: conn.host,
+  name: conn.name,
+  password: conn.password,
+  port: String(conn.port),
+  type: conn.type,
+  username: conn.username,
+});
 
 const DATABASE_OPTIONS: { value: DatabaseType; label: string }[] = [
   { label: "PostgreSQL", value: "postgresql" },
@@ -155,8 +170,13 @@ const validate = (form: FormState): string | null => {
   return null;
 };
 
-export const ConnectionForm = ({ onSuccess }: ConnectionFormProps) => {
-  const [form, setForm] = useState<FormState>(INITIAL_STATE);
+export const ConnectionForm = ({
+  connection,
+  onSuccess,
+}: ConnectionFormProps) => {
+  const [form, setForm] = useState<FormState>(
+    connection ? connectionToFormState(connection) : INITIAL_STATE
+  );
   const [testStatus, setTestStatus] = useState<TestStatus>({ state: "idle" });
   const hasHost = NEEDS_HOST.has(form.type);
   const hasUsername = NEEDS_USERNAME.has(form.type);
@@ -213,12 +233,24 @@ export const ConnectionForm = ({ onSuccess }: ConnectionFormProps) => {
         toast.error(error);
         return;
       }
-      const connection = buildConnection(form);
-      saveConnection(connection);
-      toast.success(`Connection "${connection.name}" saved`);
-      onSuccess?.(connection);
+
+      if (connection) {
+        const updated: DatabaseConnection = {
+          ...buildConnection(form),
+          createdAt: connection.createdAt,
+          id: connection.id,
+        };
+        updateConnection(updated);
+        toast.success(`Connection "${updated.name}" updated`);
+        onSuccess?.(updated);
+      } else {
+        const newConn = buildConnection(form);
+        saveConnection(newConn);
+        toast.success(`Connection "${newConn.name}" saved`);
+        onSuccess?.(newConn);
+      }
     },
-    [form, onSuccess]
+    [form, connection, onSuccess]
   );
 
   return (
@@ -349,7 +381,9 @@ export const ConnectionForm = ({ onSuccess }: ConnectionFormProps) => {
         )}
       </div>
 
-      <Button type="submit">Save connection</Button>
+      <Button type="submit">
+        {connection ? "Update connection" : "Save connection"}
+      </Button>
     </form>
   );
 };

--- a/apps/web/src/lib/connections.ts
+++ b/apps/web/src/lib/connections.ts
@@ -44,6 +44,13 @@ export const saveConnection = (connection: DatabaseConnection): void => {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(connections));
 };
 
+export const updateConnection = (updated: DatabaseConnection): void => {
+  const connections = getConnections().map((c) =>
+    c.id === updated.id ? updated : c
+  );
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(connections));
+};
+
 export const deleteConnection = (id: string): void => {
   const connections = getConnections().filter((c) => c.id !== id);
   localStorage.setItem(STORAGE_KEY, JSON.stringify(connections));

--- a/apps/web/src/routes/_default/-components/connection-list-item.tsx
+++ b/apps/web/src/routes/_default/-components/connection-list-item.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Database, Trash2 } from "lucide-react";
+import { Database, Pencil, Trash2 } from "lucide-react";
 import { useCallback } from "react";
 
 import type { DatabaseConnection } from "@/lib/connections";
@@ -8,20 +8,27 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 
 const ConnectionListItem = ({
   connection,
+  onEditRequest,
   onDeleteRequest,
 }: {
   connection: DatabaseConnection;
+  onEditRequest: (connection: DatabaseConnection) => void;
   onDeleteRequest: (connection: DatabaseConnection) => void;
 }) => {
   const subtitle =
     connection.type === "sqlite"
       ? connection.database
       : `${connection.host}:${connection.port}/${connection.database}`;
+
+  const handleEdit = useCallback(() => {
+    onEditRequest(connection);
+  }, [onEditRequest, connection]);
 
   const handleDelete = useCallback(() => {
     onDeleteRequest(connection);
@@ -45,7 +52,12 @@ const ConnectionListItem = ({
         </span>
       </ContextMenuTrigger>
       <ContextMenuContent>
-        <ContextMenuItem onSelect={handleDelete} variant="destructive">
+        <ContextMenuItem onClick={handleEdit}>
+          <Pencil />
+          Edit
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={handleDelete} variant="destructive">
           <Trash2 />
           Delete
         </ContextMenuItem>

--- a/apps/web/src/routes/_default/-components/connection-list.tsx
+++ b/apps/web/src/routes/_default/-components/connection-list.tsx
@@ -10,9 +10,11 @@ const SPRING = { damping: 30, stiffness: 400, type: "spring" } as const;
 
 const ConnectionList = ({
   connections,
+  onEditRequest,
   onDeleteRequest,
 }: {
   connections: DatabaseConnection[];
+  onEditRequest: (connection: DatabaseConnection) => void;
   onDeleteRequest: (connection: DatabaseConnection) => void;
 }) => (
   <div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
@@ -29,6 +31,7 @@ const ConnectionList = ({
           {index > 0 && <Separator />}
           <ConnectionListItem
             connection={conn}
+            onEditRequest={onEditRequest}
             onDeleteRequest={onDeleteRequest}
           />
         </motion.div>

--- a/apps/web/src/routes/_default/-components/edit-connection-dialog.tsx
+++ b/apps/web/src/routes/_default/-components/edit-connection-dialog.tsx
@@ -1,0 +1,36 @@
+import type { DatabaseConnection } from "@/lib/connections";
+
+import { ConnectionForm } from "@/components/connection-form";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const EditConnectionDialog = ({
+  connection,
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  connection: DatabaseConnection | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: (connection: DatabaseConnection) => void;
+}) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Edit connection</DialogTitle>
+        <DialogDescription>Update your connection settings.</DialogDescription>
+      </DialogHeader>
+      {connection && (
+        <ConnectionForm connection={connection} onSuccess={onSuccess} />
+      )}
+    </DialogContent>
+  </Dialog>
+);
+
+export { EditConnectionDialog };

--- a/apps/web/src/routes/_default/index.tsx
+++ b/apps/web/src/routes/_default/index.tsx
@@ -11,6 +11,7 @@ import { deleteConnection, getConnections } from "@/lib/connections";
 import { AddConnectionDialog } from "./-components/add-connection-dialog";
 import { ConnectionList } from "./-components/connection-list";
 import { DeleteConnectionDialog } from "./-components/delete-connection-dialog";
+import { EditConnectionDialog } from "./-components/edit-connection-dialog";
 
 const HomeComponent = () => {
   const navigate = useNavigate();
@@ -18,6 +19,7 @@ const HomeComponent = () => {
   const [deleteTarget, setDeleteTarget] = useState<DatabaseConnection | null>(
     null
   );
+  const [editTarget, setEditTarget] = useState<DatabaseConnection | null>(null);
   const [addOpen, setAddOpen] = useState(false);
 
   const handleDeleteRequest = useCallback((connection: DatabaseConnection) => {
@@ -43,6 +45,21 @@ const HomeComponent = () => {
   const handleDeleteOpenChange = useCallback((open: boolean) => {
     if (!open) {
       setDeleteTarget(null);
+    }
+  }, []);
+
+  const handleEditRequest = useCallback((connection: DatabaseConnection) => {
+    setEditTarget(connection);
+  }, []);
+
+  const handleEditSuccess = useCallback(() => {
+    setEditTarget(null);
+    setConnections(getConnections());
+  }, []);
+
+  const handleEditOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setEditTarget(null);
     }
   }, []);
 
@@ -88,6 +105,7 @@ const HomeComponent = () => {
 
           <ConnectionList
             connections={connections}
+            onEditRequest={handleEditRequest}
             onDeleteRequest={handleDeleteRequest}
           />
         </div>
@@ -97,6 +115,13 @@ const HomeComponent = () => {
         open={addOpen}
         onOpenChange={setAddOpen}
         onSuccess={handleAddSuccess}
+      />
+
+      <EditConnectionDialog
+        connection={editTarget}
+        open={editTarget !== null}
+        onOpenChange={handleEditOpenChange}
+        onSuccess={handleEditSuccess}
       />
 
       <DeleteConnectionDialog


### PR DESCRIPTION
## Summary

- Added `updateConnection()` function to persist connection updates to localStorage
- Extended `ConnectionForm` to support both create and edit modes with dynamic button labels
- Created `EditConnectionDialog` component for editing existing connections
- Added "Edit" option to connection context menu with icon and visual separator from destructive actions
- Fixed context menu item event handling to use `onClick` (base-ui convention) instead of `onSelect`

Users can now right-click a connection to edit or delete it. Edit opens a pre-filled dialog that preserves the connection's ID and creation timestamp while updating other properties.