### PR TITLE
Refactor query tab bar with segment tabs and clean up layout

### DIFF
--- a/apps/web/src/components/titlebar/dynamic-island/dynamic-island.tsx
+++ b/apps/web/src/components/titlebar/dynamic-island/dynamic-island.tsx
@@ -27,7 +27,7 @@ export const DynamicIsland = ({
     <motion.div
       layout
       transition={SPRING}
-      className="pointer-events-auto flex h-6 items-center rounded-full border border-border/60 bg-secondary/50 px-2.5 shadow-sm backdrop-blur-xl backdrop-saturate-200"
+      className="pointer-events-auto flex h-6 items-center rounded-full border border-border/60 bg-background px-2.5 shadow-sm backdrop-blur-xl backdrop-saturate-200"
     >
       <DynamicIslandContent
         isConnecting={isConnecting}

--- a/apps/web/src/components/titlebar/titlebar.tsx
+++ b/apps/web/src/components/titlebar/titlebar.tsx
@@ -26,7 +26,7 @@ export const Titlebar = ({
     <header
       className={cn(
         "flex h-9.5 shrink-0 select-none items-center",
-        !hasSidebar && "border-b bg-background",
+        !hasSidebar && "border-b border-sidebar-border bg-sidebar-background",
         className
       )}
       data-tauri-drag-region=""

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -35,6 +35,8 @@ const tabsListVariants = cva(
       variant: {
         default: "bg-muted",
         line: "gap-1 bg-transparent",
+        segment:
+          "gap-0 rounded-none bg-muted/30 p-0 group-data-horizontal/tabs:h-auto",
       },
     },
   }
@@ -64,6 +66,7 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
         "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        "group-data-[variant=segment]/tabs-list:rounded-sm group-data-[variant=segment]/tabs-list:border-transparent group-data-[variant=segment]/tabs-list:bg-transparent group-data-[variant=segment]/tabs-list:px-3 group-data-[variant=segment]/tabs-list:py-1.5 group-data-[variant=segment]/tabs-list:text-xs group-data-[variant=segment]/tabs-list:text-muted-foreground group-data-[variant=segment]/tabs-list:hover:text-foreground/80 group-data-[variant=segment]/tabs-list:after:hidden group-data-[variant=segment]/tabs-list:data-active:bg-background group-data-[variant=segment]/tabs-list:data-active:text-foreground group-data-[variant=segment]/tabs-list:data-active:shadow-sm",
         className
       )}
       {...props}

--- a/apps/web/src/components/workspace/query-tab-bar.tsx
+++ b/apps/web/src/components/workspace/query-tab-bar.tsx
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import type { QueryTab, TabStatus } from "@/lib/query-types";
 
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Tooltip,
   TooltipContent,
@@ -35,43 +36,29 @@ const StatusIcon = ({ status }: { status: TabStatus }) => {
   }
 };
 
-interface TabItemProps {
-  tab: QueryTab;
-  isActive: boolean;
-  onSelect: (tabId: string) => void;
+interface TabCloseButtonProps {
+  tabTitle: string;
+  tabId: string;
   onClose: (tabId: string) => void;
 }
 
-const TabItem = ({ tab, isActive, onSelect, onClose }: TabItemProps) => {
-  const handleSelect = useCallback(() => onSelect(tab.id), [onSelect, tab.id]);
-  const handleClose = useCallback(
+const TabCloseButton = ({ tabTitle, tabId, onClose }: TabCloseButtonProps) => {
+  const handleClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      onClose(tab.id);
+      onClose(tabId);
     },
-    [onClose, tab.id]
+    [onClose, tabId]
   );
 
   return (
     <button
       type="button"
-      onClick={handleSelect}
-      className={`group flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-xs transition-colors ${
-        isActive
-          ? "border-primary text-foreground"
-          : "border-transparent text-muted-foreground hover:text-foreground"
-      }`}
+      onClick={handleClick}
+      className="ml-0.5 rounded p-0.5 opacity-0 hover:bg-muted group-hover/tab:opacity-100"
+      aria-label={`Close ${tabTitle}`}
     >
-      <StatusIcon status={tab.status} />
-      <span className="max-w-[120px] truncate">{tab.title}</span>
-      <button
-        type="button"
-        onClick={handleClose}
-        className="ml-0.5 rounded p-0.5 opacity-0 hover:bg-muted group-hover:opacity-100"
-        aria-label={`Close ${tab.title}`}
-      >
-        <X className="size-3" />
-      </button>
+      <X className="size-3" />
     </button>
   );
 };
@@ -82,32 +69,51 @@ export const QueryTabBar = ({
   onSelectTab,
   onCloseTab,
   onAddTab,
-}: QueryTabBarProps) => (
-  <div className="flex items-center gap-0.5 border-b bg-muted/30 px-1">
-    {tabs.map((tab) => (
-      <TabItem
-        key={tab.id}
-        tab={tab}
-        isActive={tab.id === activeTabId}
-        onSelect={onSelectTab}
-        onClose={onCloseTab}
-      />
-    ))}
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            onClick={onAddTab}
-            className="ml-1"
-            aria-label="New query tab"
-          />
-        }
-      >
-        <Plus className="size-3.5" />
-      </TooltipTrigger>
-      <TooltipContent>New tab</TooltipContent>
-    </Tooltip>
-  </div>
-);
+}: QueryTabBarProps) => {
+  const handleValueChange = useCallback(
+    (value: unknown) => {
+      onSelectTab(value as string);
+    },
+    [onSelectTab]
+  );
+
+  return (
+    <Tabs
+      value={activeTabId}
+      onValueChange={handleValueChange}
+      className="gap-0"
+    >
+      <div className="flex items-center border-b">
+        <TabsList variant="segment" className="flex-1">
+          {tabs.map((tab) => (
+            <TabsTrigger key={tab.id} value={tab.id} className="group/tab">
+              <StatusIcon status={tab.status} />
+              <span className="max-w-[120px] truncate">{tab.title}</span>
+              <TabCloseButton
+                tabTitle={tab.title}
+                tabId={tab.id}
+                onClose={onCloseTab}
+              />
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={onAddTab}
+                className="mx-1"
+                aria-label="New query tab"
+              />
+            }
+          >
+            <Plus className="size-3.5" />
+          </TooltipTrigger>
+          <TooltipContent>New tab</TooltipContent>
+        </Tooltip>
+      </div>
+    </Tabs>
+  );
+};

--- a/apps/web/src/components/workspace/workspace-layout.tsx
+++ b/apps/web/src/components/workspace/workspace-layout.tsx
@@ -36,7 +36,6 @@ export const WorkspaceLayout = ({
 }: WorkspaceLayoutProps) => {
   const sidebarRef = usePanelRef();
   const chatPanelRef = usePanelRef();
-  const [sidebarWidthPct, setSidebarWidthPct] = useState(25);
   const [isChatOpen, setIsChatOpen] = useState(false);
   const hasBeenOpenedRef = useRef(false);
 
@@ -49,10 +48,6 @@ export const WorkspaceLayout = ({
     selectedDatabase,
     setSelectedDatabase,
   } = useSchema(connection.id, isConnected);
-
-  const handleResize = useCallback((size: PanelSize) => {
-    setSidebarWidthPct(size.asPercentage);
-  }, []);
 
   const handleChatResize = useCallback((size: PanelSize) => {
     setIsChatOpen(size.asPercentage > 0);
@@ -86,8 +81,6 @@ export const WorkspaceLayout = ({
   return (
     <div className="flex h-svh flex-col">
       <Titlebar
-        leadingWidth={`${sidebarWidthPct - 0.08}%`}
-        leading={<div />}
         center={
           <DynamicIsland
             isConnecting={isConnecting}
@@ -114,7 +107,6 @@ export const WorkspaceLayout = ({
           maxSize="40%"
           collapsible
           collapsedSize="0%"
-          onResize={handleResize}
           className="border-r border-sidebar-border"
         >
           <WorkspaceSidebar

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -152,4 +152,25 @@
     @apply font-sans;
     overflow: hidden;
   }
+
+  [data-variant="segment"]
+    > [data-slot="tabs-trigger"]
+    + [data-slot="tabs-trigger"]::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 25%;
+    height: 50%;
+    width: 1px;
+    background-color: var(--border);
+    opacity: 0.5;
+    transition: opacity 150ms;
+  }
+
+  [data-variant="segment"]
+    > [data-slot="tabs-trigger"][data-active]
+    + [data-slot="tabs-trigger"]::before,
+  [data-variant="segment"] > [data-slot="tabs-trigger"][data-active]::before {
+    opacity: 0;
+  }
 }


### PR DESCRIPTION
## Summary

Refactors the query tab bar to leverage the shadcn Tabs component with a new segment variant, improving consistency and reducing custom styling. Cleans up unnecessary state management and adjusts titlebar colors for better visual hierarchy.

## Changes

- Replace custom tab implementation with shadcn Tabs component and segment variant
- Add segment variant styling to tabs component with separators between tabs
- Update titlebar to use sidebar colors when sidebar is not visible
- Remove unused sidebar width tracking from WorkspaceLayout
- Extract TabCloseButton as a focused, reusable component

## Testing

The query tabs should display with the new segment styling, with proper active/inactive states and close button behavior on hover.