### PR TITLE
Add 'query table' action and CSV export for results

### DIFF
--- a/apps/web/src/components/titlebar/connection-toolbar.tsx
+++ b/apps/web/src/components/titlebar/connection-toolbar.tsx
@@ -1,5 +1,5 @@
-import { Link, useNavigate } from "@tanstack/react-router";
-import { Plus, ShieldCheck, Unplug } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+import { ShieldCheck, Unplug } from "lucide-react";
 import { useCallback, useState } from "react";
 
 import type { DatabaseConnection } from "@/lib/connections";
@@ -36,10 +36,8 @@ export const ConnectionToolbar = ({
   }, []);
 
   return (
-    <>
+    <div className="flex items-center space-x-2">
       <ChatPanelToggle isOpen={isChatOpen} onToggle={onChatToggle} />
-
-      <Separator orientation="vertical" className="mx-1 h-4" />
 
       <Tooltip>
         <TooltipTrigger
@@ -62,23 +60,6 @@ export const ConnectionToolbar = ({
       <Tooltip>
         <TooltipTrigger
           render={
-            <Link to="/onboarding">
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label="New connection"
-              />
-            </Link>
-          }
-        >
-          <Plus className="size-3.5" />
-        </TooltipTrigger>
-        <TooltipContent>New connection</TooltipContent>
-      </Tooltip>
-
-      <Tooltip>
-        <TooltipTrigger
-          render={
             <Button
               variant="ghost"
               size="icon-xs"
@@ -91,6 +72,6 @@ export const ConnectionToolbar = ({
         </TooltipTrigger>
         <TooltipContent>Disconnect from {connection.name}</TooltipContent>
       </Tooltip>
-    </>
+    </div>
   );
 };

--- a/apps/web/src/components/titlebar/connection-toolbar.tsx
+++ b/apps/web/src/components/titlebar/connection-toolbar.tsx
@@ -5,7 +5,6 @@ import { useCallback, useState } from "react";
 import type { DatabaseConnection } from "@/lib/connections";
 
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
 import {
   Tooltip,
   TooltipContent,

--- a/apps/web/src/components/workspace/query-status-bar.tsx
+++ b/apps/web/src/components/workspace/query-status-bar.tsx
@@ -1,7 +1,17 @@
+import { Download } from "lucide-react";
+
 import type { ExecuteResult } from "@/lib/tauri";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface QueryStatusBarProps {
   result: ExecuteResult;
+  onDownloadCsv?: () => void;
 }
 
 const getLabel = (resultType: string, count: number): string => {
@@ -11,7 +21,10 @@ const getLabel = (resultType: string, count: number): string => {
   return count === 1 ? "row" : "rows";
 };
 
-export const QueryStatusBar = ({ result }: QueryStatusBarProps) => {
+export const QueryStatusBar = ({
+  result,
+  onDownloadCsv,
+}: QueryStatusBarProps) => {
   const count =
     result.resultType === "tabular" ? result.rowCount : result.count;
   const label = getLabel(result.resultType, count);
@@ -24,6 +37,24 @@ export const QueryStatusBar = ({ result }: QueryStatusBarProps) => {
       <span>{result.executionTimeMs}ms</span>
       {result.isTruncated && (
         <span className="text-amber-500">Result truncated</span>
+      )}
+      {onDownloadCsv && (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="ml-auto"
+                onClick={onDownloadCsv}
+                aria-label="Download as CSV"
+              />
+            }
+          >
+            <Download className="size-3" />
+          </TooltipTrigger>
+          <TooltipContent>Download as CSV</TooltipContent>
+        </Tooltip>
       )}
     </div>
   );

--- a/apps/web/src/components/workspace/table-node.tsx
+++ b/apps/web/src/components/workspace/table-node.tsx
@@ -1,4 +1,11 @@
-import { ChevronRight, Eye, Link, ListOrdered, Table2 } from "lucide-react";
+import {
+  ChevronRight,
+  Eye,
+  Link,
+  ListOrdered,
+  Play,
+  Table2,
+} from "lucide-react";
 import { useCallback } from "react";
 
 import type { TableItem, ViewItem } from "@/lib/tauri";
@@ -26,13 +33,13 @@ const isTableItem = (item: TableItem | ViewItem): item is TableItem =>
   "indexes" in item;
 
 export const TableNode = ({ table, isView = false }: TableNodeProps) => {
-  const { insertAtCursor } = useEditorInsert();
+  const { queryTable } = useEditorInsert();
   const hasIndexes = isTableItem(table) && table.indexes.length > 0;
   const hasForeignKeys = isTableItem(table) && table.foreignKeys.length > 0;
 
-  const handleInsert = useCallback(() => {
-    insertAtCursor(table.name);
-  }, [insertAtCursor, table.name]);
+  const handleQueryTable = useCallback(() => {
+    queryTable(table.name);
+  }, [queryTable, table.name]);
 
   return (
     <Collapsible className="group/table">
@@ -52,14 +59,14 @@ export const TableNode = ({ table, isView = false }: TableNodeProps) => {
               <button
                 type="button"
                 className="mr-1 rounded p-0.5 text-muted-foreground opacity-0 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground group-hover/table:opacity-100"
-                onClick={handleInsert}
-                aria-label={`Insert ${table.name}`}
+                onClick={handleQueryTable}
+                aria-label={`Query ${table.name}`}
               />
             }
           >
-            <Table2 className="size-3" />
+            <Play className="size-3" />
           </TooltipTrigger>
-          <TooltipContent>Insert table name</TooltipContent>
+          <TooltipContent>Query table</TooltipContent>
         </Tooltip>
       </div>
       <CollapsibleContent>

--- a/apps/web/src/components/workspace/workspace-content.tsx
+++ b/apps/web/src/components/workspace/workspace-content.tsx
@@ -17,9 +17,11 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useEditorInsert } from "@/contexts/editor-insert-context";
 import { useQueryExecution } from "@/contexts/query-execution-context";
 import { useQueryTabs } from "@/hooks/use-query-tabs";
 import { isSqlDatabase } from "@/lib/connections";
+import { downloadCsv, tabularResultToCsv } from "@/lib/csv";
 
 import { CommandEditor } from "./command-editor";
 import { DocumentViewer } from "./document-viewer";
@@ -48,6 +50,7 @@ export const WorkspaceContent = ({
     activeTab,
     activeTabId,
     addTab,
+    addTabWithSql,
     closeTab,
     setActiveTabId,
     updateTabSql,
@@ -55,6 +58,7 @@ export const WorkspaceContent = ({
   } = useQueryTabs(connection.id);
 
   const { setExecutionState } = useQueryExecution();
+  const { registerQueryTable } = useEditorInsert();
 
   const activeStatus = activeTab?.status;
   const activeResult = activeTab?.result;
@@ -70,6 +74,18 @@ export const WorkspaceContent = ({
       });
     }
   }, [activeStatus, activeResult, activeError, setExecutionState]);
+
+  const handleQueryTable = useCallback(
+    (tableName: string) => {
+      addTabWithSql(`SELECT * FROM ${tableName};`);
+    },
+    [addTabWithSql]
+  );
+
+  useEffect(() => {
+    registerQueryTable(handleQueryTable);
+    return () => registerQueryTable(null);
+  }, [registerQueryTable, handleQueryTable]);
 
   const handleExecute = useCallback(() => {
     if (activeTab) {
@@ -176,6 +192,13 @@ interface ResultsPanelProps {
 }
 
 const ResultsPanel = ({ status, result, error, isSql }: ResultsPanelProps) => {
+  const handleDownloadCsv = useCallback(() => {
+    if (result?.resultType === "tabular") {
+      const csv = tabularResultToCsv(result);
+      downloadCsv(csv, `query-results-${Date.now()}.csv`);
+    }
+  }, [result]);
+
   if (status === "running") {
     return (
       <div className="flex h-full flex-col gap-2 p-4">
@@ -211,7 +234,7 @@ const ResultsPanel = ({ status, result, error, isSql }: ResultsPanelProps) => {
         <div className="flex-1 overflow-auto">
           <ResultsTable result={result} />
         </div>
-        <QueryStatusBar result={result} />
+        <QueryStatusBar result={result} onDownloadCsv={handleDownloadCsv} />
       </div>
     );
   }

--- a/apps/web/src/components/workspace/workspace-layout.tsx
+++ b/apps/web/src/components/workspace/workspace-layout.tsx
@@ -107,7 +107,6 @@ export const WorkspaceLayout = ({
           maxSize="40%"
           collapsible
           collapsedSize="0%"
-          className="border-r border-sidebar-border"
         >
           <WorkspaceSidebar
             connection={connection}

--- a/apps/web/src/contexts/editor-insert-context.tsx
+++ b/apps/web/src/contexts/editor-insert-context.tsx
@@ -5,7 +5,9 @@ import { createContext, use, useCallback, useRef } from "react";
 
 interface EditorInsertContextValue {
   insertAtCursor: (text: string) => void;
+  queryTable: (tableName: string) => void;
   registerEditor: (view: EditorView | null) => void;
+  registerQueryTable: (handler: ((tableName: string) => void) | null) => void;
 }
 
 const EditorInsertContext = createContext<EditorInsertContextValue | null>(
@@ -14,10 +16,18 @@ const EditorInsertContext = createContext<EditorInsertContextValue | null>(
 
 export const EditorInsertProvider = ({ children }: { children: ReactNode }) => {
   const editorRef = useRef<EditorView | null>(null);
+  const queryTableRef = useRef<((tableName: string) => void) | null>(null);
 
   const registerEditor = useCallback((view: EditorView | null) => {
     editorRef.current = view;
   }, []);
+
+  const registerQueryTable = useCallback(
+    (handler: ((tableName: string) => void) | null) => {
+      queryTableRef.current = handler;
+    },
+    []
+  );
 
   const insertAtCursor = useCallback((text: string) => {
     const view = editorRef.current;
@@ -33,8 +43,14 @@ export const EditorInsertProvider = ({ children }: { children: ReactNode }) => {
     view.focus();
   }, []);
 
+  const queryTable = useCallback((tableName: string) => {
+    queryTableRef.current?.(tableName);
+  }, []);
+
   return (
-    <EditorInsertContext value={{ insertAtCursor, registerEditor }}>
+    <EditorInsertContext
+      value={{ insertAtCursor, queryTable, registerEditor, registerQueryTable }}
+    >
       {children}
     </EditorInsertContext>
   );

--- a/apps/web/src/hooks/use-query-tabs.ts
+++ b/apps/web/src/hooks/use-query-tabs.ts
@@ -41,6 +41,13 @@ export const useQueryTabs = (connectionId: string) => {
     setActiveTabId(tab.id);
   }, []);
 
+  const addTabWithSql = useCallback((sql: string) => {
+    counterRef.current += 1;
+    const tab: QueryTab = { ...createNewTab(counterRef.current), sql };
+    setTabs((prev) => [...prev, tab]);
+    setActiveTabId(tab.id);
+  }, []);
+
   const closeTab = useCallback(
     (tabId: string) => {
       setTabs((prev) => {
@@ -112,6 +119,7 @@ export const useQueryTabs = (connectionId: string) => {
     activeTab,
     activeTabId,
     addTab,
+    addTabWithSql,
     closeTab,
     executeTab,
     setActiveTabId,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19,7 +19,7 @@
   --accent-foreground: oklch(0.2435 0 0);
   --destructive: oklch(0.6271 0.1936 33.339);
   --destructive-foreground: oklch(1 0 0);
-  --border: oklch(0.8822 0 0);
+  --border: oklch(0.923 0.003 48.717);
   --input: oklch(0.8822 0 0);
   --ring: oklch(0.4341 0.0392 41.9938);
   --chart-1: oklch(0.4341 0.0392 41.9938);
@@ -58,7 +58,7 @@
   --accent-foreground: oklch(0.9491 0 0);
   --destructive: oklch(0.6271 0.1936 33.339);
   --destructive-foreground: oklch(1 0 0);
-  --border: oklch(0.2351 0.0115 91.7467);
+  --border: oklch(1 0 0 / 10%);
   --input: oklch(0.4017 0 0);
   --ring: oklch(0.9247 0.0524 66.1732);
   --chart-1: oklch(0.9247 0.0524 66.1732);

--- a/apps/web/src/lib/csv.ts
+++ b/apps/web/src/lib/csv.ts
@@ -1,0 +1,30 @@
+import type { TabularResult } from "@/lib/tauri";
+
+const escapeCell = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  const str = String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return `"${str.replaceAll('"', '""')}"`;
+  }
+  return str;
+};
+
+export const tabularResultToCsv = (result: TabularResult): string => {
+  const header = result.columns.map((col) => escapeCell(col.name)).join(",");
+  const rows = result.rows.map((row) =>
+    row.map((cell) => escapeCell(cell)).join(",")
+  );
+  return [header, ...rows].join("\n");
+};
+
+export const downloadCsv = (csv: string, filename: string): void => {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
## Summary

- Replace 'insert table name' with 'query table' button that creates a new query tab pre-filled with `SELECT * FROM table_name`
- Add CSV download capability for tabular query results with proper CSV escaping (commas, quotes, newlines)
- Extend EditorInsertContext with queryTable bridging pattern for sidebar-to-workspace communication
- Add CSV download button to QueryStatusBar (tabular results only)

## Test plan

- Hover over a table in schema explorer → button tooltip now says "Query table" with Play icon
- Click button → new tab opens with pre-filled SELECT query (not auto-executed)
- Column clicks still insert column name at cursor (existing behavior preserved)
- Run any query with tabular results → CSV download button appears in status bar
- Click download → `.csv` file downloads with correct headers and data, proper escaping