### PR TITLE
Enhance Dynamic Island with reconnect support and micro-interactions

### DIFF
--- a/apps/web/src/components/titlebar/dynamic-island/dynamic-island-content.tsx
+++ b/apps/web/src/components/titlebar/dynamic-island/dynamic-island-content.tsx
@@ -7,6 +7,7 @@ import {
   ConnectedIdleStatus,
   ConnectingStatus,
   ConnectionErrorStatus,
+  ReconnectingStatus,
 } from "./island-connection-status";
 import {
   QueryErrorStatus,
@@ -16,6 +17,7 @@ import {
 
 type IslandState =
   | "connecting"
+  | "reconnecting"
   | "connection-error"
   | "query-running"
   | "query-error"
@@ -25,11 +27,13 @@ type IslandState =
 interface DynamicIslandContentProps {
   isConnecting: boolean;
   isConnected: boolean;
+  isReconnecting: boolean;
   connectionError: string | null;
   connectionName: string;
   serverVersion: string | null;
   username: string;
   database: string;
+  onReconnect: () => void;
 }
 
 const DISMISS_DELAY_SUCCESS = 3000;
@@ -38,11 +42,13 @@ const DISMISS_DELAY_ERROR = 4000;
 export const DynamicIslandContent = ({
   isConnecting,
   isConnected,
+  isReconnecting,
   connectionError,
   connectionName,
   serverVersion,
   username,
   database,
+  onReconnect,
 }: DynamicIslandContentProps) => {
   const { state: execState } = useQueryExecution();
   const [dismissed, setDismissed] = useState(false);
@@ -51,6 +57,7 @@ export const DynamicIslandContent = ({
   const resolvedState = resolveIslandState(
     isConnecting,
     isConnected,
+    isReconnecting,
     connectionError,
     execState.status,
     dismissed
@@ -90,7 +97,17 @@ export const DynamicIslandContent = ({
   return (
     <AnimatePresence mode="wait">
       {resolvedState === "connection-error" && connectionError && (
-        <ConnectionErrorStatus key="conn-error" error={connectionError} />
+        <ConnectionErrorStatus
+          key="conn-error"
+          error={connectionError}
+          onReconnect={onReconnect}
+        />
+      )}
+      {resolvedState === "reconnecting" && (
+        <ReconnectingStatus
+          key="reconnecting"
+          connectionName={connectionName}
+        />
       )}
       {resolvedState === "connecting" && (
         <ConnectingStatus key="connecting" connectionName={connectionName} />
@@ -127,10 +144,14 @@ export const DynamicIslandContent = ({
 const resolveIslandState = (
   isConnecting: boolean,
   isConnected: boolean,
+  isReconnecting: boolean,
   connectionError: string | null,
   queryStatus: string,
   dismissed: boolean
 ): IslandState => {
+  if (isReconnecting) {
+    return "reconnecting";
+  }
   if (connectionError) {
     return "connection-error";
   }

--- a/apps/web/src/components/titlebar/dynamic-island/dynamic-island.tsx
+++ b/apps/web/src/components/titlebar/dynamic-island/dynamic-island.tsx
@@ -7,36 +7,46 @@ const SPRING = { damping: 30, stiffness: 400, type: "spring" } as const;
 interface DynamicIslandProps {
   isConnecting: boolean;
   isConnected: boolean;
+  isReconnecting: boolean;
   connectionError: string | null;
   connectionName: string;
   serverVersion: string | null;
   username: string;
   database: string;
+  onReconnect: () => void;
 }
 
 export const DynamicIsland = ({
   isConnecting,
   isConnected,
+  isReconnecting,
   connectionError,
   connectionName,
   serverVersion,
   username,
   database,
+  onReconnect,
 }: DynamicIslandProps) => (
   <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
     <motion.div
       layout
       transition={SPRING}
+      whileHover={{
+        boxShadow:
+          "0 0 0 1px color-mix(in oklch, var(--border) 80%, transparent)",
+      }}
       className="pointer-events-auto flex h-6 items-center rounded-full border border-border/60 bg-background px-2.5 shadow-sm backdrop-blur-xl backdrop-saturate-200"
     >
       <DynamicIslandContent
         isConnecting={isConnecting}
         isConnected={isConnected}
+        isReconnecting={isReconnecting}
         connectionError={connectionError}
         connectionName={connectionName}
         serverVersion={serverVersion}
         username={username}
         database={database}
+        onReconnect={onReconnect}
       />
     </motion.div>
   </div>

--- a/apps/web/src/components/titlebar/dynamic-island/island-connection-status.tsx
+++ b/apps/web/src/components/titlebar/dynamic-island/island-connection-status.tsx
@@ -7,6 +7,8 @@ interface ConnectingStatusProps {
 
 const DOT_IDS = ["d1", "d2", "d3"] as const;
 
+const BUTTON_SPRING = { damping: 20, stiffness: 400, type: "spring" } as const;
+
 export const ConnectingStatus = ({ connectionName }: ConnectingStatusProps) => (
   <motion.div
     className="flex items-center gap-1.5"
@@ -35,6 +37,36 @@ export const ConnectingStatus = ({ connectionName }: ConnectingStatusProps) => (
   </motion.div>
 );
 
+export const ReconnectingStatus = ({
+  connectionName,
+}: ConnectingStatusProps) => (
+  <motion.div
+    className="flex items-center gap-1.5"
+    initial={{ filter: "blur(4px)", opacity: 0 }}
+    animate={{ filter: "blur(0px)", opacity: 1 }}
+    exit={{ filter: "blur(4px)", opacity: 0 }}
+  >
+    <div className="flex items-center gap-0.5">
+      {DOT_IDS.map((id, i) => (
+        <motion.span
+          key={id}
+          className="size-1 rounded-full bg-amber-400"
+          animate={{ opacity: [0.3, 1, 0.3] }}
+          transition={{
+            delay: i * 0.15,
+            duration: 1,
+            ease: "easeInOut",
+            repeat: Infinity,
+          }}
+        />
+      ))}
+    </div>
+    <span className="text-[0.625rem] text-amber-500">
+      Reconnecting to {connectionName}…
+    </span>
+  </motion.div>
+);
+
 interface ConnectedIdleStatusProps {
   serverVersion: string | null;
   username: string;
@@ -47,10 +79,12 @@ export const ConnectedIdleStatus = ({
   database,
 }: ConnectedIdleStatusProps) => (
   <motion.div
-    className="flex items-center gap-1.5"
+    className="flex cursor-default items-center gap-1.5"
     initial={{ filter: "blur(4px)", opacity: 0 }}
     animate={{ filter: "blur(0px)", opacity: 1 }}
     exit={{ filter: "blur(4px)", opacity: 0 }}
+    whileHover={{ opacity: 0.75 }}
+    transition={BUTTON_SPRING}
   >
     <span className="relative flex size-2 shrink-0">
       <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-400 opacity-50" />
@@ -70,10 +104,12 @@ export const ConnectedIdleStatus = ({
 
 interface ConnectionErrorStatusProps {
   error: string;
+  onReconnect: () => void;
 }
 
 export const ConnectionErrorStatus = ({
   error,
+  onReconnect,
 }: ConnectionErrorStatusProps) => (
   <motion.div
     className="flex items-center gap-1.5"
@@ -82,8 +118,18 @@ export const ConnectionErrorStatus = ({
     exit={{ filter: "blur(4px)", opacity: 0 }}
   >
     <AlertCircle className="size-3 shrink-0 text-destructive" />
-    <span className="max-w-[160px] truncate text-[0.625rem] text-destructive">
+    <span className="max-w-[140px] truncate text-[0.625rem] text-destructive">
       {error}
     </span>
+    <motion.button
+      type="button"
+      onClick={onReconnect}
+      className="cursor-pointer text-[0.625rem] text-destructive underline underline-offset-2"
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.92 }}
+      transition={BUTTON_SPRING}
+    >
+      Retry
+    </motion.button>
   </motion.div>
 );

--- a/apps/web/src/components/workspace/workspace-layout.tsx
+++ b/apps/web/src/components/workspace/workspace-layout.tsx
@@ -24,16 +24,20 @@ interface WorkspaceLayoutProps {
   connection: DatabaseConnection;
   isConnected: boolean;
   isConnecting: boolean;
+  isReconnecting: boolean;
   connectionError: string | null;
   serverVersion: string | null;
+  onReconnect: () => void;
 }
 
 export const WorkspaceLayout = ({
   connection,
   isConnected,
   isConnecting,
+  isReconnecting,
   connectionError,
   serverVersion,
+  onReconnect,
 }: WorkspaceLayoutProps) => {
   const sidebarRef = usePanelRef();
   const chatPanelRef = usePanelRef();
@@ -106,11 +110,13 @@ export const WorkspaceLayout = ({
           <DynamicIsland
             isConnecting={isConnecting}
             isConnected={isConnected}
+            isReconnecting={isReconnecting}
             connectionError={connectionError}
             connectionName={connection.name}
             serverVersion={serverVersion}
             username={connection.username}
             database={connection.database}
+            onReconnect={onReconnect}
           />
         }
       >

--- a/apps/web/src/hooks/use-connection-lifecycle.ts
+++ b/apps/web/src/hooks/use-connection-lifecycle.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { DatabaseConnection } from "@/lib/connections";
 
@@ -11,19 +11,28 @@ import {
 interface ConnectionLifecycleState {
   isConnected: boolean;
   isConnecting: boolean;
+  isReconnecting: boolean;
   error: string | null;
   serverVersion: string | null;
+  reconnect: () => void;
 }
 
 export const useConnectionLifecycle = (
   connection: DatabaseConnection
 ): ConnectionLifecycleState => {
-  const [state, setState] = useState<ConnectionLifecycleState>({
+  const [reconnectCount, setReconnectCount] = useState(0);
+  const [state, setState] = useState<
+    Omit<ConnectionLifecycleState, "reconnect" | "isReconnecting">
+  >({
     error: null,
     isConnected: false,
     isConnecting: true,
     serverVersion: null,
   });
+
+  const reconnect = useCallback(() => {
+    setReconnectCount((c) => c + 1);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -77,7 +86,11 @@ export const useConnectionLifecycle = (
       cancelled = true;
       disconnectFromDatabase(connection.id);
     };
-  }, [connection]);
+  }, [connection, reconnectCount]);
 
-  return state;
+  return {
+    ...state,
+    isReconnecting: reconnectCount > 0 && state.isConnecting,
+    reconnect,
+  };
 };

--- a/apps/web/src/routes/workspace/$connectionId.tsx
+++ b/apps/web/src/routes/workspace/$connectionId.tsx
@@ -8,8 +8,14 @@ import { getConnections } from "@/lib/connections";
 
 const WorkspacePage = () => {
   const { connection } = Route.useRouteContext();
-  const { isConnected, isConnecting, error, serverVersion } =
-    useConnectionLifecycle(connection);
+  const {
+    isConnected,
+    isConnecting,
+    isReconnecting,
+    error,
+    serverVersion,
+    reconnect,
+  } = useConnectionLifecycle(connection);
 
   return (
     <QueryExecutionProvider>
@@ -18,8 +24,10 @@ const WorkspacePage = () => {
           connection={connection}
           isConnected={isConnected}
           isConnecting={isConnecting}
+          isReconnecting={isReconnecting}
           connectionError={error}
           serverVersion={serverVersion}
+          onReconnect={reconnect}
         />
       </EditorInsertProvider>
     </QueryExecutionProvider>


### PR DESCRIPTION
## Summary

Enhanced the Dynamic Island titlebar component with richer connection state management and interactive controls:
- Added a "reconnecting" state with amber pulsing indicator to distinguish reconnect attempts from initial connection
- Added interactive "Retry" button on connection errors that triggers the reconnect flow
- Implemented subtle micro-interactions: island pill glows on hover, idle status dims on hover for feedback
- Refactored `useConnectionLifecycle` hook to expose `reconnect()` callback and track `isReconnecting` state

## Changes

- Modified Dynamic Island components to handle new `isReconnecting` state
- Updated `useConnectionLifecycle` hook with reconnect logic driven by `reconnectCount` state
- Enhanced `ReconnectingStatus` component with distinct amber animation pattern
- Added Retry button with spring press animations to `ConnectionErrorStatus`
- Added hover micro-interactions with smooth opacity transitions

## Testing

- Type checking passes (`bun run check-types`)
- Lint/format clean (`bun run fix`)
- Ready for manual testing in dev environment