### PR TITLE
Fix multi-statement SQL and Dynamic Island truncation

### DIFF
--- a/apps/web/src-tauri/src/commands.rs
+++ b/apps/web/src-tauri/src/commands.rs
@@ -131,7 +131,7 @@ macro_rules! fetch_rows_native {
     ($pool:expr, $sql:expr, $max_rows:expr) => {{
         use sqlx::{Column, Row, TypeInfo, ValueRef};
 
-        let mut stream = sqlx::query($sql).fetch($pool);
+        let mut stream = sqlx::raw_sql($sql).fetch($pool);
         let mut columns: Option<Vec<ColumnInfo>> = None;
         let mut rows: Vec<Vec<serde_json::Value>> = Vec::new();
         let mut is_truncated = false;

--- a/apps/web/src/components/titlebar/dynamic-island/island-connection-status.tsx
+++ b/apps/web/src/components/titlebar/dynamic-island/island-connection-status.tsx
@@ -118,7 +118,7 @@ export const ConnectionErrorStatus = ({
     exit={{ filter: "blur(4px)", opacity: 0 }}
   >
     <AlertCircle className="size-3 shrink-0 text-destructive" />
-    <span className="max-w-[140px] truncate text-[0.625rem] text-destructive">
+    <span className="max-w-[280px] truncate text-[0.625rem] text-destructive">
       {error}
     </span>
     <motion.button

--- a/apps/web/src/components/titlebar/dynamic-island/island-query-status.tsx
+++ b/apps/web/src/components/titlebar/dynamic-island/island-query-status.tsx
@@ -61,7 +61,7 @@ export const QueryErrorStatus = ({ error }: QueryErrorStatusProps) => (
     exit={{ filter: "blur(4px)", opacity: 0 }}
   >
     <AlertTriangle className="size-3 shrink-0 text-amber-500" />
-    <span className="max-w-[180px] truncate text-[0.625rem] text-amber-500">
+    <span className="max-w-[360px] truncate text-[0.625rem] text-amber-500">
       {error}
     </span>
   </motion.div>


### PR DESCRIPTION
## Summary

- Fixed backend to support multi-statement SQL queries using `sqlx::raw_sql()` instead of `sqlx::query()`, which uses the simple query protocol supporting semicolon-separated statements
- Widened Dynamic Island error message constraints to display full error text: connection errors 140px→280px, query errors 180px→360px

## What was broken

1. Executing queries like `SELECT 1; SELECT 2;` failed with "Cannot insert multiple commands into a prepared statement" because the prepared statement protocol only supports single statements
2. Error messages in the Dynamic Island were truncated and unreadable (e.g., long database errors)

## How it's fixed

The `sqlx::raw_sql()` API uses PostgreSQL's simple query protocol, which allows multiple statements. The `.fetch()` method returns the same `Stream<Result<Row>>` type as `.query().fetch()`, so no other code changes were needed.

The Dynamic Island already has Framer Motion `layout` animation for smooth width transitions—increasing the `max-w` constraints reveals more of the error text while maintaining the pill-shaped design.