### PR TITLE
Implement SQL dialect transpilation with polyglot-sql

### DIFF
--- a/apps/web/src-tauri/Cargo.lock
+++ b/apps/web/src-tauri/Cargo.lock
@@ -2915,6 +2915,7 @@ dependencies = [
  "futures",
  "log",
  "mongodb",
+ "polyglot-sql",
  "redis",
  "serde",
  "serde_json",
@@ -3261,6 +3262,18 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polyglot-sql"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bccd5cbca75edb3852dad81a34d9fa14c3abb2725d3cbc5dcb2d9e8250e4801"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -37,3 +37,4 @@ urlencoding = "2"
 mongodb = "3"
 redis = { version = "0.27", features = ["tokio-comp", "aio"] }
 dirs = "6"
+polyglot-sql = "0.1"

--- a/apps/web/src-tauri/src/commands.rs
+++ b/apps/web/src-tauri/src/commands.rs
@@ -7,6 +7,7 @@ use crate::db::error::DbError;
 use crate::db::execute::execute_for_pool;
 use crate::db::pool::ConnectionPoolManager;
 use crate::db::schema::{fetch_schema, list_databases};
+use crate::db::transpile::{pool_dialect, transpile_sql};
 use crate::db::types::{
     ConnectionParams, ExecuteResult, QueryParams, SchemaInfo, TestConnectionResult,
 };
@@ -75,11 +76,19 @@ pub async fn execute_query(
     let max_rows = params.max_rows.unwrap_or(DEFAULT_MAX_ROWS) as usize;
     let timeout_secs = params.timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS);
 
+    let sql = match params.source_dialect.as_deref() {
+        Some(source) => {
+            let target = pool_dialect(&pool);
+            transpile_sql(&params.sql, source, target)?
+        }
+        None => params.sql.clone(),
+    };
+
     let start = Instant::now();
 
     let result = tokio::time::timeout(
         std::time::Duration::from_secs(timeout_secs),
-        execute_for_pool(&pool, &params.sql, max_rows, params.schema.as_deref()),
+        execute_for_pool(&pool, &sql, max_rows, params.schema.as_deref()),
     )
     .await
     .map_err(DbError::from)?;

--- a/apps/web/src-tauri/src/db/mod.rs
+++ b/apps/web/src-tauri/src/db/mod.rs
@@ -8,5 +8,6 @@ pub mod postgres;
 pub mod redis_driver;
 pub mod schema;
 pub mod sqlite;
+pub mod transpile;
 pub mod types;
 pub mod version;

--- a/apps/web/src-tauri/src/db/transpile.rs
+++ b/apps/web/src-tauri/src/db/transpile.rs
@@ -1,0 +1,79 @@
+use polyglot_sql::{transpile, DialectType};
+
+use crate::db::error::DbError;
+use crate::db::pool::DatabasePool;
+
+pub fn pool_dialect(pool: &DatabasePool) -> DialectType {
+    match pool {
+        DatabasePool::Postgres(_) => DialectType::PostgreSQL,
+        DatabasePool::MySql(_) => DialectType::MySQL,
+        DatabasePool::Sqlite(_) => DialectType::SQLite,
+        _ => unreachable!("transpile only applies to SQL pools"),
+    }
+}
+
+const TRANSPILE_STACK_SIZE: usize = 16 * 1024 * 1024;
+
+pub fn transpile_sql(
+    sql: &str,
+    source_dialect: &str,
+    target: DialectType,
+) -> Result<String, DbError> {
+    let source: DialectType = source_dialect.parse().map_err(|e| DbError {
+        code: "UNSUPPORTED_DIALECT".to_string(),
+        message: format!("Unsupported source dialect '{source_dialect}': {e}"),
+    })?;
+
+    if source == target {
+        return Ok(sql.to_string());
+    }
+
+    let sql = sql.to_string();
+    let result = std::thread::Builder::new()
+        .stack_size(TRANSPILE_STACK_SIZE)
+        .spawn(move || transpile(&sql, source, target))
+        .map_err(|e| DbError {
+            code: "TRANSPILE_ERROR".to_string(),
+            message: format!("Failed to spawn transpile thread: {e}"),
+        })?
+        .join()
+        .map_err(|_| DbError {
+            code: "TRANSPILE_ERROR".to_string(),
+            message: "SQL transpilation crashed unexpectedly".to_string(),
+        })?
+        .map_err(|e| DbError {
+            code: "TRANSPILE_ERROR".to_string(),
+            message: format!("SQL transpilation failed: {e}"),
+        })?;
+
+    Ok(result.join(";\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ifnull_mysql_to_postgres() {
+        let result = transpile_sql(
+            r#"select IFNULL(avatar_url, name) FROM "users""#,
+            "mysql",
+            DialectType::PostgreSQL,
+        )
+        .unwrap();
+        assert_eq!(result, r#"SELECT COALESCE(avatar_url, name) FROM "users""#);
+    }
+
+    #[test]
+    fn test_same_dialect_passthrough() {
+        let sql = "SELECT 1";
+        let result = transpile_sql(sql, "postgresql", DialectType::PostgreSQL).unwrap();
+        assert_eq!(result, sql);
+    }
+
+    #[test]
+    fn test_unsupported_dialect() {
+        let result = transpile_sql("SELECT 1", "invalid", DialectType::PostgreSQL);
+        assert!(result.is_err());
+    }
+}

--- a/apps/web/src-tauri/src/db/types.rs
+++ b/apps/web/src-tauri/src/db/types.rs
@@ -85,6 +85,7 @@ pub struct QueryParams {
     pub max_rows: Option<u64>,
     pub timeout_secs: Option<u64>,
     pub schema: Option<String>,
+    pub source_dialect: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/apps/web/src/components/workspace/dialect-selector.tsx
+++ b/apps/web/src/components/workspace/dialect-selector.tsx
@@ -1,0 +1,138 @@
+import { ArrowRightLeft } from "lucide-react";
+import { useCallback } from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const DIALECT_GROUPS = [
+  {
+    dialects: [
+      { label: "PostgreSQL", value: "postgresql" },
+      { label: "MySQL", value: "mysql" },
+      { label: "SQLite", value: "sqlite" },
+      { label: "SQL Server", value: "tsql" },
+      { label: "Oracle", value: "oracle" },
+    ],
+    label: "Databases",
+  },
+  {
+    dialects: [
+      { label: "BigQuery", value: "bigquery" },
+      { label: "Snowflake", value: "snowflake" },
+      { label: "Redshift", value: "redshift" },
+      { label: "Databricks", value: "databricks" },
+      { label: "Athena", value: "athena" },
+      { label: "Teradata", value: "teradata" },
+      { label: "Fabric", value: "fabric" },
+    ],
+    label: "Cloud & Warehouses",
+  },
+  {
+    dialects: [
+      { label: "DuckDB", value: "duckdb" },
+      { label: "ClickHouse", value: "clickhouse" },
+      { label: "Apache Spark", value: "spark" },
+      { label: "Hive", value: "hive" },
+      { label: "Trino", value: "trino" },
+      { label: "Presto", value: "presto" },
+      { label: "DataFusion", value: "datafusion" },
+      { label: "Druid", value: "druid" },
+      { label: "Drill", value: "drill" },
+      { label: "Dremio", value: "dremio" },
+      { label: "Exasol", value: "exasol" },
+    ],
+    label: "Analytics",
+  },
+  {
+    dialects: [
+      { label: "CockroachDB", value: "cockroachdb" },
+      { label: "TiDB", value: "tidb" },
+      { label: "SingleStore", value: "singlestore" },
+      { label: "Materialize", value: "materialize" },
+      { label: "RisingWave", value: "risingwave" },
+      { label: "StarRocks", value: "starrocks" },
+      { label: "Doris", value: "doris" },
+    ],
+    label: "NewSQL & Streaming",
+  },
+] as const;
+
+const DIALECT_DISPLAY_NAMES: Record<string, string> = {
+  mysql: "MySQL",
+  postgresql: "PostgreSQL",
+  sqlite: "SQLite",
+};
+
+interface DialectSelectorProps {
+  value: string;
+  connectionDialect: string;
+  onChange: (dialect: string) => void;
+}
+
+export const DialectSelector = ({
+  value,
+  connectionDialect,
+  onChange,
+}: DialectSelectorProps) => {
+  const isTranspiling = value !== connectionDialect;
+
+  const handleValueChange = useCallback(
+    (v: string | null) => {
+      if (v) {
+        onChange(v);
+      }
+    },
+    [onChange]
+  );
+
+  const targetLabel =
+    DIALECT_DISPLAY_NAMES[connectionDialect] ?? connectionDialect;
+
+  return (
+    <div className="flex items-center gap-1">
+      <Select value={value} onValueChange={handleValueChange}>
+        <SelectTrigger size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent align="start" alignItemWithTrigger={false}>
+          {DIALECT_GROUPS.map((group, idx) => (
+            <SelectGroup key={group.label}>
+              {idx > 0 && <SelectSeparator />}
+              <SelectLabel>{group.label}</SelectLabel>
+              {group.dialects.map((dialect) => (
+                <SelectItem key={dialect.value} value={dialect.value}>
+                  {dialect.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          ))}
+        </SelectContent>
+      </Select>
+      {isTranspiling && (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span className="flex items-center text-amber-500">
+                <ArrowRightLeft className="size-3" />
+              </span>
+            }
+          />
+          <TooltipContent>Transpiling to {targetLabel}</TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/components/workspace/sql-editor.tsx
+++ b/apps/web/src/components/workspace/sql-editor.tsx
@@ -33,6 +33,7 @@ interface SqlEditorProps {
   onUpdate?: (update: ViewUpdate) => void;
   onToggleSyntaxTree?: () => void;
   databaseType: SqlDatabaseType;
+  writingDialect?: SqlDatabaseType;
   readOnly?: boolean;
   schema: SchemaInfo | null;
 }
@@ -44,6 +45,7 @@ export const SqlEditor = ({
   onUpdate,
   onToggleSyntaxTree,
   databaseType,
+  writingDialect,
   readOnly = false,
   schema,
 }: SqlEditorProps) => {
@@ -96,9 +98,11 @@ export const SqlEditor = ({
     { enabled: !!onToggleSyntaxTree }
   );
 
+  const effectiveDialect = writingDialect ?? databaseType;
+
   const extensions = useMemo(() => {
     const langSupport = sql({
-      dialect: DIALECT_MAP[databaseType],
+      dialect: DIALECT_MAP[effectiveDialect],
       schema: sqlNamespace,
     });
 
@@ -123,7 +127,7 @@ export const SqlEditor = ({
     return exts;
   }, [
     preventNewlineOnExecute,
-    databaseType,
+    effectiveDialect,
     sqlNamespace,
     tableCompletionSource,
     columnCompletionSource,

--- a/apps/web/src/components/workspace/workspace-content.tsx
+++ b/apps/web/src/components/workspace/workspace-content.tsx
@@ -1,10 +1,10 @@
 import type { ViewUpdate } from "@codemirror/view";
 
-import { useHotkey } from "@tanstack/react-hotkeys";
 import { Loader2, Play } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
-import type { DatabaseConnection } from "@/lib/connections";
+import type { DatabaseConnection, DatabaseType } from "@/lib/connections";
+import type { QueryTab } from "@/lib/query-types";
 import type { ExecuteResult, SchemaInfo } from "@/lib/tauri";
 
 import {
@@ -25,11 +25,13 @@ import { useEditorInsert } from "@/contexts/editor-insert-context";
 import { useQueryExecution } from "@/contexts/query-execution-context";
 import { useQueryTabs } from "@/hooks/use-query-tabs";
 import { useSyntaxTree } from "@/hooks/use-syntax-tree";
+import { useWorkspaceHotkeys } from "@/hooks/use-workspace-hotkeys";
 import { isSqlDatabase } from "@/lib/connections";
 import { downloadCsv, tabularResultToCsv } from "@/lib/csv";
 import { formatSql } from "@/lib/format-sql";
 
 import { CommandEditor } from "./command-editor";
+import { DialectSelector } from "./dialect-selector";
 import { DocumentViewer } from "./document-viewer";
 import { ExecuteButton } from "./execute-button";
 import { FormatButton } from "./format-button";
@@ -40,6 +42,18 @@ import { ResultsTable } from "./results-table";
 import { SqlEditor } from "./sql-editor";
 import { SyntaxTreePanel } from "./syntax-tree-panel";
 import { SyntaxTreeToggle } from "./syntax-tree-toggle";
+
+type SqlDialect = "postgresql" | "mysql" | "sqlite";
+
+const SQL_DIALECTS = new Set<string>(["postgresql", "mysql", "sqlite"]);
+
+const resolveEditorDialect = (
+  sourceDialect: string | null,
+  connectionType: string
+): SqlDialect =>
+  sourceDialect && SQL_DIALECTS.has(sourceDialect)
+    ? (sourceDialect as SqlDialect)
+    : (connectionType as SqlDialect);
 
 interface WorkspaceContentProps {
   connection: DatabaseConnection;
@@ -66,10 +80,137 @@ export const WorkspaceContent = ({
     addTabWithSql,
     closeTab,
     setActiveTabId,
+    updateTabDialect,
     updateTabSql,
     executeTab,
   } = useQueryTabs(connection.id, selectedDatabase);
 
+  const isSql = isSqlDatabase(connection.type);
+
+  if (isConnecting) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 bg-background">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          Connecting to {connection.name}...
+        </p>
+      </div>
+    );
+  }
+
+  if (connectionError) {
+    return (
+      <div className="flex h-full items-center justify-center bg-background">
+        <QueryErrorDisplay error={connectionError} />
+      </div>
+    );
+  }
+
+  return (
+    <ConnectedWorkspace
+      connection={connection}
+      schema={schema}
+      selectedDatabase={selectedDatabase}
+      tabs={tabs}
+      activeTab={activeTab}
+      activeTabId={activeTabId}
+      isSql={isSql}
+      addTab={addTab}
+      addTabWithSql={addTabWithSql}
+      closeTab={closeTab}
+      setActiveTabId={setActiveTabId}
+      updateTabDialect={updateTabDialect}
+      updateTabSql={updateTabSql}
+      executeTab={executeTab}
+    />
+  );
+};
+
+interface EditorPanelProps {
+  activeTab: QueryTab | undefined;
+  isSql: boolean;
+  connectionType: DatabaseType;
+  editorDialect: SqlDialect;
+  schema: SchemaInfo | null;
+  onSqlChange: (val: string) => void;
+  onExecute: () => void;
+  onEditorUpdate: (update: ViewUpdate) => void;
+  onToggleSyntaxTree: () => void;
+}
+
+const EditorPanel = ({
+  activeTab,
+  isSql,
+  connectionType,
+  editorDialect,
+  schema,
+  onSqlChange,
+  onExecute,
+  onEditorUpdate,
+  onToggleSyntaxTree,
+}: EditorPanelProps) => {
+  if (!activeTab) {
+    return null;
+  }
+
+  if (isSql) {
+    return (
+      <SqlEditor
+        value={activeTab.sql}
+        onChange={onSqlChange}
+        onExecute={onExecute}
+        onUpdate={onEditorUpdate}
+        onToggleSyntaxTree={onToggleSyntaxTree}
+        databaseType={connectionType as "postgresql" | "mysql" | "sqlite"}
+        writingDialect={editorDialect}
+        schema={schema}
+      />
+    );
+  }
+
+  return (
+    <CommandEditor
+      value={activeTab.sql}
+      onChange={onSqlChange}
+      onExecute={onExecute}
+      databaseType={connectionType}
+    />
+  );
+};
+
+interface ConnectedWorkspaceProps {
+  connection: DatabaseConnection;
+  schema: SchemaInfo | null;
+  selectedDatabase: string | null;
+  tabs: QueryTab[];
+  activeTab: QueryTab | undefined;
+  activeTabId: string;
+  isSql: boolean;
+  addTab: () => void;
+  addTabWithSql: (sql: string) => void;
+  closeTab: (tabId: string) => void;
+  setActiveTabId: (id: string) => void;
+  updateTabDialect: (tabId: string, dialect: string | null) => void;
+  updateTabSql: (tabId: string, sql: string) => void;
+  executeTab: (tabId: string, sqlOverride?: string) => void;
+}
+
+const ConnectedWorkspace = ({
+  connection,
+  schema,
+  selectedDatabase: _selectedDatabase,
+  tabs,
+  activeTab,
+  activeTabId,
+  isSql,
+  addTab,
+  addTabWithSql,
+  closeTab,
+  setActiveTabId,
+  updateTabDialect,
+  updateTabSql,
+  executeTab,
+}: ConnectedWorkspaceProps) => {
   const { setExecutionState } = useQueryExecution();
   const { getSelectedText, registerQueryTable } = useEditorInsert();
 
@@ -81,7 +222,6 @@ export const WorkspaceContent = ({
   const activeStatus = activeTab?.status;
   const activeResult = activeTab?.result;
   const activeError = activeTab?.error;
-  const isSql = isSqlDatabase(connection.type);
 
   const toggleSyntaxTree = useCallback(() => {
     setIsSyntaxTreeOpen((prev) => !prev);
@@ -129,15 +269,17 @@ export const WorkspaceContent = ({
     [isSyntaxTreeOpen, handleSyntaxTreeUpdate]
   );
 
+  const editorDialect = resolveEditorDialect(
+    activeTab?.sourceDialect ?? null,
+    connection.type
+  );
+
   const handleFormat = useCallback(() => {
     if (activeTab?.sql.trim() && isSql) {
-      const formatted = formatSql(
-        activeTab.sql,
-        connection.type as "postgresql" | "mysql" | "sqlite"
-      );
+      const formatted = formatSql(activeTab.sql, editorDialect);
       updateTabSql(activeTab.id, formatted);
     }
-  }, [activeTab, isSql, connection.type, updateTabSql]);
+  }, [activeTab, isSql, editorDialect, updateTabSql]);
 
   const handleSqlChange = useCallback(
     (val: string) => {
@@ -148,92 +290,24 @@ export const WorkspaceContent = ({
     [activeTab, updateTabSql]
   );
 
-  useHotkey("Mod+Shift+F", () => {
-    handleFormat();
+  const handleDialectChange = useCallback(
+    (dialect: string) => {
+      if (activeTab) {
+        const newDialect = dialect === connection.type ? null : dialect;
+        updateTabDialect(activeTab.id, newDialect);
+      }
+    },
+    [activeTab, connection.type, updateTabDialect]
+  );
+
+  useWorkspaceHotkeys({
+    activeTab,
+    addTab,
+    closeTab,
+    handleFormat,
+    setActiveTabId,
+    tabs,
   });
-
-  useHotkey("Mod+T", () => {
-    addTab();
-  });
-
-  useHotkey("Mod+W", () => {
-    if (activeTab) {
-      closeTab(activeTab.id);
-    }
-  });
-
-  useHotkey("Mod+1", () => {
-    if (tabs[0]) {
-      setActiveTabId(tabs[0].id);
-    }
-  });
-
-  useHotkey("Mod+2", () => {
-    if (tabs[1]) {
-      setActiveTabId(tabs[1].id);
-    }
-  });
-
-  useHotkey("Mod+3", () => {
-    if (tabs[2]) {
-      setActiveTabId(tabs[2].id);
-    }
-  });
-
-  useHotkey("Mod+4", () => {
-    if (tabs[3]) {
-      setActiveTabId(tabs[3].id);
-    }
-  });
-
-  useHotkey("Mod+5", () => {
-    if (tabs[4]) {
-      setActiveTabId(tabs[4].id);
-    }
-  });
-
-  useHotkey("Mod+6", () => {
-    if (tabs[5]) {
-      setActiveTabId(tabs[5].id);
-    }
-  });
-
-  useHotkey("Mod+7", () => {
-    if (tabs[6]) {
-      setActiveTabId(tabs[6].id);
-    }
-  });
-
-  useHotkey("Mod+8", () => {
-    if (tabs[7]) {
-      setActiveTabId(tabs[7].id);
-    }
-  });
-
-  useHotkey("Mod+9", () => {
-    if (tabs[8]) {
-      setActiveTabId(tabs[8].id);
-    }
-  });
-
-  if (isConnecting) {
-    return (
-      <div className="flex h-full flex-col items-center justify-center gap-3 bg-background">
-        <Loader2 className="size-6 animate-spin text-muted-foreground" />
-        <p className="text-sm text-muted-foreground">
-          Connecting to {connection.name}...
-        </p>
-      </div>
-    );
-  }
-
-  if (connectionError) {
-    return (
-      <div className="flex h-full items-center justify-center bg-background">
-        <QueryErrorDisplay error={connectionError} />
-      </div>
-    );
-  }
 
   return (
     <div className="flex h-full flex-col bg-background">
@@ -249,27 +323,17 @@ export const WorkspaceContent = ({
         <ResizablePanel defaultSize="40%" minSize="15%">
           <div className="flex h-full flex-col">
             <div className="flex-1">
-              {activeTab && isSql && (
-                <SqlEditor
-                  value={activeTab.sql}
-                  onChange={handleSqlChange}
-                  onExecute={handleExecute}
-                  onUpdate={handleEditorUpdate}
-                  onToggleSyntaxTree={toggleSyntaxTree}
-                  databaseType={
-                    connection.type as "postgresql" | "mysql" | "sqlite"
-                  }
-                  schema={schema}
-                />
-              )}
-              {activeTab && !isSql && (
-                <CommandEditor
-                  value={activeTab.sql}
-                  onChange={handleSqlChange}
-                  onExecute={handleExecute}
-                  databaseType={connection.type}
-                />
-              )}
+              <EditorPanel
+                activeTab={activeTab}
+                isSql={isSql}
+                connectionType={connection.type}
+                editorDialect={editorDialect}
+                schema={schema}
+                onSqlChange={handleSqlChange}
+                onExecute={handleExecute}
+                onEditorUpdate={handleEditorUpdate}
+                onToggleSyntaxTree={toggleSyntaxTree}
+              />
             </div>
           </div>
         </ResizablePanel>
@@ -277,31 +341,21 @@ export const WorkspaceContent = ({
         <ResizableHandle />
 
         <ResizablePanel defaultSize="60%" minSize="20%">
-          <div className="flex items-center justify-between border-b px-2 py-1">
-            <span className="text-xs text-muted-foreground">
-              {activeTab?.title}
-            </span>
-            <div className="flex items-center gap-1">
-              {isSql && (
-                <>
-                  <FormatButton
-                    disabled={!activeTab?.sql.trim()}
-                    onClick={handleFormat}
-                  />
-                  <SyntaxTreeToggle
-                    isOpen={isSyntaxTreeOpen}
-                    onToggle={toggleSyntaxTree}
-                  />
-                </>
-              )}
-              <ExecuteButton
-                isRunning={activeTab?.status === "running"}
-                disabled={!activeTab?.sql.trim()}
-                hasSelection={hasSelection}
-                onClick={handleExecute}
-              />
-            </div>
-          </div>
+          <EditorToolbar
+            title={activeTab?.title}
+            isSql={isSql}
+            sourceDialect={activeTab?.sourceDialect ?? null}
+            connectionType={connection.type}
+            onDialectChange={handleDialectChange}
+            isFormatDisabled={!activeTab?.sql.trim()}
+            onFormat={handleFormat}
+            isSyntaxTreeOpen={isSyntaxTreeOpen}
+            onToggleSyntaxTree={toggleSyntaxTree}
+            isRunning={activeTab?.status === "running"}
+            isExecuteDisabled={!activeTab?.sql.trim()}
+            hasSelection={hasSelection}
+            onExecute={handleExecute}
+          />
           <BottomPanel
             isSyntaxTreeOpen={isSyntaxTreeOpen}
             treeData={treeData}
@@ -315,6 +369,68 @@ export const WorkspaceContent = ({
     </div>
   );
 };
+
+interface EditorToolbarProps {
+  title: string | undefined;
+  isSql: boolean;
+  sourceDialect: string | null;
+  connectionType: string;
+  onDialectChange: (dialect: string) => void;
+  isFormatDisabled: boolean;
+  onFormat: () => void;
+  isSyntaxTreeOpen: boolean;
+  onToggleSyntaxTree: () => void;
+  isRunning: boolean;
+  isExecuteDisabled: boolean;
+  hasSelection: boolean;
+  onExecute: () => void;
+}
+
+const EditorToolbar = ({
+  title,
+  isSql,
+  sourceDialect,
+  connectionType,
+  onDialectChange,
+  isFormatDisabled,
+  onFormat,
+  isSyntaxTreeOpen,
+  onToggleSyntaxTree,
+  isRunning,
+  isExecuteDisabled,
+  hasSelection,
+  onExecute,
+}: EditorToolbarProps) => (
+  <div className="flex items-center justify-between border-b px-2 py-1">
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-muted-foreground">{title}</span>
+      {isSql && (
+        <DialectSelector
+          value={sourceDialect ?? connectionType}
+          connectionDialect={connectionType}
+          onChange={onDialectChange}
+        />
+      )}
+    </div>
+    <div className="flex items-center gap-1">
+      {isSql && (
+        <>
+          <FormatButton disabled={isFormatDisabled} onClick={onFormat} />
+          <SyntaxTreeToggle
+            isOpen={isSyntaxTreeOpen}
+            onToggle={onToggleSyntaxTree}
+          />
+        </>
+      )}
+      <ExecuteButton
+        isRunning={isRunning}
+        disabled={isExecuteDisabled}
+        hasSelection={hasSelection}
+        onClick={onExecute}
+      />
+    </div>
+  </div>
+);
 
 const LOADING_SKELETON_IDS = ["s1", "s2", "s3", "s4", "s5"];
 

--- a/apps/web/src/hooks/use-query-tabs.ts
+++ b/apps/web/src/hooks/use-query-tabs.ts
@@ -8,6 +8,7 @@ const createNewTab = (counter: number): QueryTab => ({
   error: null,
   id: crypto.randomUUID(),
   result: null,
+  sourceDialect: null,
   sql: "",
   status: "idle",
   title: `Query ${counter}`,
@@ -77,6 +78,15 @@ export const useQueryTabs = (
     setTabs((prev) => prev.map((t) => (t.id === tabId ? { ...t, sql } : t)));
   }, []);
 
+  const updateTabDialect = useCallback(
+    (tabId: string, dialect: string | null) => {
+      setTabs((prev) =>
+        prev.map((t) => (t.id === tabId ? { ...t, sourceDialect: dialect } : t))
+      );
+    },
+    []
+  );
+
   const executeTab = useCallback(
     async (tabId: string, sqlOverride?: string) => {
       const tab = tabs.find((t) => t.id === tabId);
@@ -97,6 +107,7 @@ export const useQueryTabs = (
         const result = await executeQuery({
           connectionId,
           schema: selectedDatabase ?? undefined,
+          sourceDialect: tab?.sourceDialect ?? undefined,
           sql: sqlToExecute,
         });
         setTabs((prev) =>
@@ -129,6 +140,7 @@ export const useQueryTabs = (
     executeTab,
     setActiveTabId,
     tabs,
+    updateTabDialect,
     updateTabSql,
   };
 };

--- a/apps/web/src/hooks/use-workspace-hotkeys.ts
+++ b/apps/web/src/hooks/use-workspace-hotkeys.ts
@@ -1,0 +1,89 @@
+import { useHotkey } from "@tanstack/react-hotkeys";
+
+import type { QueryTab } from "@/lib/query-types";
+
+interface WorkspaceHotkeysParams {
+  tabs: QueryTab[];
+  activeTab: QueryTab | undefined;
+  addTab: () => void;
+  closeTab: (tabId: string) => void;
+  setActiveTabId: (id: string) => void;
+  handleFormat: () => void;
+}
+
+export const useWorkspaceHotkeys = ({
+  tabs,
+  activeTab,
+  addTab,
+  closeTab,
+  setActiveTabId,
+  handleFormat,
+}: WorkspaceHotkeysParams) => {
+  useHotkey("Mod+Shift+F", () => {
+    handleFormat();
+  });
+
+  useHotkey("Mod+T", () => {
+    addTab();
+  });
+
+  useHotkey("Mod+W", () => {
+    if (activeTab) {
+      closeTab(activeTab.id);
+    }
+  });
+
+  useHotkey("Mod+1", () => {
+    if (tabs[0]) {
+      setActiveTabId(tabs[0].id);
+    }
+  });
+
+  useHotkey("Mod+2", () => {
+    if (tabs[1]) {
+      setActiveTabId(tabs[1].id);
+    }
+  });
+
+  useHotkey("Mod+3", () => {
+    if (tabs[2]) {
+      setActiveTabId(tabs[2].id);
+    }
+  });
+
+  useHotkey("Mod+4", () => {
+    if (tabs[3]) {
+      setActiveTabId(tabs[3].id);
+    }
+  });
+
+  useHotkey("Mod+5", () => {
+    if (tabs[4]) {
+      setActiveTabId(tabs[4].id);
+    }
+  });
+
+  useHotkey("Mod+6", () => {
+    if (tabs[5]) {
+      setActiveTabId(tabs[5].id);
+    }
+  });
+
+  useHotkey("Mod+7", () => {
+    if (tabs[6]) {
+      setActiveTabId(tabs[6].id);
+    }
+  });
+
+  useHotkey("Mod+8", () => {
+    if (tabs[7]) {
+      setActiveTabId(tabs[7].id);
+    }
+  });
+
+  useHotkey("Mod+9", () => {
+    if (tabs[8]) {
+      setActiveTabId(tabs[8].id);
+    }
+  });
+};

--- a/apps/web/src/lib/query-types.ts
+++ b/apps/web/src/lib/query-types.ts
@@ -9,4 +9,5 @@ export interface QueryTab {
   result: ExecuteResult | null;
   error: string | null;
   status: TabStatus;
+  sourceDialect: string | null;
 }

--- a/apps/web/src/lib/tauri.ts
+++ b/apps/web/src/lib/tauri.ts
@@ -41,6 +41,7 @@ export interface QueryParams {
   maxRows?: number;
   timeoutSecs?: number;
   schema?: string;
+  sourceDialect?: string;
 }
 
 export interface ColumnInfo {


### PR DESCRIPTION
## Summary

Add SQL dialect transpilation using the polyglot-sql Rust crate. Users can now write SQL in any dialect (MySQL, BigQuery, Snowflake, DuckDB, etc.) and have it automatically translated to the target database's native syntax before execution.

## Changes

**Backend (Rust):**
- Added polyglot-sql v0.1.4 dependency
- Created transpile module with stack-safe thread spawning (16MB stack) to handle the crate's deep recursion
- Wired transpilation into execute_query command with proper error handling
- Added comprehensive unit tests covering MySQL→PostgreSQL IFNULL→COALESCE conversion

**Frontend (React):**
- Added sourceDialect field to QueryTab and QueryParams types
- Created DialectSelector component with 30+ dialects grouped by category (Databases, Cloud & Warehouses, Analytics, NewSQL & Streaming)
- Updated SqlEditor to use writing dialect for syntax highlighting
- Refactored WorkspaceContent for maintainability: split into ConnectedWorkspace, EditorPanel, and EditorToolbar components
- Extracted workspace hotkeys into useWorkspaceHotkeys hook

## Testing

Manual test: Write `SELECT IFNULL(avatar_url, name) FROM "users"` in MySQL dialect, execute against PostgreSQL — transpiles to `SELECT COALESCE(avatar_url, name) FROM "users"` and runs successfully. Non-matching dialects show an amber ArrowRightLeft indicator in the toolbar.

## Fixes

Resolved app crash caused by polyglot-sql's stack overflow on certain SQL inputs by spawning transpilation on a dedicated thread with 16MB stack and catching panics gracefully.