### PR TITLE
Replace SQL formatter with Rust polyglot-sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ Chat with an AI that understands your schema. It sees your tables, columns, type
 
 ### Smart editor
 
-CodeMirror-powered SQL editor with schema-aware autocomplete, syntax highlighting, SQL beautifier, and a syntax tree inspector. Work across multiple query tabs with full keyboard shortcut support.
+CodeMirror-powered SQL editor with schema-aware autocomplete, syntax highlighting, and a syntax tree inspector. Work across multiple query tabs with full keyboard shortcut support.
+
+### SQL dialect engine
+
+Write SQL in any dialect and run it against any database. Powered by [polyglot-sql](https://github.com/polyglot-sql/polyglot-sql), queries are automatically transpiled between dialects at execution time. The built-in SQL formatter is also dialect-aware, supporting 30+ SQL dialects including PostgreSQL, MySQL, BigQuery, Snowflake, DuckDB, ClickHouse, Spark, and more.
 
 ### Native experience
 
@@ -99,7 +103,7 @@ oh-my-query/
 
 **Frontend** — React 19, TanStack Router, Tailwind CSS v4, shadcn/ui, CodeMirror, Framer Motion, Vercel AI SDK
 
-**Desktop** — Tauri v2, Rust, sqlx (PostgreSQL/MySQL/SQLite), mongodb, redis
+**Desktop** — Tauri v2, Rust, sqlx (PostgreSQL/MySQL/SQLite), mongodb, redis, polyglot-sql (transpilation & formatting)
 
 **Tooling** — Turborepo, Bun, TypeScript 5, Ultracite (Oxlint + Oxfmt)
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,7 +49,6 @@
     "remark-gfm": "^4.0.1",
     "shadcn": "^3.8.4",
     "sonner": "^2.0.7",
-    "sql-formatter": "^15.7.2",
     "tailwind-merge": "^3.3.1",
     "tw-animate-css": "^1.2.5",
     "zod": "catalog:"

--- a/apps/web/src-tauri/src/commands.rs
+++ b/apps/web/src-tauri/src/commands.rs
@@ -7,7 +7,7 @@ use crate::db::error::DbError;
 use crate::db::execute::execute_for_pool;
 use crate::db::pool::ConnectionPoolManager;
 use crate::db::schema::{fetch_schema, list_databases};
-use crate::db::transpile::{pool_dialect, transpile_sql};
+use crate::db::transpile::{format_sql as do_format_sql, pool_dialect, transpile_sql};
 use crate::db::types::{
     ConnectionParams, ExecuteResult, QueryParams, SchemaInfo, TestConnectionResult,
 };
@@ -108,4 +108,9 @@ pub async fn execute_query(
     }
 
     Ok(execute_result)
+}
+
+#[tauri::command]
+pub async fn format_sql(sql: String, dialect: String) -> Result<String, DbError> {
+    do_format_sql(&sql, &dialect)
 }

--- a/apps/web/src-tauri/src/db/transpile.rs
+++ b/apps/web/src-tauri/src/db/transpile.rs
@@ -1,4 +1,5 @@
-use polyglot_sql::{transpile, DialectType};
+use polyglot_sql::generator::GeneratorConfig;
+use polyglot_sql::{parse, transpile, DialectType, Generator};
 
 use crate::db::error::DbError;
 use crate::db::pool::DatabasePool;
@@ -49,6 +50,47 @@ pub fn transpile_sql(
     Ok(result.join(";\n"))
 }
 
+pub fn format_sql(sql: &str, dialect: &str) -> Result<String, DbError> {
+    let parsed_dialect: DialectType = dialect.parse().map_err(|e| DbError {
+        code: "UNSUPPORTED_DIALECT".to_string(),
+        message: format!("Unsupported dialect '{dialect}': {e}"),
+    })?;
+
+    let sql = sql.to_string();
+    let result = std::thread::Builder::new()
+        .stack_size(TRANSPILE_STACK_SIZE)
+        .spawn(move || -> polyglot_sql::Result<Vec<String>> {
+            let expressions = parse(&sql, parsed_dialect)?;
+            let config = GeneratorConfig {
+                pretty: true,
+                dialect: Some(parsed_dialect),
+                ..GeneratorConfig::default()
+            };
+            expressions
+                .iter()
+                .map(|expr| {
+                    let mut gen = Generator::with_config(config.clone());
+                    gen.generate(expr)
+                })
+                .collect()
+        })
+        .map_err(|e| DbError {
+            code: "FORMAT_ERROR".to_string(),
+            message: format!("Failed to spawn format thread: {e}"),
+        })?
+        .join()
+        .map_err(|_| DbError {
+            code: "FORMAT_ERROR".to_string(),
+            message: "SQL formatting crashed unexpectedly".to_string(),
+        })?
+        .map_err(|e| DbError {
+            code: "FORMAT_ERROR".to_string(),
+            message: format!("SQL formatting failed: {e}"),
+        })?;
+
+    Ok(result.join(";\n\n"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -75,5 +117,28 @@ mod tests {
     fn test_unsupported_dialect() {
         let result = transpile_sql("SELECT 1", "invalid", DialectType::PostgreSQL);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_format_sql_basic() {
+        let result = format_sql(
+            "select id, name from users where active = true",
+            "postgresql",
+        )
+        .unwrap();
+        assert!(result.contains("SELECT"));
+        assert!(result.contains('\n'));
+    }
+
+    #[test]
+    fn test_format_sql_unsupported_dialect() {
+        let result = format_sql("SELECT 1", "not_a_dialect");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_format_sql_multi_statement() {
+        let result = format_sql("select 1; select 2", "postgresql").unwrap();
+        assert!(result.contains(";\n\n"));
     }
 }

--- a/apps/web/src-tauri/src/lib.rs
+++ b/apps/web/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub fn run() {
             commands::execute_query,
             commands::list_connection_databases,
             commands::get_schema,
+            commands::format_sql,
             config::get_config,
             config::save_config,
         ])

--- a/apps/web/src/components/workspace/workspace-content.tsx
+++ b/apps/web/src/components/workspace/workspace-content.tsx
@@ -274,10 +274,16 @@ const ConnectedWorkspace = ({
     connection.type
   );
 
-  const handleFormat = useCallback(() => {
-    if (activeTab?.sql.trim() && isSql) {
-      const formatted = formatSql(activeTab.sql, editorDialect);
+  const handleFormat = useCallback(async () => {
+    if (!activeTab?.sql.trim() || !isSql) {
+      return;
+    }
+
+    try {
+      const formatted = await formatSql(activeTab.sql, editorDialect);
       updateTabSql(activeTab.id, formatted);
+    } catch {
+      // Leave SQL unchanged on format error
     }
   }, [activeTab, isSql, editorDialect, updateTabSql]);
 

--- a/apps/web/src/lib/format-sql.ts
+++ b/apps/web/src/lib/format-sql.ts
@@ -1,17 +1,13 @@
-import { format } from "sql-formatter";
+import { isTauri } from "@/lib/tauri";
 
-type SqlDatabaseType = "postgresql" | "mysql" | "sqlite";
+export const formatSql = async (
+  sql: string,
+  dialect: string
+): Promise<string> => {
+  if (!isTauri()) {
+    return sql;
+  }
 
-const LANGUAGE_MAP: Record<SqlDatabaseType, "postgresql" | "mysql" | "sqlite"> =
-  {
-    mysql: "mysql",
-    postgresql: "postgresql",
-    sqlite: "sqlite",
-  };
-
-export const formatSql = (sql: string, databaseType: SqlDatabaseType): string =>
-  format(sql, {
-    keywordCase: "upper",
-    language: LANGUAGE_MAP[databaseType],
-    tabWidth: 2,
-  });
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<string>("format_sql", { dialect, sql });
+};

--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,6 @@
         "remark-gfm": "^4.0.1",
         "shadcn": "^3.8.4",
         "sonner": "^2.0.7",
-        "sql-formatter": "^15.7.2",
         "tailwind-merge": "^3.3.1",
         "tw-animate-css": "^1.2.5",
         "zod": "catalog:",
@@ -831,8 +830,6 @@
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
-    "discontinuous-range": ["discontinuous-range@1.0.0", "", {}, "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="],
-
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dotenv": ["dotenv@17.2.4", "", {}, "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw=="],
@@ -1221,8 +1218,6 @@
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
-    "moo": ["moo@0.5.2", "", {}, "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="],
-
     "motion": ["motion@12.34.0", "", { "dependencies": { "framer-motion": "^12.34.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-01Sfa/zgsD/di8zA/uFW5Eb7/SPXoGyUfy+uMRMW5Spa8j0z/UbfQewAYvPMYFCXRlyD6e5aLHh76TxeeJD+RA=="],
 
     "motion-dom": ["motion-dom@12.34.0", "", { "dependencies": { "motion-utils": "^12.29.2" } }, "sha512-Lql3NuEcScRDxTAO6GgUsRHBZOWI/3fnMlkMcH5NftzcN37zJta+bpbMAV9px4Nj057TuvRooMK7QrzMCgtz6Q=="],
@@ -1236,8 +1231,6 @@
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
-    "nearley": ["nearley@2.20.1", "", { "dependencies": { "commander": "^2.19.0", "moo": "^0.5.0", "railroad-diagrams": "^1.0.0", "randexp": "0.4.6" }, "bin": { "nearleyc": "bin/nearleyc.js", "nearley-test": "bin/nearley-test.js", "nearley-unparse": "bin/nearley-unparse.js", "nearley-railroad": "bin/nearley-railroad.js" } }, "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -1327,10 +1320,6 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
-    "railroad-diagrams": ["railroad-diagrams@1.0.0", "", {}, "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="],
-
-    "randexp": ["randexp@0.4.6", "", { "dependencies": { "discontinuous-range": "1.0.0", "ret": "~0.1.10" } }, "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ=="],
-
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
@@ -1387,8 +1376,6 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
-    "ret": ["ret@0.1.15", "", {}, "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="],
-
     "rettime": ["rettime@0.10.1", "", {}, "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
@@ -1442,8 +1429,6 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
-
-    "sql-formatter": ["sql-formatter@15.7.2", "", { "dependencies": { "argparse": "^2.0.1", "nearley": "^2.20.1" }, "bin": { "sql-formatter": "bin/sql-formatter-cli.cjs" } }, "sha512-b0BGoM81KFRVSpZFwPpIPU5gng4YD8DI/taLD96NXCFRf5af3FzSE4aSwjKmxcyTmf/MfPu91j75883nRrWDBw=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -1664,8 +1649,6 @@
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "nearley/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 


### PR DESCRIPTION
Move SQL formatting from JavaScript to Rust using the polyglot-sql crate that's already integrated for transpilation. This enables dialect-aware formatting for all 35 supported dialects instead of just 3 (postgresql, mysql, sqlite).

Implement a new Tauri command that parses SQL and generates pretty-printed output using polyglot-sql's Generator with dialect-specific configuration. The frontend call remains the same but is now async with graceful error handling.

All tests pass including 3 new unit tests for format_sql. The sql-formatter npm dependency is removed.