### PR TITLE
feat: add query history and tab persistence

### DIFF
--- a/apps/web/src-tauri/src/lib.rs
+++ b/apps/web/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod config;
 mod db;
+mod persistence;
 
 use db::pool::ConnectionPoolManager;
 
@@ -24,6 +25,10 @@ pub fn run() {
             commands::format_sql,
             config::get_config,
             config::save_config,
+            persistence::get_tabs,
+            persistence::save_tabs,
+            persistence::append_history,
+            persistence::get_history,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/web/src-tauri/src/persistence.rs
+++ b/apps/web/src-tauri/src/persistence.rs
@@ -1,0 +1,145 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tokio::io::AsyncWriteExt;
+
+use crate::config::ConfigError;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedTab {
+    pub id: String,
+    pub title: String,
+    pub sql: String,
+    pub source_dialect: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TabState {
+    pub tabs: Vec<PersistedTab>,
+    pub active_tab_id: String,
+    pub counter: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryEntry {
+    pub sql: String,
+    pub connection_id: String,
+    pub database: Option<String>,
+    pub timestamp: String,
+    pub success: bool,
+    pub error: Option<String>,
+    pub execution_time_ms: u64,
+}
+
+const MAX_HISTORY_ENTRIES: usize = 10_000;
+
+fn tabs_path(connection_id: &str) -> Result<PathBuf, ConfigError> {
+    let home = dirs::home_dir().ok_or_else(|| ConfigError {
+        code: "HOME_NOT_FOUND".to_string(),
+        message: "Could not determine home directory".to_string(),
+    })?;
+    Ok(home
+        .join(".config")
+        .join("oh-my-query")
+        .join("tabs")
+        .join(format!("{connection_id}.json")))
+}
+
+fn history_path(connection_id: &str) -> Result<PathBuf, ConfigError> {
+    let home = dirs::home_dir().ok_or_else(|| ConfigError {
+        code: "HOME_NOT_FOUND".to_string(),
+        message: "Could not determine home directory".to_string(),
+    })?;
+    Ok(home
+        .join(".config")
+        .join("oh-my-query")
+        .join("history")
+        .join(format!("{connection_id}.jsonl")))
+}
+
+async fn ensure_parent_dir(path: &PathBuf) -> Result<(), ConfigError> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    Ok(())
+}
+
+async fn enforce_history_limit(path: &PathBuf) -> Result<(), ConfigError> {
+    let content = tokio::fs::read_to_string(path).await?;
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.len() <= MAX_HISTORY_ENTRIES {
+        return Ok(());
+    }
+    let trimmed: String = lines[lines.len() - MAX_HISTORY_ENTRIES..].join("\n");
+    let mut output = trimmed;
+    output.push('\n');
+    tokio::fs::write(path, output).await?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_tabs(connection_id: String) -> Result<Option<TabState>, ConfigError> {
+    let path = tabs_path(&connection_id)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = tokio::fs::read_to_string(&path).await?;
+    let state: TabState = serde_json::from_str(&content)?;
+    Ok(Some(state))
+}
+
+#[tauri::command]
+pub async fn save_tabs(connection_id: String, state: TabState) -> Result<(), ConfigError> {
+    let path = tabs_path(&connection_id)?;
+    ensure_parent_dir(&path).await?;
+    let content = serde_json::to_string_pretty(&state)?;
+    tokio::fs::write(&path, content).await?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn append_history(entry: HistoryEntry) -> Result<(), ConfigError> {
+    let path = history_path(&entry.connection_id)?;
+    ensure_parent_dir(&path).await?;
+
+    let mut line = serde_json::to_string(&entry)?;
+    line.push('\n');
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .await?;
+    file.write_all(line.as_bytes()).await?;
+
+    enforce_history_limit(&path).await?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_history(
+    connection_id: String,
+    limit: Option<u32>,
+    offset: Option<u32>,
+) -> Result<Vec<HistoryEntry>, ConfigError> {
+    let path = history_path(&connection_id)?;
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let content = tokio::fs::read_to_string(&path).await?;
+    let mut entries: Vec<HistoryEntry> = content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+
+    entries.reverse();
+
+    let offset = offset.unwrap_or(0) as usize;
+    let limit = limit.unwrap_or(100) as usize;
+
+    Ok(entries.into_iter().skip(offset).take(limit).collect())
+}

--- a/apps/web/src-tauri/src/persistence.rs
+++ b/apps/web/src-tauri/src/persistence.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt;
 
 use crate::config::ConfigError;
@@ -59,14 +59,14 @@ fn history_path(connection_id: &str) -> Result<PathBuf, ConfigError> {
         .join(format!("{connection_id}.jsonl")))
 }
 
-async fn ensure_parent_dir(path: &PathBuf) -> Result<(), ConfigError> {
+async fn ensure_parent_dir(path: &Path) -> Result<(), ConfigError> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
     Ok(())
 }
 
-async fn enforce_history_limit(path: &PathBuf) -> Result<(), ConfigError> {
+async fn enforce_history_limit(path: &Path) -> Result<(), ConfigError> {
     let content = tokio::fs::read_to_string(path).await?;
     let lines: Vec<&str> = content.lines().collect();
     if lines.len() <= MAX_HISTORY_ENTRIES {

--- a/apps/web/src/components/workspace/query-history-list.tsx
+++ b/apps/web/src/components/workspace/query-history-list.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle2, Clock, History, XCircle } from "lucide-react";
-import { useCallback } from "react";
+import { memo, useCallback } from "react";
 
 import type { HistoryEntry } from "@/lib/persistence";
 
@@ -96,7 +96,7 @@ export const QueryHistoryList = ({ connectionId }: QueryHistoryListProps) => {
     <ScrollArea className="h-full">
       <div className="flex flex-col gap-0.5 px-2 py-1">
         {entries.map((entry) => (
-          <HistoryItem key={`${entry.timestamp}-${entry.sql}`} entry={entry} />
+          <HistoryItem key={entry.timestamp} entry={entry} />
         ))}
       </div>
     </ScrollArea>
@@ -107,7 +107,7 @@ interface HistoryItemProps {
   entry: HistoryEntry;
 }
 
-const HistoryItem = ({ entry }: HistoryItemProps) => {
+const HistoryItem = memo(function HistoryItem({ entry }: HistoryItemProps) {
   const { openQuery } = useEditorInsert();
 
   const handleClick = useCallback(() => {
@@ -151,4 +151,4 @@ const HistoryItem = ({ entry }: HistoryItemProps) => {
       </TooltipContent>
     </Tooltip>
   );
-};
+});

--- a/apps/web/src/components/workspace/query-history-list.tsx
+++ b/apps/web/src/components/workspace/query-history-list.tsx
@@ -1,0 +1,154 @@
+import { CheckCircle2, Clock, History, XCircle } from "lucide-react";
+import { useCallback } from "react";
+
+import type { HistoryEntry } from "@/lib/persistence";
+
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useEditorInsert } from "@/contexts/editor-insert-context";
+import { useQueryHistory } from "@/hooks/use-query-history";
+import { cn } from "@/lib/utils";
+
+const SECONDS_PER_MINUTE = 60;
+const SECONDS_PER_HOUR = 3600;
+const SECONDS_PER_DAY = 86_400;
+
+const formatRelativeTime = (timestamp: string): string => {
+  const seconds = Math.floor(
+    (Date.now() - new Date(timestamp).getTime()) / 1000
+  );
+  if (seconds < SECONDS_PER_MINUTE) {
+    return "just now";
+  }
+  if (seconds < SECONDS_PER_HOUR) {
+    const minutes = Math.floor(seconds / SECONDS_PER_MINUTE);
+    return `${minutes}m ago`;
+  }
+  if (seconds < SECONDS_PER_DAY) {
+    const hours = Math.floor(seconds / SECONDS_PER_HOUR);
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(seconds / SECONDS_PER_DAY);
+  return `${days}d ago`;
+};
+
+const MAX_SQL_DISPLAY_LENGTH = 120;
+
+const truncateSql = (
+  sql: string,
+  maxLength = MAX_SQL_DISPLAY_LENGTH
+): string => {
+  const oneLine = sql.replaceAll(/\s+/g, " ").trim();
+  if (oneLine.length <= maxLength) {
+    return oneLine;
+  }
+  return `${oneLine.slice(0, maxLength)}...`;
+};
+
+const SKELETON_ITEMS = ["h1", "h2", "h3", "h4", "h5"];
+
+interface QueryHistoryListProps {
+  connectionId: string;
+}
+
+export const QueryHistoryList = ({ connectionId }: QueryHistoryListProps) => {
+  const { entries, isLoading } = useQueryHistory(connectionId);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2 px-3 py-2">
+        {SKELETON_ITEMS.map((id) => (
+          <Skeleton key={id} className="h-12 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <History />
+            </EmptyMedia>
+            <EmptyTitle>No history yet</EmptyTitle>
+            <EmptyDescription>Run a query to see it here</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="flex flex-col gap-0.5 px-2 py-1">
+        {entries.map((entry) => (
+          <HistoryItem key={`${entry.timestamp}-${entry.sql}`} entry={entry} />
+        ))}
+      </div>
+    </ScrollArea>
+  );
+};
+
+interface HistoryItemProps {
+  entry: HistoryEntry;
+}
+
+const HistoryItem = ({ entry }: HistoryItemProps) => {
+  const { openQuery } = useEditorInsert();
+
+  const handleClick = useCallback(() => {
+    openQuery(entry.sql);
+  }, [openQuery, entry.sql]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            onClick={handleClick}
+            className={cn(
+              "flex w-full flex-col gap-1 rounded-md px-2 py-1.5 text-left",
+              "hover:bg-accent/50 transition-colors"
+            )}
+          />
+        }
+      >
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+            {entry.success ? (
+              <CheckCircle2 className="size-3 text-emerald-500" />
+            ) : (
+              <XCircle className="size-3 text-destructive" />
+            )}
+            <span>{entry.executionTimeMs}ms</span>
+          </div>
+          <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+            <Clock className="size-2.5" />
+            <span>{formatRelativeTime(entry.timestamp)}</span>
+          </div>
+        </div>
+        <p className="line-clamp-2 text-xs font-mono text-foreground/80">
+          {truncateSql(entry.sql)}
+        </p>
+      </TooltipTrigger>
+      <TooltipContent side="right" className="max-w-80">
+        <pre className="whitespace-pre-wrap text-xs">{entry.sql}</pre>
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/apps/web/src/components/workspace/workspace-content.tsx
+++ b/apps/web/src/components/workspace/workspace-content.tsx
@@ -23,6 +23,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useEditorInsert } from "@/contexts/editor-insert-context";
 import { useQueryExecution } from "@/contexts/query-execution-context";
+import {
+  QueryTabsProvider,
+  useQueryTabsContext,
+} from "@/contexts/query-tabs-context";
 import { useQueryTabs } from "@/hooks/use-query-tabs";
 import { useSyntaxTree } from "@/hooks/use-syntax-tree";
 import { useWorkspaceHotkeys } from "@/hooks/use-workspace-hotkeys";
@@ -72,23 +76,10 @@ export const WorkspaceContent = ({
   schema,
   selectedDatabase,
 }: WorkspaceContentProps) => {
-  const {
-    tabs,
-    activeTab,
-    activeTabId,
-    addTab,
-    addTabWithSql,
-    closeTab,
-    setActiveTabId,
-    updateTabDialect,
-    updateTabSql,
-    executeTab,
-    isRestored,
-  } = useQueryTabs(connection.id, selectedDatabase);
-
+  const queryTabs = useQueryTabs(connection.id, selectedDatabase);
   const isSql = isSqlDatabase(connection.type);
 
-  if (!isRestored || isConnecting) {
+  if (!queryTabs.isRestored || isConnecting) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 bg-background">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
@@ -108,22 +99,13 @@ export const WorkspaceContent = ({
   }
 
   return (
-    <ConnectedWorkspace
-      connection={connection}
-      schema={schema}
-      selectedDatabase={selectedDatabase}
-      tabs={tabs}
-      activeTab={activeTab}
-      activeTabId={activeTabId}
-      isSql={isSql}
-      addTab={addTab}
-      addTabWithSql={addTabWithSql}
-      closeTab={closeTab}
-      setActiveTabId={setActiveTabId}
-      updateTabDialect={updateTabDialect}
-      updateTabSql={updateTabSql}
-      executeTab={executeTab}
-    />
+    <QueryTabsProvider value={queryTabs}>
+      <ConnectedWorkspace
+        connection={connection}
+        schema={schema}
+        isSql={isSql}
+      />
+    </QueryTabsProvider>
   );
 };
 
@@ -182,36 +164,27 @@ const EditorPanel = ({
 interface ConnectedWorkspaceProps {
   connection: DatabaseConnection;
   schema: SchemaInfo | null;
-  selectedDatabase: string | null;
-  tabs: QueryTab[];
-  activeTab: QueryTab | undefined;
-  activeTabId: string;
   isSql: boolean;
-  addTab: () => void;
-  addTabWithSql: (sql: string) => void;
-  closeTab: (tabId: string) => void;
-  setActiveTabId: (id: string) => void;
-  updateTabDialect: (tabId: string, dialect: string | null) => void;
-  updateTabSql: (tabId: string, sql: string) => void;
-  executeTab: (tabId: string, sqlOverride?: string) => void;
 }
 
 const ConnectedWorkspace = ({
   connection,
   schema,
-  selectedDatabase: _selectedDatabase,
-  tabs,
-  activeTab,
-  activeTabId,
   isSql,
-  addTab,
-  addTabWithSql,
-  closeTab,
-  setActiveTabId,
-  updateTabDialect,
-  updateTabSql,
-  executeTab,
 }: ConnectedWorkspaceProps) => {
+  const {
+    tabs,
+    activeTab,
+    activeTabId,
+    addTab,
+    addTabWithSql,
+    closeTab,
+    setActiveTabId,
+    updateTabDialect,
+    updateTabSql,
+    executeTab,
+  } = useQueryTabsContext();
+
   const { setExecutionState } = useQueryExecution();
   const { getSelectedText, registerQueryTable, registerOpenQuery } =
     useEditorInsert();
@@ -221,23 +194,24 @@ const ConnectedWorkspace = ({
   const { treeData, handleEditorUpdate: handleSyntaxTreeUpdate } =
     useSyntaxTree(isSyntaxTreeOpen);
 
-  const activeStatus = activeTab?.status;
-  const activeResult = activeTab?.result;
-  const activeError = activeTab?.error;
-
   const toggleSyntaxTree = useCallback(() => {
     setIsSyntaxTreeOpen((prev) => !prev);
   }, []);
 
   useEffect(() => {
-    if (activeStatus) {
+    if (activeTab?.status) {
       setExecutionState({
-        error: activeError ?? null,
-        result: activeResult ?? null,
-        status: activeStatus,
+        error: activeTab.error ?? null,
+        result: activeTab.result ?? null,
+        status: activeTab.status,
       });
     }
-  }, [activeStatus, activeResult, activeError, setExecutionState]);
+  }, [
+    activeTab?.status,
+    activeTab?.result,
+    activeTab?.error,
+    setExecutionState,
+  ]);
 
   const handleQueryTable = useCallback(
     (tableName: string) => {

--- a/apps/web/src/components/workspace/workspace-content.tsx
+++ b/apps/web/src/components/workspace/workspace-content.tsx
@@ -83,11 +83,12 @@ export const WorkspaceContent = ({
     updateTabDialect,
     updateTabSql,
     executeTab,
+    isRestored,
   } = useQueryTabs(connection.id, selectedDatabase);
 
   const isSql = isSqlDatabase(connection.type);
 
-  if (isConnecting) {
+  if (!isRestored || isConnecting) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 bg-background">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
@@ -212,7 +213,8 @@ const ConnectedWorkspace = ({
   executeTab,
 }: ConnectedWorkspaceProps) => {
   const { setExecutionState } = useQueryExecution();
-  const { getSelectedText, registerQueryTable } = useEditorInsert();
+  const { getSelectedText, registerQueryTable, registerOpenQuery } =
+    useEditorInsert();
 
   const [isSyntaxTreeOpen, setIsSyntaxTreeOpen] = useState(false);
   const [hasSelection, setHasSelection] = useState(false);
@@ -248,6 +250,11 @@ const ConnectedWorkspace = ({
     registerQueryTable(handleQueryTable);
     return () => registerQueryTable(null);
   }, [registerQueryTable, handleQueryTable]);
+
+  useEffect(() => {
+    registerOpenQuery(addTabWithSql);
+    return () => registerOpenQuery(null);
+  }, [registerOpenQuery, addTabWithSql]);
 
   const handleExecute = useCallback(() => {
     if (activeTab) {

--- a/apps/web/src/components/workspace/workspace-sidebar.tsx
+++ b/apps/web/src/components/workspace/workspace-sidebar.tsx
@@ -95,7 +95,7 @@ const DatabaseSelector = ({
         onSelect(value);
       }
     },
-    [onSelect],
+    [onSelect]
   );
 
   return (
@@ -176,7 +176,7 @@ export const WorkspaceSidebar = ({
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setFilter(e.target.value);
     },
-    [],
+    []
   );
 
   useHotkey("F5", () => {
@@ -190,7 +190,7 @@ export const WorkspaceSidebar = ({
     <div
       className={cn(
         "flex h-full flex-col text-sidebar-foreground",
-        isTauri() ? "bg-transparent" : "bg-sidebar",
+        isTauri() ? "bg-transparent" : "bg-sidebar"
       )}
     >
       <div className="flex items-center justify-between px-3 py-2">

--- a/apps/web/src/components/workspace/workspace-sidebar.tsx
+++ b/apps/web/src/components/workspace/workspace-sidebar.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Tooltip,
   TooltipContent,
@@ -30,6 +31,7 @@ import {
 import { isTauri } from "@/lib/tauri";
 import { cn } from "@/lib/utils";
 
+import { QueryHistoryList } from "./query-history-list";
 import { SchemaTree } from "./schema-tree";
 
 interface WorkspaceSidebarProps {
@@ -93,7 +95,7 @@ const DatabaseSelector = ({
         onSelect(value);
       }
     },
-    [onSelect]
+    [onSelect],
   );
 
   return (
@@ -115,6 +117,49 @@ const DatabaseSelector = ({
   );
 };
 
+interface SchemaTabContentProps {
+  schema: SchemaInfo | null;
+  isLoading: boolean;
+  error: string | null;
+  filter: string;
+  onFilterChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onRetry: () => void;
+}
+
+const SchemaTabContent = ({
+  schema,
+  isLoading,
+  error,
+  filter,
+  onFilterChange,
+  onRetry,
+}: SchemaTabContentProps) => (
+  <>
+    {schema && (
+      <div className="px-2 py-2">
+        <InputGroup>
+          <InputGroupAddon>
+            <InputGroupText>
+              <Search />
+            </InputGroupText>
+          </InputGroupAddon>
+          <InputGroupInput
+            placeholder="Filter tables..."
+            value={filter}
+            onChange={onFilterChange}
+          />
+        </InputGroup>
+      </div>
+    )}
+
+    <ScrollArea className="min-h-0 flex-1">
+      {isLoading && !schema && <SchemaLoadingState />}
+      {error && <SchemaErrorState error={error} onRetry={onRetry} />}
+      {schema && <SchemaTree schema={schema} filter={filter} />}
+    </ScrollArea>
+  </>
+);
+
 export const WorkspaceSidebar = ({
   connection,
   schema,
@@ -131,7 +176,7 @@ export const WorkspaceSidebar = ({
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setFilter(e.target.value);
     },
-    []
+    [],
   );
 
   useHotkey("F5", () => {
@@ -145,7 +190,7 @@ export const WorkspaceSidebar = ({
     <div
       className={cn(
         "flex h-full flex-col text-sidebar-foreground",
-        isTauri() ? "bg-transparent" : "bg-sidebar"
+        isTauri() ? "bg-transparent" : "bg-sidebar",
       )}
     >
       <div className="flex items-center justify-between px-3 py-2">
@@ -174,28 +219,29 @@ export const WorkspaceSidebar = ({
 
       <Separator className="bg-sidebar-border" />
 
-      {schema && (
-        <div className="px-2 py-2">
-          <InputGroup>
-            <InputGroupAddon>
-              <InputGroupText>
-                <Search />
-              </InputGroupText>
-            </InputGroupAddon>
-            <InputGroupInput
-              placeholder="Filter tables..."
-              value={filter}
-              onChange={handleFilterChange}
-            />
-          </InputGroup>
+      <Tabs defaultValue="schema" className="flex min-h-0 flex-1 flex-col">
+        <div className="px-2 pt-2">
+          <TabsList className="w-full bg-transparent">
+            <TabsTrigger value="schema">Schema</TabsTrigger>
+            <TabsTrigger value="history">History</TabsTrigger>
+          </TabsList>
         </div>
-      )}
 
-      <ScrollArea className="min-h-0 flex-1">
-        {isLoading && !schema && <SchemaLoadingState />}
-        {error && <SchemaErrorState error={error} onRetry={refresh} />}
-        {schema && <SchemaTree schema={schema} filter={filter} />}
-      </ScrollArea>
+        <TabsContent value="schema" className="flex min-h-0 flex-1 flex-col">
+          <SchemaTabContent
+            schema={schema}
+            isLoading={isLoading}
+            error={error}
+            filter={filter}
+            onFilterChange={handleFilterChange}
+            onRetry={refresh}
+          />
+        </TabsContent>
+
+        <TabsContent value="history" className="min-h-0 flex-1">
+          <QueryHistoryList connectionId={connection.id} />
+        </TabsContent>
+      </Tabs>
 
       {showDatabaseSelector && (
         <DatabaseSelector

--- a/apps/web/src/contexts/editor-insert-context.tsx
+++ b/apps/web/src/contexts/editor-insert-context.tsx
@@ -6,8 +6,10 @@ import { createContext, use, useCallback, useRef } from "react";
 interface EditorInsertContextValue {
   getSelectedText: () => string | null;
   insertAtCursor: (text: string) => void;
+  openQuery: (sql: string) => void;
   queryTable: (tableName: string) => void;
   registerEditor: (view: EditorView | null) => void;
+  registerOpenQuery: (handler: ((sql: string) => void) | null) => void;
   registerQueryTable: (handler: ((tableName: string) => void) | null) => void;
 }
 
@@ -18,6 +20,7 @@ const EditorInsertContext = createContext<EditorInsertContextValue | null>(
 export const EditorInsertProvider = ({ children }: { children: ReactNode }) => {
   const editorRef = useRef<EditorView | null>(null);
   const queryTableRef = useRef<((tableName: string) => void) | null>(null);
+  const openQueryRef = useRef<((sql: string) => void) | null>(null);
 
   const registerEditor = useCallback((view: EditorView | null) => {
     editorRef.current = view;
@@ -26,6 +29,13 @@ export const EditorInsertProvider = ({ children }: { children: ReactNode }) => {
   const registerQueryTable = useCallback(
     (handler: ((tableName: string) => void) | null) => {
       queryTableRef.current = handler;
+    },
+    []
+  );
+
+  const registerOpenQuery = useCallback(
+    (handler: ((sql: string) => void) | null) => {
+      openQueryRef.current = handler;
     },
     []
   );
@@ -60,13 +70,19 @@ export const EditorInsertProvider = ({ children }: { children: ReactNode }) => {
     queryTableRef.current?.(tableName);
   }, []);
 
+  const openQuery = useCallback((sql: string) => {
+    openQueryRef.current?.(sql);
+  }, []);
+
   return (
     <EditorInsertContext
       value={{
         getSelectedText,
         insertAtCursor,
+        openQuery,
         queryTable,
         registerEditor,
+        registerOpenQuery,
         registerQueryTable,
       }}
     >

--- a/apps/web/src/contexts/query-tabs-context.tsx
+++ b/apps/web/src/contexts/query-tabs-context.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+import { createContext, use } from "react";
+
+import type { QueryTab } from "@/lib/query-types";
+
+interface QueryTabsContextValue {
+  tabs: QueryTab[];
+  activeTab: QueryTab | undefined;
+  activeTabId: string;
+  addTab: () => void;
+  addTabWithSql: (sql: string) => void;
+  closeTab: (tabId: string) => void;
+  setActiveTabId: (id: string) => void;
+  updateTabDialect: (tabId: string, dialect: string | null) => void;
+  updateTabSql: (tabId: string, sql: string) => void;
+  executeTab: (tabId: string, sqlOverride?: string) => void;
+}
+
+const QueryTabsContext = createContext<QueryTabsContextValue | null>(null);
+
+export const QueryTabsProvider = ({
+  value,
+  children,
+}: {
+  value: QueryTabsContextValue;
+  children: ReactNode;
+}) => <QueryTabsContext value={value}>{children}</QueryTabsContext>;
+
+export const useQueryTabsContext = (): QueryTabsContextValue => {
+  const ctx = use(QueryTabsContext);
+  if (!ctx) {
+    throw new Error(
+      "useQueryTabsContext must be used within a QueryTabsProvider"
+    );
+  }
+  return ctx;
+};

--- a/apps/web/src/hooks/use-query-history.ts
+++ b/apps/web/src/hooks/use-query-history.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import type { HistoryEntry } from "@/lib/persistence";
 
-import { getHistory } from "@/lib/persistence";
+import { getHistory, HISTORY_UPDATED_EVENT } from "@/lib/persistence";
 
 export const useQueryHistory = (connectionId: string) => {
   const [entries, setEntries] = useState<HistoryEntry[]>([]);
@@ -21,6 +21,14 @@ export const useQueryHistory = (connectionId: string) => {
 
   useEffect(() => {
     refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    const handler = () => {
+      refresh();
+    };
+    window.addEventListener(HISTORY_UPDATED_EVENT, handler);
+    return () => window.removeEventListener(HISTORY_UPDATED_EVENT, handler);
   }, [refresh]);
 
   return { entries, isLoading, refresh };

--- a/apps/web/src/hooks/use-query-history.ts
+++ b/apps/web/src/hooks/use-query-history.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { HistoryEntry } from "@/lib/persistence";
+
+import { getHistory } from "@/lib/persistence";
+
+export const useQueryHistory = (connectionId: string) => {
+  const [entries, setEntries] = useState<HistoryEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const result = await getHistory(connectionId);
+      setEntries(result);
+    } catch {
+      setEntries([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [connectionId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { entries, isLoading, refresh };
+};

--- a/apps/web/src/hooks/use-query-tabs.ts
+++ b/apps/web/src/hooks/use-query-tabs.ts
@@ -3,8 +3,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { PersistedTab, TabState } from "@/lib/persistence";
 import type { QueryTab } from "@/lib/query-types";
 
-import { appendHistory, getTabs, saveTabs } from "@/lib/persistence";
-import { executeQuery } from "@/lib/tauri";
+import { getTabs, saveTabs } from "@/lib/persistence";
+
+import { useTabExecution } from "./use-tab-execution";
 
 const SAVE_DEBOUNCE_MS = 500;
 
@@ -35,16 +36,6 @@ const fromPersistedTab = (persisted: PersistedTab): QueryTab => ({
   title: persisted.title,
 });
 
-const extractErrorMessage = (error: unknown): string => {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  if (typeof error === "object" && error !== null && "message" in error) {
-    return String((error as { message: unknown }).message);
-  }
-  return "Query execution failed";
-};
-
 export const useQueryTabs = (
   connectionId: string,
   selectedDatabase: string | null
@@ -58,6 +49,14 @@ export const useQueryTabs = (
   );
   const [isRestored, setIsRestored] = useState(false);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
+
+  const { execute } = useTabExecution({
+    connectionId,
+    selectedDatabase,
+    setTabs,
+  });
 
   useEffect(() => {
     const restore = async () => {
@@ -159,70 +158,15 @@ export const useQueryTabs = (
   );
 
   const executeTab = useCallback(
-    async (tabId: string, sqlOverride?: string) => {
-      const tab = tabs.find((t) => t.id === tabId);
+    (tabId: string, sqlOverride?: string) => {
+      const tab = tabsRef.current.find((t) => t.id === tabId);
       const sqlToExecute = sqlOverride ?? tab?.sql;
       if (!sqlToExecute?.trim()) {
         return;
       }
-
-      setTabs((prev) =>
-        prev.map((t) =>
-          t.id === tabId
-            ? { ...t, error: null, result: null, status: "running" as const }
-            : t
-        )
-      );
-
-      const startTime = performance.now();
-      let success = false;
-      let errorMessage: string | null = null;
-      let executionTimeMs = 0;
-
-      try {
-        const result = await executeQuery({
-          connectionId,
-          schema: selectedDatabase ?? undefined,
-          sourceDialect: tab?.sourceDialect ?? undefined,
-          sql: sqlToExecute,
-        });
-        ({ executionTimeMs } = result);
-        success = true;
-        setTabs((prev) =>
-          prev.map((t) =>
-            t.id === tabId
-              ? { ...t, error: null, result, status: "success" as const }
-              : t
-          )
-        );
-      } catch (error) {
-        const message = extractErrorMessage(error);
-        errorMessage = message;
-        executionTimeMs = Math.round(performance.now() - startTime);
-        setTabs((prev) =>
-          prev.map((t) =>
-            t.id === tabId
-              ? { ...t, error: message, result: null, status: "error" as const }
-              : t
-          )
-        );
-      }
-
-      try {
-        await appendHistory({
-          connectionId,
-          database: selectedDatabase,
-          error: errorMessage,
-          executionTimeMs,
-          sql: sqlToExecute,
-          success,
-          timestamp: new Date().toISOString(),
-        });
-      } catch {
-        // Silently ignore history write failures
-      }
+      execute(tabId, sqlToExecute, tab?.sourceDialect);
     },
-    [connectionId, selectedDatabase, tabs]
+    [execute]
   );
 
   return {

--- a/apps/web/src/hooks/use-query-tabs.ts
+++ b/apps/web/src/hooks/use-query-tabs.ts
@@ -1,8 +1,12 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
+import type { PersistedTab, TabState } from "@/lib/persistence";
 import type { QueryTab } from "@/lib/query-types";
 
+import { appendHistory, getTabs, saveTabs } from "@/lib/persistence";
 import { executeQuery } from "@/lib/tauri";
+
+const SAVE_DEBOUNCE_MS = 500;
 
 const createNewTab = (counter: number): QueryTab => ({
   error: null,
@@ -12,6 +16,23 @@ const createNewTab = (counter: number): QueryTab => ({
   sql: "",
   status: "idle",
   title: `Query ${counter}`,
+});
+
+const toPersistedTab = (tab: QueryTab): PersistedTab => ({
+  id: tab.id,
+  sourceDialect: tab.sourceDialect,
+  sql: tab.sql,
+  title: tab.title,
+});
+
+const fromPersistedTab = (persisted: PersistedTab): QueryTab => ({
+  error: null,
+  id: persisted.id,
+  result: null,
+  sourceDialect: persisted.sourceDialect,
+  sql: persisted.sql,
+  status: "idle",
+  title: persisted.title,
 });
 
 const extractErrorMessage = (error: unknown): string => {
@@ -35,6 +56,56 @@ export const useQueryTabs = (
   const [activeTabId, setActiveTabId] = useState<string>(
     () => tabs[0]?.id ?? ""
   );
+  const [isRestored, setIsRestored] = useState(false);
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const restore = async () => {
+      try {
+        const saved = await getTabs(connectionId);
+        if (saved && saved.tabs.length > 0) {
+          const restoredTabs = saved.tabs.map(fromPersistedTab);
+          counterRef.current = saved.counter;
+          setTabs(restoredTabs);
+          setActiveTabId(saved.activeTabId);
+        }
+      } catch {
+        // Fall back to default tab on restore failure
+      } finally {
+        setIsRestored(true);
+      }
+    };
+    restore();
+  }, [connectionId]);
+
+  useEffect(() => {
+    if (!isRestored) {
+      return;
+    }
+
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+
+    saveTimeoutRef.current = setTimeout(async () => {
+      const state: TabState = {
+        activeTabId,
+        counter: counterRef.current,
+        tabs: tabs.map(toPersistedTab),
+      };
+      try {
+        await saveTabs(connectionId, state);
+      } catch {
+        // Silently ignore save failures
+      }
+    }, SAVE_DEBOUNCE_MS);
+
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, [tabs, activeTabId, connectionId, isRestored]);
 
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0];
 
@@ -57,7 +128,7 @@ export const useQueryTabs = (
       setTabs((prev) => {
         const next = prev.filter((t) => t.id !== tabId);
         if (next.length === 0) {
-          counterRef.current += 1;
+          counterRef.current = 1;
           const tab = createNewTab(counterRef.current);
           setActiveTabId(tab.id);
           return [tab];
@@ -103,6 +174,11 @@ export const useQueryTabs = (
         )
       );
 
+      const startTime = performance.now();
+      let success = false;
+      let errorMessage: string | null = null;
+      let executionTimeMs = 0;
+
       try {
         const result = await executeQuery({
           connectionId,
@@ -110,6 +186,8 @@ export const useQueryTabs = (
           sourceDialect: tab?.sourceDialect ?? undefined,
           sql: sqlToExecute,
         });
+        ({ executionTimeMs } = result);
+        success = true;
         setTabs((prev) =>
           prev.map((t) =>
             t.id === tabId
@@ -119,6 +197,8 @@ export const useQueryTabs = (
         );
       } catch (error) {
         const message = extractErrorMessage(error);
+        errorMessage = message;
+        executionTimeMs = Math.round(performance.now() - startTime);
         setTabs((prev) =>
           prev.map((t) =>
             t.id === tabId
@@ -126,6 +206,20 @@ export const useQueryTabs = (
               : t
           )
         );
+      }
+
+      try {
+        await appendHistory({
+          connectionId,
+          database: selectedDatabase,
+          error: errorMessage,
+          executionTimeMs,
+          sql: sqlToExecute,
+          success,
+          timestamp: new Date().toISOString(),
+        });
+      } catch {
+        // Silently ignore history write failures
       }
     },
     [connectionId, selectedDatabase, tabs]
@@ -138,6 +232,7 @@ export const useQueryTabs = (
     addTabWithSql,
     closeTab,
     executeTab,
+    isRestored,
     setActiveTabId,
     tabs,
     updateTabDialect,

--- a/apps/web/src/hooks/use-tab-execution.ts
+++ b/apps/web/src/hooks/use-tab-execution.ts
@@ -1,0 +1,92 @@
+import { useCallback } from "react";
+
+import type { QueryTab } from "@/lib/query-types";
+
+import { appendHistory, HISTORY_UPDATED_EVENT } from "@/lib/persistence";
+import { executeQuery } from "@/lib/tauri";
+
+const extractErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return "Query execution failed";
+};
+
+interface UseTabExecutionParams {
+  connectionId: string;
+  selectedDatabase: string | null;
+  setTabs: React.Dispatch<React.SetStateAction<QueryTab[]>>;
+}
+
+export const useTabExecution = ({
+  connectionId,
+  selectedDatabase,
+  setTabs,
+}: UseTabExecutionParams) => {
+  const execute = useCallback(
+    async (tabId: string, sql: string, sourceDialect?: string | null) => {
+      setTabs((prev) =>
+        prev.map((t) =>
+          t.id === tabId
+            ? { ...t, error: null, result: null, status: "running" as const }
+            : t
+        )
+      );
+
+      const startTime = performance.now();
+      let success = false;
+      let errorMessage: string | null = null;
+      let executionTimeMs = 0;
+
+      try {
+        const result = await executeQuery({
+          connectionId,
+          schema: selectedDatabase ?? undefined,
+          sourceDialect: sourceDialect ?? undefined,
+          sql,
+        });
+        ({ executionTimeMs } = result);
+        success = true;
+        setTabs((prev) =>
+          prev.map((t) =>
+            t.id === tabId
+              ? { ...t, error: null, result, status: "success" as const }
+              : t
+          )
+        );
+      } catch (error) {
+        const message = extractErrorMessage(error);
+        errorMessage = message;
+        executionTimeMs = Math.round(performance.now() - startTime);
+        setTabs((prev) =>
+          prev.map((t) =>
+            t.id === tabId
+              ? { ...t, error: message, result: null, status: "error" as const }
+              : t
+          )
+        );
+      }
+
+      try {
+        await appendHistory({
+          connectionId,
+          database: selectedDatabase,
+          error: errorMessage,
+          executionTimeMs,
+          sql,
+          success,
+          timestamp: new Date().toISOString(),
+        });
+        window.dispatchEvent(new CustomEvent(HISTORY_UPDATED_EVENT));
+      } catch {
+        // Silently ignore history write failures
+      }
+    },
+    [connectionId, selectedDatabase, setTabs]
+  );
+
+  return { execute };
+};

--- a/apps/web/src/lib/persistence.ts
+++ b/apps/web/src/lib/persistence.ts
@@ -1,0 +1,97 @@
+import { isTauri } from "@/lib/tauri";
+
+export interface PersistedTab {
+  id: string;
+  title: string;
+  sql: string;
+  sourceDialect: string | null;
+}
+
+export interface TabState {
+  tabs: PersistedTab[];
+  activeTabId: string;
+  counter: number;
+}
+
+export interface HistoryEntry {
+  sql: string;
+  connectionId: string;
+  database: string | null;
+  timestamp: string;
+  success: boolean;
+  error: string | null;
+  executionTimeMs: number;
+}
+
+const TABS_STORAGE_PREFIX = "oh-my-query-tabs-";
+const HISTORY_STORAGE_PREFIX = "oh-my-query-history-";
+const MAX_BROWSER_HISTORY = 500;
+
+export const getTabs = async (
+  connectionId: string
+): Promise<TabState | null> => {
+  if (!isTauri()) {
+    const raw = localStorage.getItem(`${TABS_STORAGE_PREFIX}${connectionId}`);
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw) as TabState;
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<TabState | null>("get_tabs", { connectionId });
+};
+
+export const saveTabs = async (
+  connectionId: string,
+  state: TabState
+): Promise<void> => {
+  if (!isTauri()) {
+    localStorage.setItem(
+      `${TABS_STORAGE_PREFIX}${connectionId}`,
+      JSON.stringify(state)
+    );
+    return;
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  await invoke("save_tabs", { connectionId, state });
+};
+
+export const appendHistory = async (entry: HistoryEntry): Promise<void> => {
+  if (!isTauri()) {
+    const key = `${HISTORY_STORAGE_PREFIX}${entry.connectionId}`;
+    const raw = localStorage.getItem(key);
+    const entries: HistoryEntry[] = raw
+      ? (JSON.parse(raw) as HistoryEntry[])
+      : [];
+    entries.push(entry);
+    const trimmed = entries.slice(-MAX_BROWSER_HISTORY);
+    localStorage.setItem(key, JSON.stringify(trimmed));
+    return;
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  await invoke("append_history", { entry });
+};
+
+export const getHistory = async (
+  connectionId: string,
+  limit?: number,
+  offset?: number
+): Promise<HistoryEntry[]> => {
+  if (!isTauri()) {
+    const raw = localStorage.getItem(
+      `${HISTORY_STORAGE_PREFIX}${connectionId}`
+    );
+    if (!raw) {
+      return [];
+    }
+    const entries = (JSON.parse(raw) as HistoryEntry[]).toReversed();
+    const start = offset ?? 0;
+    return entries.slice(start, start + (limit ?? 100));
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<HistoryEntry[]>("get_history", { connectionId, limit, offset });
+};

--- a/apps/web/src/lib/persistence.ts
+++ b/apps/web/src/lib/persistence.ts
@@ -23,9 +23,27 @@ export interface HistoryEntry {
   executionTimeMs: number;
 }
 
+export const HISTORY_UPDATED_EVENT = "oh-my-query:history-updated";
+
 const TABS_STORAGE_PREFIX = "oh-my-query-tabs-";
 const HISTORY_STORAGE_PREFIX = "oh-my-query-history-";
 const MAX_BROWSER_HISTORY = 500;
+
+const safeParse = <T>(raw: string, fallback: T): T => {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+};
+
+const isValidTabState = (value: unknown): value is TabState => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return Array.isArray(obj.tabs) && typeof obj.activeTabId === "string";
+};
 
 export const getTabs = async (
   connectionId: string
@@ -35,7 +53,8 @@ export const getTabs = async (
     if (!raw) {
       return null;
     }
-    return JSON.parse(raw) as TabState;
+    const parsed = safeParse<unknown>(raw, null);
+    return isValidTabState(parsed) ? parsed : null;
   }
 
   const { invoke } = await import("@tauri-apps/api/core");
@@ -62,9 +81,7 @@ export const appendHistory = async (entry: HistoryEntry): Promise<void> => {
   if (!isTauri()) {
     const key = `${HISTORY_STORAGE_PREFIX}${entry.connectionId}`;
     const raw = localStorage.getItem(key);
-    const entries: HistoryEntry[] = raw
-      ? (JSON.parse(raw) as HistoryEntry[])
-      : [];
+    const entries = raw ? safeParse<HistoryEntry[]>(raw, []) : [];
     entries.push(entry);
     const trimmed = entries.slice(-MAX_BROWSER_HISTORY);
     localStorage.setItem(key, JSON.stringify(trimmed));
@@ -87,7 +104,7 @@ export const getHistory = async (
     if (!raw) {
       return [];
     }
-    const entries = (JSON.parse(raw) as HistoryEntry[]).toReversed();
+    const entries = safeParse<HistoryEntry[]>(raw, []).toReversed();
     const start = offset ?? 0;
     return entries.slice(start, start + (limit ?? 100));
   }


### PR DESCRIPTION
## Summary
- **Tab persistence**: Query tabs (SQL content, dialect, title) are saved per connection and restored on reconnect, with debounced writes to avoid excessive I/O.
- **Query history**: Every executed query is recorded with timestamp, success/error status, and execution time. History is stored as JSONL on desktop (up to 10k entries) and in localStorage for the browser (up to 500).
- **History UI**: A new "History" tab in the workspace sidebar lets users browse past queries with relative timestamps and status indicators. Clicking a history entry opens it in a new editor tab.
- **Dual-mode persistence**: Tauri commands (`persistence.rs`) handle file-based storage on desktop; the frontend falls back to `localStorage` when running in the browser.

## Test plan
- [x] Open a connection, create multiple tabs with SQL, close and reopen — tabs should be restored
- [x] Execute queries (both successful and failing) and verify they appear in the History tab
- [x] Click a history entry and confirm it opens in a new editor tab
- [x] Verify browser mode works with localStorage fallback