### PR TITLE
feat(cd): add macOS release workflow with Homebrew tap distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-macos:
+    name: Build macOS (${{ matrix.label }})
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            label: arm64
+          - target: x86_64-apple-darwin
+            label: x64
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.9"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "apps/web/src-tauri -> target"
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: apps/web
+          tagName: ${{ github.ref_name }}
+          releaseName: "oh-my-query ${{ github.ref_name }}"
+          releaseBody: "See assets below to download. Install via Homebrew: `brew install --cask victor-teles/oh-my-query/oh-my-query`"
+          releaseDraft: false
+          prerelease: false
+          args: --target ${{ matrix.target }}
+
+  update-homebrew-tap:
+    name: Update Homebrew tap
+    needs: build-macos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Download DMGs and compute SHA256
+        id: hashes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BASE="https://github.com/victor-teles/oh-my-query/releases/download/${{ github.ref_name }}"
+
+          curl -sL "${BASE}/oh-my-query_${VERSION}_aarch64.dmg" -o arm64.dmg
+          curl -sL "${BASE}/oh-my-query_${VERSION}_x64.dmg" -o x64.dmg
+
+          echo "aarch64_sha=$(shasum -a 256 arm64.dmg | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "x64_sha=$(shasum -a 256 x64.dmg | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - name: Dispatch tap update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: victor-teles/homebrew-oh-my-query
+          event-type: update-cask
+          client-payload: |
+            {
+              "version": "${{ steps.version.outputs.version }}",
+              "aarch64_sha": "${{ steps.hashes.outputs.aarch64_sha }}",
+              "x64_sha": "${{ steps.hashes.outputs.x64_sha }}"
+            }

--- a/.homebrew/Casks/oh-my-query.rb
+++ b/.homebrew/Casks/oh-my-query.rb
@@ -1,0 +1,33 @@
+cask "oh-my-query" do
+  version "0.1.0"
+
+  on_arm do
+    url "https://github.com/victor-teles/oh-my-query/releases/download/v#{version}/oh-my-query_#{version}_aarch64.dmg"
+    sha256 "PLACEHOLDER"
+  end
+
+  on_intel do
+    url "https://github.com/victor-teles/oh-my-query/releases/download/v#{version}/oh-my-query_#{version}_x64.dmg"
+    sha256 "PLACEHOLDER"
+  end
+
+  name "oh-my-query"
+  desc "Desktop app for querying databases with AI"
+  homepage "https://github.com/victor-teles/oh-my-query"
+
+  app "oh-my-query.app"
+
+  postflight do
+    system_command "/usr/bin/xattr",
+      args: ["-dr", "com.apple.quarantine", "#{appdir}/oh-my-query.app"],
+      sudo: false
+  end
+
+  uninstall quit: "dev.ohmyquery.app"
+
+  zap trash: [
+    "~/Library/Application Support/dev.ohmyquery.app",
+    "~/Library/Caches/dev.ohmyquery.app",
+    "~/Library/Logs/dev.ohmyquery.app",
+  ]
+end

--- a/.homebrew/workflows/update-cask.yml
+++ b/.homebrew/workflows/update-cask.yml
@@ -1,0 +1,73 @@
+# Place this file at .github/workflows/update-cask.yml in the homebrew-oh-my-query repo
+name: Update Cask
+
+on:
+  repository_dispatch:
+    types: [update-cask]
+
+jobs:
+  update:
+    name: Update oh-my-query cask
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract payload
+        id: payload
+        run: |
+          VERSION="${{ github.event.client_payload.version }}"
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "aarch64_sha=${{ github.event.client_payload.aarch64_sha }}" >> $GITHUB_OUTPUT
+          echo "x64_sha=${{ github.event.client_payload.x64_sha }}" >> $GITHUB_OUTPUT
+
+      - name: Update cask version and hashes
+        env:
+          VERSION: ${{ steps.payload.outputs.version }}
+          AARCH64_SHA: ${{ steps.payload.outputs.aarch64_sha }}
+          X64_SHA: ${{ steps.payload.outputs.x64_sha }}
+        run: |
+          python3 - <<'PYEOF'
+          import re, os
+
+          cask_path = "Casks/oh-my-query.rb"
+          version = os.environ["VERSION"]
+          aarch64_sha = os.environ["AARCH64_SHA"]
+          x64_sha = os.environ["X64_SHA"]
+
+          with open(cask_path, "r") as f:
+              content = f.read()
+
+          content = re.sub(r'version "[^"]*"', f'version "{version}"', content)
+
+          content = re.sub(
+              r'(on_arm do\n.*\n\s+sha256 ")[^"]*(")',
+              rf'\g<1>{aarch64_sha}\g<2>',
+              content
+          )
+
+          content = re.sub(
+              r'(on_intel do\n.*\n\s+sha256 ")[^"]*(")',
+              rf'\g<1>{x64_sha}\g<2>',
+              content
+          )
+
+          with open(cask_path, "w") as f:
+              f.write(content)
+
+          print(f"Updated cask to v{version}")
+          PYEOF
+
+      - name: Verify changes
+        run: cat Casks/oh-my-query.rb
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/oh-my-query.rb
+          git commit -m "Update oh-my-query to v${{ steps.payload.outputs.version }}"
+          git push

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "oh-my-query",
   "version": "0.1.0",
-  "identifier": "com.tauri.dev",
+  "identifier": "dev.ohmyquery.app",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:3001",


### PR DESCRIPTION
## Summary

Added a complete CI/CD pipeline for distributing unsigned macOS builds via Homebrew tap:

- **Release workflow** (`.github/workflows/release.yml`): Triggered on version tags (`v*`), builds macOS DMGs for both arm64 and x64 in parallel using `tauri-apps/tauri-action`, creates GitHub Release with both artifacts
- **Homebrew integration**: Auto-updates the tap repository with SHA256 hashes via `repository_dispatch` after each release
- **Reference files**: Included `.homebrew/` directory with the cask file and update workflow as templates for the separate `homebrew-oh-my-query` tap repository
- **Bundle identifier**: Updated from `com.tauri.dev` to `dev.ohmyquery.app` for proper macOS app identification

## Test plan

- Create a GitHub PAT with `repo` + `workflow` scopes
- Add it as `HOMEBREW_TAP_TOKEN` secret in repository settings
- Create a separate public repo `victor-teles/homebrew-oh-my-query` and copy the files from `.homebrew/`
- Push a test tag (`git tag v0.1.0 && git push origin v0.1.0`) to verify the workflow builds both architectures and creates the release
- Verify the tap update workflow dispatches successfully to the tap repository