### PR TITLE
fix(cd): sync artifact version with git tag in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  bump-version:
+    name: Bump version from tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Bump version in config files
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v' apps/web/src-tauri/tauri.conf.json > tmp.json && mv tmp.json apps/web/src-tauri/tauri.conf.json
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" apps/web/src-tauri/Cargo.toml
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add apps/web/src-tauri/tauri.conf.json apps/web/src-tauri/Cargo.toml
+          git diff --staged --quiet && exit 0
+          git commit -m "chore: bump version to ${GITHUB_REF_NAME#v}"
+          git push origin main
+
   build-macos:
     name: Build macOS (${{ matrix.label }})
+    needs: bump-version
     permissions:
       contents: write
     strategy:
@@ -25,6 +51,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oh-my-query"
-version = "0.1.0"
+version = "0.0.3"
 description = "A query UI tool"
 authors = ["victor"]
 license = ""

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "oh-my-query",
-  "version": "0.1.0",
+  "version": "0.0.3",
   "identifier": "dev.ohmyquery.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Add a `bump-version` job that syncs `tauri.conf.json` and `Cargo.toml` with the git tag version before building. This ensures artifact filenames match the release version, fixing the Homebrew tap update step which was failing to download artifacts with mismatched versions.

The job patches the config files, commits to main, and the `build-macos` job then checks out the updated main branch so Tauri generates correctly named artifacts (e.g., `oh-my-query_0.0.3_x64.dmg` for tag `v0.0.3`).