### PR TITLE
Hide syntax tree behind dev mode

### DIFF
--- a/apps/web/src-tauri/Cargo.lock
+++ b/apps/web/src-tauri/Cargo.lock
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "oh-my-query"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "async-trait",
  "dirs",

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -23,9 +23,7 @@
         "hiddenTitle": true,
         "transparent": true,
         "windowEffects": {
-          "effects": [
-            "sidebar"
-          ],
+          "effects": ["sidebar"],
           "state": "followsWindowActiveState"
         }
       }

--- a/apps/web/src/components/workspace/sql-editor.tsx
+++ b/apps/web/src/components/workspace/sql-editor.tsx
@@ -96,7 +96,7 @@ export const SqlEditor = ({
     () => {
       onToggleSyntaxTree?.();
     },
-    { enabled: !!onToggleSyntaxTree }
+    { enabled: import.meta.env.DEV && !!onToggleSyntaxTree }
   );
 
   const effectiveDialect = writingDialect ?? databaseType;

--- a/apps/web/src/components/workspace/workspace-content.tsx
+++ b/apps/web/src/components/workspace/workspace-content.tsx
@@ -123,7 +123,7 @@ interface EditorPanelProps {
   onSqlChange: (val: string) => void;
   onExecute: () => void;
   onEditorUpdate: (update: ViewUpdate) => void;
-  onToggleSyntaxTree: () => void;
+  onToggleSyntaxTree?: () => void;
 }
 
 const EditorPanel = ({
@@ -196,8 +196,9 @@ const ConnectedWorkspace = ({
 
   const [isSyntaxTreeOpen, setIsSyntaxTreeOpen] = useState(false);
   const [hasSelection, setHasSelection] = useState(false);
+  const syntaxTreeEnabled = import.meta.env.DEV && isSyntaxTreeOpen;
   const { treeData, handleEditorUpdate: handleSyntaxTreeUpdate } =
-    useSyntaxTree(isSyntaxTreeOpen);
+    useSyntaxTree(syntaxTreeEnabled);
 
   const toggleSyntaxTree = useCallback(() => {
     setIsSyntaxTreeOpen((prev) => !prev);
@@ -244,7 +245,7 @@ const ConnectedWorkspace = ({
 
   const handleEditorUpdate = useCallback(
     (update: ViewUpdate) => {
-      if (isSyntaxTreeOpen) {
+      if (syntaxTreeEnabled) {
         handleSyntaxTreeUpdate(update);
       }
       if (update.selectionSet) {
@@ -252,7 +253,7 @@ const ConnectedWorkspace = ({
         setHasSelection(from !== to);
       }
     },
-    [isSyntaxTreeOpen, handleSyntaxTreeUpdate]
+    [syntaxTreeEnabled, handleSyntaxTreeUpdate]
   );
 
   const editorDialect = resolveEditorDialect(
@@ -324,7 +325,9 @@ const ConnectedWorkspace = ({
                 onSqlChange={handleSqlChange}
                 onExecute={handleExecute}
                 onEditorUpdate={handleEditorUpdate}
-                onToggleSyntaxTree={toggleSyntaxTree}
+                onToggleSyntaxTree={
+                  import.meta.env.DEV ? toggleSyntaxTree : undefined
+                }
               />
             </div>
           </div>
@@ -341,7 +344,7 @@ const ConnectedWorkspace = ({
             onDialectChange={handleDialectChange}
             isFormatDisabled={!activeTab?.sql.trim()}
             onFormat={handleFormat}
-            isSyntaxTreeOpen={isSyntaxTreeOpen}
+            isSyntaxTreeOpen={syntaxTreeEnabled}
             onToggleSyntaxTree={toggleSyntaxTree}
             isRunning={activeTab?.status === "running"}
             isExecuteDisabled={!activeTab?.sql.trim()}
@@ -349,7 +352,7 @@ const ConnectedWorkspace = ({
             onExecute={handleExecute}
           />
           <BottomPanel
-            isSyntaxTreeOpen={isSyntaxTreeOpen}
+            isSyntaxTreeOpen={syntaxTreeEnabled}
             treeData={treeData}
             status={activeTab?.status}
             result={activeTab?.result ?? null}
@@ -408,10 +411,12 @@ const EditorToolbar = ({
       {isSql && (
         <>
           <FormatButton disabled={isFormatDisabled} onClick={onFormat} />
-          <SyntaxTreeToggle
-            isOpen={isSyntaxTreeOpen}
-            onToggle={onToggleSyntaxTree}
-          />
+          {import.meta.env.DEV && (
+            <SyntaxTreeToggle
+              isOpen={isSyntaxTreeOpen}
+              onToggle={onToggleSyntaxTree}
+            />
+          )}
         </>
       )}
       <ExecuteButton


### PR DESCRIPTION
## Summary

The syntax tree visualization is now only visible in development mode (`import.meta.env.DEV`). In production builds, the toggle button and keyboard shortcut are disabled, hiding developer tools from end users.

## Changes

- Gate `SyntaxTreeToggle` button rendering to development mode
- Disable `Cmd+Shift+D` keyboard shortcut in production
- Make syntax tree hook conditional on dev mode
- Update props to allow optional `onToggleSyntaxTree` callback

## Testing

- Run `bun run dev:web` — syntax tree button appears and shortcut works
- Run `bun run build` — build succeeds and feature is tree-shaken in production