### PR TITLE
Add settings page with editor theming and native menu

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@tauri-apps/api": "^2.10.1",
     "@uiw/codemirror-theme-github": "^4.25.4",
+    "@uiw/codemirror-themes-all": "^4.25.5",
     "@uiw/react-codemirror": "^4.25.4",
     "ai": "^6.0.97",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src-tauri/Cargo.lock
+++ b/apps/web/src-tauri/Cargo.lock
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "oh-my-query"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "async-trait",
  "dirs",

--- a/apps/web/src-tauri/src/lib.rs
+++ b/apps/web/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@ mod db;
 mod persistence;
 
 use db::pool::ConnectionPoolManager;
+use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
+use tauri::Emitter;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -14,6 +16,62 @@ pub fn run() {
                 .build(),
         )
         .manage(ConnectionPoolManager::new())
+        .setup(|app| {
+            let app_submenu = SubmenuBuilder::new(app, "oh-my-query")
+                .about(None)
+                .separator()
+                .item(
+                    &MenuItemBuilder::with_id("settings", "Settings...")
+                        .accelerator("CmdOrCtrl+,")
+                        .build(app)?,
+                )
+                .separator()
+                .services()
+                .separator()
+                .hide()
+                .hide_others()
+                .show_all()
+                .separator()
+                .quit()
+                .build()?;
+
+            let edit_submenu = SubmenuBuilder::new(app, "Edit")
+                .undo()
+                .redo()
+                .separator()
+                .cut()
+                .copy()
+                .paste()
+                .select_all()
+                .build()?;
+
+            let view_submenu = SubmenuBuilder::new(app, "View")
+                .item(&PredefinedMenuItem::fullscreen(app, None)?)
+                .build()?;
+
+            let window_submenu = SubmenuBuilder::new(app, "Window")
+                .minimize()
+                .item(&PredefinedMenuItem::maximize(app, None)?)
+                .close_window()
+                .build()?;
+
+            let menu = MenuBuilder::new(app)
+                .item(&app_submenu)
+                .item(&edit_submenu)
+                .item(&view_submenu)
+                .item(&window_submenu)
+                .build()?;
+
+            app.set_menu(menu)?;
+
+            app.on_menu_event(move |app_handle, event| {
+                if event.id().0.as_str() == "settings" {
+                    let _ = app_handle.emit("menu-navigate", "/settings");
+                }
+            });
+
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             commands::test_connection,
             commands::connect_to_database,

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -23,9 +23,7 @@
         "hiddenTitle": true,
         "transparent": true,
         "windowEffects": {
-          "effects": [
-            "sidebar"
-          ],
+          "effects": ["sidebar"],
           "state": "followsWindowActiveState"
         }
       }

--- a/apps/web/src/components/titlebar/titlebar.tsx
+++ b/apps/web/src/components/titlebar/titlebar.tsx
@@ -26,7 +26,7 @@ export const Titlebar = ({
     <header
       className={cn(
         "flex h-9.5 shrink-0 select-none items-center",
-        !hasSidebar && "border-b border-sidebar-border bg-sidebar-background",
+        !hasSidebar && "border-b border-sidebar-border bg-sidebar/80",
         className
       )}
       data-tauri-drag-region=""

--- a/apps/web/src/components/workspace/sql-editor.tsx
+++ b/apps/web/src/components/workspace/sql-editor.tsx
@@ -1,5 +1,5 @@
 import type { Extension } from "@codemirror/state";
-import type { EditorView, ViewUpdate } from "@codemirror/view";
+import type { ViewUpdate, EditorView } from "@codemirror/view";
 
 import { sql, PostgreSQL, MySQL, SQLite } from "@codemirror/lang-sql";
 import { Prec } from "@codemirror/state";
@@ -7,11 +7,16 @@ import { keymap } from "@codemirror/view";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { githubDark } from "@uiw/codemirror-theme-github";
 import CodeMirror from "@uiw/react-codemirror";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type { SchemaInfo } from "@/lib/tauri";
 
 import { useEditorInsert } from "@/contexts/editor-insert-context";
+import { useEditorSettings } from "@/hooks/use-editor-settings";
+import {
+  createFontExtension,
+  getThemeExtension,
+} from "@/lib/codemirror-themes";
 import {
   createColumnCompletionSource,
   createTableCompletionSource,
@@ -51,6 +56,27 @@ export const SqlEditor = ({
   schema,
 }: SqlEditorProps) => {
   const { registerEditor } = useEditorInsert();
+  const { settings } = useEditorSettings();
+  const [themeExtension, setThemeExtension] = useState<Extension>(githubDark);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const ext = await getThemeExtension(settings.syntaxTheme);
+      if (!cancelled) {
+        setThemeExtension(ext);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [settings.syntaxTheme]);
+
+  const fontExtension = useMemo(
+    () => createFontExtension(settings.fontFamily, settings.fontSize),
+    [settings.fontFamily, settings.fontSize]
+  );
 
   const handleCreateEditor = useCallback(
     (view: EditorView) => {
@@ -107,7 +133,11 @@ export const SqlEditor = ({
       schema: sqlNamespace,
     });
 
-    const exts: Extension[] = [preventNewlineOnExecute, langSupport];
+    const exts: Extension[] = [
+      preventNewlineOnExecute,
+      langSupport,
+      fontExtension,
+    ];
 
     if (tableCompletionSource) {
       exts.push(
@@ -132,6 +162,7 @@ export const SqlEditor = ({
     sqlNamespace,
     tableCompletionSource,
     columnCompletionSource,
+    fontExtension,
   ]);
 
   return (
@@ -141,7 +172,7 @@ export const SqlEditor = ({
       onUpdate={onUpdate}
       onCreateEditor={handleCreateEditor}
       extensions={extensions}
-      theme={githubDark}
+      theme={themeExtension}
       placeholder="Write your SQL query here..."
       readOnly={readOnly}
       basicSetup={{

--- a/apps/web/src/components/workspace/workspace-layout.tsx
+++ b/apps/web/src/components/workspace/workspace-layout.tsx
@@ -104,7 +104,7 @@ export const WorkspaceLayout = ({
   });
 
   return (
-    <div className="flex h-svh flex-col">
+    <div className="flex h-svh flex-col bg-background">
       <Titlebar
         center={
           <DynamicIsland

--- a/apps/web/src/components/workspace/workspace-sidebar.tsx
+++ b/apps/web/src/components/workspace/workspace-sidebar.tsx
@@ -190,7 +190,7 @@ export const WorkspaceSidebar = ({
     <div
       className={cn(
         "flex h-full flex-col text-sidebar-foreground",
-        isTauri() ? "bg-transparent" : "bg-sidebar"
+        isTauri() ? "bg-sidebar/80" : "bg-sidebar"
       )}
     >
       <div className="flex items-center justify-between px-3 py-2">

--- a/apps/web/src/hooks/use-editor-settings.ts
+++ b/apps/web/src/hooks/use-editor-settings.ts
@@ -1,0 +1,36 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+import type { EditorSettings } from "@/lib/editor-settings";
+
+import { getEditorSettings, saveEditorSettings } from "@/lib/editor-settings";
+
+const listeners = new Set<() => void>();
+// oxlint-disable-next-line jest/require-hook -- module-level cache, not test code
+let cachedSettings = getEditorSettings();
+
+const subscribe = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const getSnapshot = (): EditorSettings => cachedSettings;
+
+const notify = (): void => {
+  cachedSettings = getEditorSettings();
+  for (const listener of listeners) {
+    listener();
+  }
+};
+
+export const useEditorSettings = () => {
+  const settings = useSyncExternalStore(subscribe, getSnapshot);
+
+  const updateSettings = useCallback((partial: Partial<EditorSettings>) => {
+    const current = getEditorSettings();
+    const next = { ...current, ...partial };
+    saveEditorSettings(next);
+    notify();
+  }, []);
+
+  return { settings, updateSettings };
+};

--- a/apps/web/src/hooks/use-menu-navigation.ts
+++ b/apps/web/src/hooks/use-menu-navigation.ts
@@ -1,0 +1,36 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+import { isTauri } from "@/lib/tauri";
+
+const MENU_ROUTES: Record<string, string> = {
+  "/settings": "/settings",
+};
+
+export const useMenuNavigation = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isTauri()) {
+      return;
+    }
+
+    let unlisten: (() => void) | undefined;
+
+    const setup = async () => {
+      const { listen } = await import("@tauri-apps/api/event");
+      unlisten = await listen<string>("menu-navigate", (event) => {
+        const route = MENU_ROUTES[event.payload];
+        if (route) {
+          navigate({ to: route });
+        }
+      });
+    };
+
+    setup();
+
+    return () => {
+      unlisten?.();
+    };
+  }, [navigate]);
+};

--- a/apps/web/src/lib/codemirror-themes.ts
+++ b/apps/web/src/lib/codemirror-themes.ts
@@ -1,0 +1,79 @@
+import type { Extension } from "@codemirror/state";
+
+import { EditorView } from "@codemirror/view";
+
+export interface ThemeEntry {
+  key: string;
+  label: string;
+  isDark: boolean;
+}
+
+export const THEME_ENTRIES: ThemeEntry[] = [
+  { isDark: true, key: "githubDark", label: "GitHub Dark" },
+  { isDark: false, key: "githubLight", label: "GitHub Light" },
+  { isDark: true, key: "dracula", label: "Dracula" },
+  { isDark: true, key: "atomone", label: "One Dark" },
+  { isDark: true, key: "tokyoNight", label: "Tokyo Night" },
+  { isDark: false, key: "tokyoNightDay", label: "Tokyo Night Day" },
+  { isDark: true, key: "vscodeDark", label: "VS Code Dark" },
+  { isDark: true, key: "material", label: "Material" },
+  { isDark: true, key: "materialDark", label: "Material Dark" },
+  { isDark: false, key: "materialLight", label: "Material Light" },
+  { isDark: true, key: "nord", label: "Nord" },
+  { isDark: true, key: "solarizedDark", label: "Solarized Dark" },
+  { isDark: false, key: "solarizedLight", label: "Solarized Light" },
+  { isDark: true, key: "monokai", label: "Monokai" },
+  { isDark: true, key: "sublime", label: "Sublime" },
+  { isDark: true, key: "aura", label: "Aura" },
+  { isDark: true, key: "copilot", label: "Copilot" },
+  { isDark: true, key: "andromeda", label: "Andromeda" },
+  { isDark: true, key: "xcodeDark", label: "Xcode Dark" },
+  { isDark: false, key: "xcodeLight", label: "Xcode Light" },
+];
+
+export const PREVIEW_SQL = `SELECT u.name, COUNT(o.id) AS orders
+FROM users u
+JOIN orders o ON o.user_id = u.id
+WHERE u.active = true
+GROUP BY u.name
+ORDER BY orders DESC;`;
+
+let themesModule: Record<string, Extension> | null = null;
+
+const loadThemesModule = async (): Promise<Record<string, Extension>> => {
+  if (!themesModule) {
+    themesModule =
+      (await import("@uiw/codemirror-themes-all")) as unknown as Record<
+        string,
+        Extension
+      >;
+  }
+  return themesModule;
+};
+
+export const getThemeExtension = async (key: string): Promise<Extension> => {
+  const themes = await loadThemesModule();
+  const theme = themes[key];
+  if (!theme) {
+    return themes.githubDark;
+  }
+  return theme;
+};
+
+export const createFontExtension = (
+  fontFamily: string,
+  fontSize: number
+): Extension => {
+  const family =
+    fontFamily === "system-default" ? undefined : `"${fontFamily}", monospace`;
+  return EditorView.theme({
+    ".cm-content": {
+      ...(family && { fontFamily: family }),
+      fontSize: `${fontSize}px`,
+    },
+    ".cm-gutters": {
+      ...(family && { fontFamily: family }),
+      fontSize: `${fontSize}px`,
+    },
+  });
+};

--- a/apps/web/src/lib/editor-settings.ts
+++ b/apps/web/src/lib/editor-settings.ts
@@ -1,0 +1,45 @@
+export interface EditorSettings {
+  syntaxTheme: string;
+  fontFamily: string;
+  fontSize: number;
+}
+
+const STORAGE_KEY = "oh-my-query-editor-settings";
+
+const DEFAULT_SETTINGS: EditorSettings = {
+  fontFamily: "system-default",
+  fontSize: 14,
+  syntaxTheme: "githubDark",
+};
+
+export const FONT_FAMILIES = [
+  { label: "System Default", value: "system-default" },
+  { label: "JetBrains Mono", value: "JetBrains Mono" },
+  { label: "Fira Code", value: "Fira Code" },
+  { label: "SF Mono", value: "SF Mono" },
+  { label: "Menlo", value: "Menlo" },
+  { label: "Consolas", value: "Consolas" },
+  { label: "Source Code Pro", value: "Source Code Pro" },
+] as const;
+
+export const FONT_SIZE_MIN = 12;
+export const FONT_SIZE_MAX = 24;
+
+export const getEditorSettings = (): EditorSettings => {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return DEFAULT_SETTINGS;
+  }
+  try {
+    return {
+      ...DEFAULT_SETTINGS,
+      ...(JSON.parse(raw) as Partial<EditorSettings>),
+    };
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+};
+
+export const saveEditorSettings = (settings: EditorSettings): void => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+};

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as DefaultRouteImport } from './routes/_default'
 import { Route as DefaultIndexRouteImport } from './routes/_default/index'
 import { Route as WorkspaceConnectionIdRouteImport } from './routes/workspace/$connectionId'
+import { Route as DefaultSettingsRouteImport } from './routes/_default/settings'
 import { Route as DefaultOnboardingRouteImport } from './routes/_default/onboarding'
 
 const DefaultRoute = DefaultRouteImport.update({
@@ -28,6 +29,11 @@ const WorkspaceConnectionIdRoute = WorkspaceConnectionIdRouteImport.update({
   path: '/workspace/$connectionId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DefaultSettingsRoute = DefaultSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => DefaultRoute,
+} as any)
 const DefaultOnboardingRoute = DefaultOnboardingRouteImport.update({
   id: '/onboarding',
   path: '/onboarding',
@@ -37,10 +43,12 @@ const DefaultOnboardingRoute = DefaultOnboardingRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof DefaultIndexRoute
   '/onboarding': typeof DefaultOnboardingRoute
+  '/settings': typeof DefaultSettingsRoute
   '/workspace/$connectionId': typeof WorkspaceConnectionIdRoute
 }
 export interface FileRoutesByTo {
   '/onboarding': typeof DefaultOnboardingRoute
+  '/settings': typeof DefaultSettingsRoute
   '/workspace/$connectionId': typeof WorkspaceConnectionIdRoute
   '/': typeof DefaultIndexRoute
 }
@@ -48,18 +56,20 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_default': typeof DefaultRouteWithChildren
   '/_default/onboarding': typeof DefaultOnboardingRoute
+  '/_default/settings': typeof DefaultSettingsRoute
   '/workspace/$connectionId': typeof WorkspaceConnectionIdRoute
   '/_default/': typeof DefaultIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/onboarding' | '/workspace/$connectionId'
+  fullPaths: '/' | '/onboarding' | '/settings' | '/workspace/$connectionId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/onboarding' | '/workspace/$connectionId' | '/'
+  to: '/onboarding' | '/settings' | '/workspace/$connectionId' | '/'
   id:
     | '__root__'
     | '/_default'
     | '/_default/onboarding'
+    | '/_default/settings'
     | '/workspace/$connectionId'
     | '/_default/'
   fileRoutesById: FileRoutesById
@@ -92,6 +102,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspaceConnectionIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_default/settings': {
+      id: '/_default/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof DefaultSettingsRouteImport
+      parentRoute: typeof DefaultRoute
+    }
     '/_default/onboarding': {
       id: '/_default/onboarding'
       path: '/onboarding'
@@ -104,11 +121,13 @@ declare module '@tanstack/react-router' {
 
 interface DefaultRouteChildren {
   DefaultOnboardingRoute: typeof DefaultOnboardingRoute
+  DefaultSettingsRoute: typeof DefaultSettingsRoute
   DefaultIndexRoute: typeof DefaultIndexRoute
 }
 
 const DefaultRouteChildren: DefaultRouteChildren = {
   DefaultOnboardingRoute: DefaultOnboardingRoute,
+  DefaultSettingsRoute: DefaultSettingsRoute,
   DefaultIndexRoute: DefaultIndexRoute,
 }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import {
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useMenuNavigation } from "@/hooks/use-menu-navigation";
 import "@/index.css";
 
 export interface RouterAppContext {
@@ -36,6 +37,8 @@ export const Route = createRootRouteWithContext<RouterAppContext>()({
 });
 
 function RootComponent() {
+  useMenuNavigation();
+
   return (
     <>
       <HeadContent />

--- a/apps/web/src/routes/_default.tsx
+++ b/apps/web/src/routes/_default.tsx
@@ -1,7 +1,7 @@
 import { Outlet, createFileRoute } from "@tanstack/react-router";
 
 const DefaultLayout = () => (
-  <div className="flex h-svh flex-col">
+  <div className="flex h-svh flex-col bg-background">
     <Outlet />
   </div>
 );

--- a/apps/web/src/routes/_default/-components/editor-font-section.tsx
+++ b/apps/web/src/routes/_default/-components/editor-font-section.tsx
@@ -1,0 +1,148 @@
+import type { Extension } from "@codemirror/state";
+
+import { sql, PostgreSQL } from "@codemirror/lang-sql";
+import CodeMirror from "@uiw/react-codemirror";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  createFontExtension,
+  getThemeExtension,
+  PREVIEW_SQL,
+} from "@/lib/codemirror-themes";
+import {
+  FONT_FAMILIES,
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
+} from "@/lib/editor-settings";
+
+interface EditorFontSectionProps {
+  fontFamily: string;
+  fontSize: number;
+  syntaxTheme: string;
+  onFontFamilyChange: (family: string) => void;
+  onFontSizeChange: (size: number) => void;
+}
+
+export const EditorFontSection = ({
+  fontFamily,
+  fontSize,
+  syntaxTheme,
+  onFontFamilyChange,
+  onFontSizeChange,
+}: EditorFontSectionProps) => {
+  const [themeExtension, setThemeExtension] = useState<Extension | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const ext = await getThemeExtension(syntaxTheme);
+      if (!cancelled) {
+        setThemeExtension(ext);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [syntaxTheme]);
+
+  const fontExtension = useMemo(
+    () => createFontExtension(fontFamily, fontSize),
+    [fontFamily, fontSize]
+  );
+
+  const extensions = useMemo(
+    () => [sql({ dialect: PostgreSQL }), fontExtension],
+    [fontExtension]
+  );
+
+  const handleFontFamilyChange = useCallback(
+    (v: string | null) => {
+      if (v) {
+        onFontFamilyChange(v);
+      }
+    },
+    [onFontFamilyChange]
+  );
+
+  const handleFontSizeChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = Number.parseInt(e.target.value, 10);
+      if (!Number.isNaN(val)) {
+        const clamped = Math.min(FONT_SIZE_MAX, Math.max(FONT_SIZE_MIN, val));
+        onFontSizeChange(clamped);
+      }
+    },
+    [onFontSizeChange]
+  );
+
+  return (
+    <section>
+      <h2 className="mb-1 text-sm font-medium">Code Font</h2>
+      <p className="mb-4 text-xs text-muted-foreground">
+        Customize the font used in the SQL editor.
+      </p>
+
+      <div className="mb-4 flex items-end gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-xs text-muted-foreground">Font Family</Label>
+          <Select value={fontFamily} onValueChange={handleFontFamilyChange}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start" alignItemWithTrigger={false}>
+              {FONT_FAMILIES.map((font) => (
+                <SelectItem key={font.value} value={font.value}>
+                  {font.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-xs text-muted-foreground">Size</Label>
+          <Input
+            type="number"
+            value={fontSize}
+            onChange={handleFontSizeChange}
+            min={FONT_SIZE_MIN}
+            max={FONT_SIZE_MAX}
+            step={1}
+            className="h-7 w-18 text-xs"
+          />
+        </div>
+      </div>
+
+      {themeExtension && (
+        <div className="overflow-hidden rounded-lg ring-1 ring-foreground/10">
+          <CodeMirror
+            value={PREVIEW_SQL}
+            theme={themeExtension}
+            extensions={extensions}
+            readOnly
+            editable={false}
+            basicSetup={{
+              autocompletion: false,
+              bracketMatching: false,
+              closeBrackets: false,
+              foldGutter: false,
+              highlightActiveLine: false,
+              lineNumbers: true,
+            }}
+            className="max-h-[160px] overflow-hidden text-sm [&_.cm-scroller]:overflow-hidden"
+          />
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/web/src/routes/_default/-components/general-theme-section.tsx
+++ b/apps/web/src/routes/_default/-components/general-theme-section.tsx
@@ -1,0 +1,70 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useCallback } from "react";
+
+import { useTheme } from "@/components/theme-provider";
+import { cn } from "@/lib/utils";
+
+const THEME_OPTIONS = [
+  { icon: Sun, label: "Light", value: "light" },
+  { icon: Moon, label: "Dark", value: "dark" },
+  { icon: Monitor, label: "System", value: "system" },
+] as const;
+
+const ThemeOptionCard = ({
+  icon: Icon,
+  label,
+  value,
+  isSelected,
+  onSelect,
+}: {
+  icon: typeof Sun;
+  label: string;
+  value: string;
+  isSelected: boolean;
+  onSelect: (value: string) => void;
+}) => {
+  const handleClick = useCallback(() => {
+    onSelect(value);
+  }, [onSelect, value]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(
+        "flex cursor-pointer flex-col items-center gap-2 rounded-lg px-6 py-4 ring-1 transition-all",
+        isSelected
+          ? "ring-2 ring-primary text-foreground"
+          : "ring-foreground/10 text-muted-foreground hover:ring-foreground/25 hover:text-foreground"
+      )}
+    >
+      <Icon className="size-5" />
+      <span className="text-xs font-medium">{label}</span>
+    </button>
+  );
+};
+
+export const GeneralThemeSection = () => {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <section>
+      <h2 className="mb-1 text-sm font-medium">Appearance</h2>
+      <p className="mb-4 text-xs text-muted-foreground">
+        Choose the overall look for the application.
+      </p>
+      <div className="flex gap-3">
+        {THEME_OPTIONS.map((option) => (
+          <ThemeOptionCard
+            key={option.value}
+            icon={option.icon}
+            label={option.label}
+            value={option.value}
+            isSelected={theme === option.value}
+            onSelect={setTheme}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/apps/web/src/routes/_default/-components/syntax-theme-section.tsx
+++ b/apps/web/src/routes/_default/-components/syntax-theme-section.tsx
@@ -1,0 +1,37 @@
+import { THEME_ENTRIES } from "@/lib/codemirror-themes";
+
+import { ThemePreviewCard } from "./theme-preview-card";
+
+interface SyntaxThemeSectionProps {
+  value: string;
+  fontFamily: string;
+  fontSize: number;
+  onChange: (themeKey: string) => void;
+}
+
+export const SyntaxThemeSection = ({
+  value,
+  fontFamily,
+  fontSize,
+  onChange,
+}: SyntaxThemeSectionProps) => (
+  <section>
+    <h2 className="mb-1 text-sm font-medium">Syntax Theme</h2>
+    <p className="mb-4 text-xs text-muted-foreground">
+      Choose a color scheme for the SQL editor.
+    </p>
+    <div className="grid grid-cols-3 gap-3">
+      {THEME_ENTRIES.map((entry) => (
+        <ThemePreviewCard
+          key={entry.key}
+          themeKey={entry.key}
+          label={entry.label}
+          isSelected={value === entry.key}
+          fontFamily={fontFamily}
+          fontSize={fontSize}
+          onSelect={onChange}
+        />
+      ))}
+    </div>
+  </section>
+);

--- a/apps/web/src/routes/_default/-components/theme-preview-card.tsx
+++ b/apps/web/src/routes/_default/-components/theme-preview-card.tsx
@@ -1,0 +1,106 @@
+import type { Extension } from "@codemirror/state";
+
+import { sql, PostgreSQL } from "@codemirror/lang-sql";
+import CodeMirror from "@uiw/react-codemirror";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  createFontExtension,
+  getThemeExtension,
+  PREVIEW_SQL,
+} from "@/lib/codemirror-themes";
+import { cn } from "@/lib/utils";
+
+interface ThemePreviewCardProps {
+  themeKey: string;
+  label: string;
+  isSelected: boolean;
+  fontFamily: string;
+  fontSize: number;
+  onSelect: (key: string) => void;
+}
+
+export const ThemePreviewCard = ({
+  themeKey,
+  label,
+  isSelected,
+  fontFamily,
+  fontSize,
+  onSelect,
+}: ThemePreviewCardProps) => {
+  const [themeExtension, setThemeExtension] = useState<Extension | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const ext = await getThemeExtension(themeKey);
+      if (!cancelled) {
+        setThemeExtension(ext);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [themeKey]);
+
+  const handleSelect = useCallback(() => {
+    onSelect(themeKey);
+  }, [onSelect, themeKey]);
+
+  const fontExtension = useMemo(
+    () => createFontExtension(fontFamily, fontSize),
+    [fontFamily, fontSize]
+  );
+
+  const extensions = useMemo(
+    () => [sql({ dialect: PostgreSQL }), fontExtension],
+    [fontExtension]
+  );
+
+  if (!themeExtension) {
+    return <div className="h-[120px] animate-pulse rounded-lg bg-muted" />;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleSelect}
+      className={cn(
+        "group cursor-pointer overflow-hidden rounded-lg text-left ring-1 transition-all",
+        isSelected
+          ? "ring-2 ring-primary"
+          : "ring-foreground/10 hover:ring-foreground/25"
+      )}
+    >
+      <div className="pointer-events-none h-[100px] overflow-hidden text-[10px]">
+        <CodeMirror
+          value={PREVIEW_SQL}
+          theme={themeExtension}
+          extensions={extensions}
+          readOnly
+          editable={false}
+          basicSetup={{
+            autocompletion: false,
+            bracketMatching: false,
+            closeBrackets: false,
+            foldGutter: false,
+            highlightActiveLine: false,
+            lineNumbers: false,
+          }}
+          className="h-full [&_.cm-editor]:h-full [&_.cm-scroller]:h-full [&_.cm-scroller]:overflow-hidden"
+        />
+      </div>
+      <div
+        className={cn(
+          "border-t px-2.5 py-1.5 text-[11px]",
+          isSelected
+            ? "border-primary/30 text-foreground"
+            : "border-foreground/10 text-muted-foreground group-hover:text-foreground"
+        )}
+      >
+        {label}
+      </div>
+    </button>
+  );
+};

--- a/apps/web/src/routes/_default/index.tsx
+++ b/apps/web/src/routes/_default/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
-import { Plus } from "lucide-react";
+import { Plus, Settings } from "lucide-react";
 import { useCallback, useState } from "react";
 
 import type { DatabaseConnection } from "@/lib/connections";
@@ -68,6 +68,10 @@ const HomeComponent = () => {
     }
   }, []);
 
+  const handleSettings = useCallback(() => {
+    navigate({ to: "/settings" });
+  }, [navigate]);
+
   const handleAddOpen = useCallback(() => {
     setAddOpen(true);
   }, []);
@@ -86,6 +90,21 @@ const HomeComponent = () => {
   return (
     <>
       <Titlebar>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Settings"
+                onClick={handleSettings}
+              />
+            }
+          >
+            <Settings className="size-3.5" />
+          </TooltipTrigger>
+          <TooltipContent>Settings</TooltipContent>
+        </Tooltip>
         <Tooltip>
           <TooltipTrigger
             render={

--- a/apps/web/src/routes/_default/settings.tsx
+++ b/apps/web/src/routes/_default/settings.tsx
@@ -1,0 +1,100 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { X } from "lucide-react";
+import { useCallback } from "react";
+
+import { Titlebar } from "@/components/titlebar/titlebar";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useEditorSettings } from "@/hooks/use-editor-settings";
+
+import { EditorFontSection } from "./-components/editor-font-section";
+import { GeneralThemeSection } from "./-components/general-theme-section";
+import { SyntaxThemeSection } from "./-components/syntax-theme-section";
+
+const SettingsComponent = () => {
+  const { settings, updateSettings } = useEditorSettings();
+
+  const handleClose = useCallback(() => {
+    window.history.back();
+  }, []);
+
+  const handleThemeChange = useCallback(
+    (theme: string) => {
+      updateSettings({ syntaxTheme: theme });
+    },
+    [updateSettings]
+  );
+
+  const handleFontFamilyChange = useCallback(
+    (fontFamily: string) => {
+      updateSettings({ fontFamily });
+    },
+    [updateSettings]
+  );
+
+  const handleFontSizeChange = useCallback(
+    (fontSize: number) => {
+      updateSettings({ fontSize });
+    },
+    [updateSettings]
+  );
+
+  return (
+    <>
+      <Titlebar>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Close settings"
+                onClick={handleClose}
+              />
+            }
+          >
+            <X className="size-3.5" />
+          </TooltipTrigger>
+          <TooltipContent>Close</TooltipContent>
+        </Tooltip>
+      </Titlebar>
+
+      <ScrollArea className="flex-1 overflow-hidden">
+        <div className="mx-auto max-w-2xl px-6 py-8">
+          <h1 className="mb-6 text-lg font-semibold">Settings</h1>
+
+          <GeneralThemeSection />
+
+          <Separator className="my-8" />
+
+          <SyntaxThemeSection
+            value={settings.syntaxTheme}
+            fontFamily={settings.fontFamily}
+            fontSize={settings.fontSize}
+            onChange={handleThemeChange}
+          />
+
+          <Separator className="my-8" />
+
+          <EditorFontSection
+            fontFamily={settings.fontFamily}
+            fontSize={settings.fontSize}
+            syntaxTheme={settings.syntaxTheme}
+            onFontFamilyChange={handleFontFamilyChange}
+            onFontSizeChange={handleFontSizeChange}
+          />
+        </div>
+      </ScrollArea>
+    </>
+  );
+};
+
+export const Route = createFileRoute("/_default/settings")({
+  component: SettingsComponent,
+});

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@tauri-apps/api": "^2.10.1",
         "@uiw/codemirror-theme-github": "^4.25.4",
+        "@uiw/codemirror-themes-all": "^4.25.5",
         "@uiw/react-codemirror": "^4.25.4",
         "ai": "^6.0.97",
         "class-variance-authority": "^0.7.1",
@@ -841,9 +842,79 @@
 
     "@uiw/codemirror-extensions-basic-setup": ["@uiw/codemirror-extensions-basic-setup@4.25.4", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-YzNwkm0AbPv1EXhCHYR5v0nqfemG2jEB0Z3Att4rBYqKrlG7AA9Rhjc3IyBaOzsBu18wtrp9/+uhTyu7TXSRng=="],
 
+    "@uiw/codemirror-theme-abcdef": ["@uiw/codemirror-theme-abcdef@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-QyYTRLHLrGgaQ+O0/rmk4UQ5tU+woYlOVdX1iH4S/XekghHt0O7RtAke+Of5LlrMMXhdz831tN9+cr0b2R5yrA=="],
+
+    "@uiw/codemirror-theme-abyss": ["@uiw/codemirror-theme-abyss@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-4mZPCxc85w3jH2UeS4d9RqawNvfJZ5Rk+jy/5ZAMzE8pZ7BmlkkemTpq2n1/xSon4JMFih57rPSEhaSTq2Sheg=="],
+
+    "@uiw/codemirror-theme-androidstudio": ["@uiw/codemirror-theme-androidstudio@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-EPqBsJfcm2sykjpXcBb0ANojp5jEqFWCIijXFA/4DjiT3BWTp+lWfDz8tvC6EAacpLAw72Lff4swV8+uVYuQZg=="],
+
+    "@uiw/codemirror-theme-andromeda": ["@uiw/codemirror-theme-andromeda@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-22fbIskJcStmCxcZ23TBSJXoRh79CkQ5JbXntctPtImyFtTqvhFlqKhdsqjZV9iQKDNS8MZM8HgZ9TuXr/ZshA=="],
+
+    "@uiw/codemirror-theme-atomone": ["@uiw/codemirror-theme-atomone@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-xazbBg6pRo5nY3Y5qf0aCgzKAsRrpYQtNGdC8bPQNHRVeAHSdRC3Ur2LTgKLFPZOCYM15BwK0xcHNwY/kXxf5A=="],
+
+    "@uiw/codemirror-theme-aura": ["@uiw/codemirror-theme-aura@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-NUiLToPCA0RutAi0mRpf9tq//+7Va3oEu7fkXjdDnCvxQ2iuVX+KcQuYB9m7qxNu3XhoTYGoiapSeazhMhOX0w=="],
+
+    "@uiw/codemirror-theme-basic": ["@uiw/codemirror-theme-basic@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-UREiY7NEFMjeBOGp8ssKf1jx8uDMWxGHjZV2myee+llPCPvPzfWq8Oa6ACFhilByl/poJ7KM1GjvrdYEJNY9eA=="],
+
+    "@uiw/codemirror-theme-bbedit": ["@uiw/codemirror-theme-bbedit@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-6B8ebidbja0RqIx1n5/pq/ssGXB989Tiq2BG5QM2/KRCIwvMnmrRvrjRt8sryirlhw+gS5fKeaITL6CfyjzdKg=="],
+
+    "@uiw/codemirror-theme-bespin": ["@uiw/codemirror-theme-bespin@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-RaolTBN6EmxbUSsX754QCBkWWq9TU8YETtuA5gduCZRboNxtfFE1fIkF2oKDMXJQpLv9ouTmf3s8n9REhEPyxw=="],
+
+    "@uiw/codemirror-theme-console": ["@uiw/codemirror-theme-console@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-YSAfNMG2Zt9Fey2Njc8gtu9MAjfJ6mksV5t7BBjE9HeeBSy1EvninoFfO/pfN5OGSk+ndm6dfx0KvXEcj2/4Gw=="],
+
+    "@uiw/codemirror-theme-copilot": ["@uiw/codemirror-theme-copilot@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-mGMlHNJoHIec9mbJ1q69pmwpJAGGh+ejgfg1q3QNnTEu+mI1MiylekSgH48q7cv5nxaoLrARsCoJ0h9AxLpIbQ=="],
+
+    "@uiw/codemirror-theme-darcula": ["@uiw/codemirror-theme-darcula@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-StEvIU2DV1a+SnVpLdD3voQ70FoIGwllYDnQH19WCO8STNEdS52P0+79Vpt0aPtl9sNSRhIh9AHyXie3Osp/nA=="],
+
+    "@uiw/codemirror-theme-dracula": ["@uiw/codemirror-theme-dracula@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-3sRgqSB6egzoZZt+5sBgvkHMQns7XmzVUdsZTgoWzBCK8sFplbNnDI8RfBy2wZNGwnCFANnkryAkZVRVv4brVw=="],
+
+    "@uiw/codemirror-theme-duotone": ["@uiw/codemirror-theme-duotone@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-nlRjWzvidJ3nZ3fgtrKlQKhvWwuSgLdUIX5lvXTByL8vwz8Ogt+gNma26W+XxE3dCdUbjB/bCxN2ekS90prj1g=="],
+
+    "@uiw/codemirror-theme-eclipse": ["@uiw/codemirror-theme-eclipse@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-L8n1MKNcNvKH4VJE19b2U769sNurWcPQpTsfV1s5AwzlN7D5BfWd43fhg3fUjPNKvijp9YgkhVYPwH+lFABHKg=="],
+
     "@uiw/codemirror-theme-github": ["@uiw/codemirror-theme-github@4.25.4", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.4" } }, "sha512-M5zRT2vIpNsuKN0Lz+DwLnmhHW8Eddp1M9zC0hm3V+bvffmaSn/pUDey1eqGIv5xNNmjhqvDAz0a90xLYCzvSw=="],
 
+    "@uiw/codemirror-theme-gruvbox-dark": ["@uiw/codemirror-theme-gruvbox-dark@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-bbSaXPH75FIahV/PoTpjrx+mSBy7MWbgvN9wluExlPo2yP6zaXrHP+zoaxx/20prLayLhTWrnqcYEW3rnRtbbg=="],
+
+    "@uiw/codemirror-theme-kimbie": ["@uiw/codemirror-theme-kimbie@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-VZQ0FEAvSWqWgEJzZgvwftbvDv1YOXDOqU5y4WY/EZaDei3Iz+3YU1N+AenhU/ZYUmdqlcq8fan3LVGRea+CIg=="],
+
+    "@uiw/codemirror-theme-material": ["@uiw/codemirror-theme-material@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-CEbeigZuddW42L0qhstjFuULMEc8wjMUisSmdOoCsmimlsPX9OC173bNlit22Zpjxu4XQzoaQq+OTPV565AZjA=="],
+
+    "@uiw/codemirror-theme-monokai": ["@uiw/codemirror-theme-monokai@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-Mp1VJvJluysbMAxjlOpwVrKHFN19kcBgP8xw2NABGhooM2+86rFjH/m1MEHO4PmaSSIPdqna3rWZo6maQ+IqQw=="],
+
+    "@uiw/codemirror-theme-monokai-dimmed": ["@uiw/codemirror-theme-monokai-dimmed@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-B/o2Cmi3p1KQQbROgaSGuJpLu4kSWL1IXhLofsfXcLKfrvZbQ8y/1dfHTiCuvWPkUyFIH5BGFgGhl1IXjQDuVg=="],
+
+    "@uiw/codemirror-theme-noctis-lilac": ["@uiw/codemirror-theme-noctis-lilac@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-eQ9ckqc6Y0Z4mWMCRlVijeAb5kcgyg052MDpq2zdECXs3WLd7kmEh1wVTrT8rCsMX7a/EADqMbLgBWirpIN5CA=="],
+
+    "@uiw/codemirror-theme-nord": ["@uiw/codemirror-theme-nord@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-2U2/auzCanIYWKPOYrOubsMF9hGDzbWshuhKpnUnD0P/61j/mIOsy0SnMUwwlA3hfRG58awCEy20dvknRJdpIQ=="],
+
+    "@uiw/codemirror-theme-okaidia": ["@uiw/codemirror-theme-okaidia@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-M+KK0rx9ruX4Wo3Es8b8n38OcGeNhaLwJARPLGSMjlOW4UPho4OGWLv9fVJndf8a9IhgxWeMBwDxfEwCb0oLag=="],
+
+    "@uiw/codemirror-theme-quietlight": ["@uiw/codemirror-theme-quietlight@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-M9NJW3+OcaKTvp9EAQUSn665zpGG6PRoUqo3Zkr185PKIpY3uA7BzZzjxh8Us9p1MZ/ZWgqFvVPO/d4CE9rKdw=="],
+
+    "@uiw/codemirror-theme-red": ["@uiw/codemirror-theme-red@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-Khh2TfC/VIbv9cHg1xcHafeBAAFsSg+kR+/Z8T3KwgU6GIrJcLuhfvtsUhsASKUSJavNFrLzUaImYbMphaEhbw=="],
+
+    "@uiw/codemirror-theme-solarized": ["@uiw/codemirror-theme-solarized@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-+uzEgMUPNmoZtxfsEV1l3fFYQbiJ5oxqSxzOLqDe+gcO2OA/uZay1SG+o/7QeBcBMuuxciS7tHjf/BITX11+cw=="],
+
+    "@uiw/codemirror-theme-sublime": ["@uiw/codemirror-theme-sublime@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-dtGcZTZEgEbnHZIcQawSUS4qxhiQ3JnlxGJXmzvgMjwhQoQVC5r4OTepuRiMv1HbyI/SdNv4wIOlPCvVYQbYjg=="],
+
+    "@uiw/codemirror-theme-tokyo-night": ["@uiw/codemirror-theme-tokyo-night@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-p6T1Nj5j3AQmdOT180TmiKMv/TB4aR+tLg3LOoUEKeNV6K2iZyti4qNMTvhPpQnKP0wY6NtuCA1SD5sAPDD0Ow=="],
+
+    "@uiw/codemirror-theme-tokyo-night-day": ["@uiw/codemirror-theme-tokyo-night-day@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-Lp4EJEuhdbX5lJaFnMQQXcyjQVjgg60g4lfwSBsJOxgsX7EsnY+NvGJa9c94SImCPtfAco9UhWBUWoPBVm6LmQ=="],
+
+    "@uiw/codemirror-theme-tokyo-night-storm": ["@uiw/codemirror-theme-tokyo-night-storm@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-3ahmnAOwGhFdMkmibymLpmdS5DR/7GY3WjOeHp9afeFbSN54QYyV1hrpwEoYOo7VEouUlzXTfrUYz/E0YOmQsg=="],
+
+    "@uiw/codemirror-theme-tomorrow-night-blue": ["@uiw/codemirror-theme-tomorrow-night-blue@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-zPNlGS51Wfcrv2FEmehe0EznYL3EZhU29CLQKIMtz2pH05EnE+Wfraq5qsDkydoS+SF1xqAvhr/n1emettYyzw=="],
+
+    "@uiw/codemirror-theme-vscode": ["@uiw/codemirror-theme-vscode@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-oLOFdNabcmvrGMgNjqDsUjaUeRfOK0N+NGGcfe7hhiCPtug84JFho5t2naOtdNyRpY1U41PNkzsgpHEjDxoUJg=="],
+
+    "@uiw/codemirror-theme-white": ["@uiw/codemirror-theme-white@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-MUq3xkJD8Wim+D44T2AW/WNeWDYUzNVX1scmcO+bIwJnNGyFfkjla5y9S4xqVQPN5jpVV0n+CEThocKszAg6EQ=="],
+
+    "@uiw/codemirror-theme-xcode": ["@uiw/codemirror-theme-xcode@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-/v/pec5gO1ZDdF2Qv7YTlf1g/s5Fd8tlCVB7KMYJ1Ge/2HS6dLmwumND9Vz0QavsZtc0em8d0e0Ng4XLvrnrrQ=="],
+
     "@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.4", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-2SLktItgcZC4p0+PfFusEbAHwbuAWe3bOOntCevVgHtrWGtGZX3IPv2k8IKZMgOXtAHyGKpJvT9/nspPn/uCQg=="],
+
+    "@uiw/codemirror-themes-all": ["@uiw/codemirror-themes-all@4.25.5", "", { "dependencies": { "@uiw/codemirror-theme-abcdef": "4.25.5", "@uiw/codemirror-theme-abyss": "4.25.5", "@uiw/codemirror-theme-androidstudio": "4.25.5", "@uiw/codemirror-theme-andromeda": "4.25.5", "@uiw/codemirror-theme-atomone": "4.25.5", "@uiw/codemirror-theme-aura": "4.25.5", "@uiw/codemirror-theme-basic": "4.25.5", "@uiw/codemirror-theme-bbedit": "4.25.5", "@uiw/codemirror-theme-bespin": "4.25.5", "@uiw/codemirror-theme-console": "4.25.5", "@uiw/codemirror-theme-copilot": "4.25.5", "@uiw/codemirror-theme-darcula": "4.25.5", "@uiw/codemirror-theme-dracula": "4.25.5", "@uiw/codemirror-theme-duotone": "4.25.5", "@uiw/codemirror-theme-eclipse": "4.25.5", "@uiw/codemirror-theme-github": "4.25.5", "@uiw/codemirror-theme-gruvbox-dark": "4.25.5", "@uiw/codemirror-theme-kimbie": "4.25.5", "@uiw/codemirror-theme-material": "4.25.5", "@uiw/codemirror-theme-monokai": "4.25.5", "@uiw/codemirror-theme-monokai-dimmed": "4.25.5", "@uiw/codemirror-theme-noctis-lilac": "4.25.5", "@uiw/codemirror-theme-nord": "4.25.5", "@uiw/codemirror-theme-okaidia": "4.25.5", "@uiw/codemirror-theme-quietlight": "4.25.5", "@uiw/codemirror-theme-red": "4.25.5", "@uiw/codemirror-theme-solarized": "4.25.5", "@uiw/codemirror-theme-sublime": "4.25.5", "@uiw/codemirror-theme-tokyo-night": "4.25.5", "@uiw/codemirror-theme-tokyo-night-day": "4.25.5", "@uiw/codemirror-theme-tokyo-night-storm": "4.25.5", "@uiw/codemirror-theme-tomorrow-night-blue": "4.25.5", "@uiw/codemirror-theme-vscode": "4.25.5", "@uiw/codemirror-theme-white": "4.25.5", "@uiw/codemirror-theme-xcode": "4.25.5", "@uiw/codemirror-themes": "4.25.5" } }, "sha512-zPtwrP78oaUNlL80pxAu6vCR3VPxHgB/KC8eoulqbvaTnCnQaFf8e1xbz3Ub4MkeQFLWTDGacQyE+sbA0lPBsw=="],
 
     "@uiw/react-codemirror": ["@uiw/react-codemirror@4.25.4", "", { "dependencies": { "@babel/runtime": "^7.18.6", "@codemirror/commands": "^6.1.0", "@codemirror/state": "^6.1.1", "@codemirror/theme-one-dark": "^6.0.0", "@uiw/codemirror-extensions-basic-setup": "4.25.4", "codemirror": "^6.0.0" }, "peerDependencies": { "@codemirror/view": ">=6.0.0", "react": ">=17.0.0", "react-dom": ">=17.0.0" } }, "sha512-ipO067oyfUw+DVaXhQCxkB0ZD9b7RnY+ByrprSYSKCHaULvJ3sqWYC/Zen6zVQ8/XC4o5EPBfatGiX20kC7XGA=="],
 
@@ -2104,6 +2175,78 @@
     "@tanstack/router-generator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tanstack/router-plugin/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@uiw/codemirror-theme-abcdef/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-abyss/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-androidstudio/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-andromeda/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-atomone/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-aura/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-basic/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-bbedit/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-bespin/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-console/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-copilot/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-darcula/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-dracula/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-duotone/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-eclipse/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-gruvbox-dark/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-kimbie/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-material/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-monokai/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-monokai-dimmed/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-noctis-lilac/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-nord/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-okaidia/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-quietlight/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-red/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-solarized/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-sublime/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-tokyo-night/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-tokyo-night-day/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-tokyo-night-storm/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-tomorrow-night-blue/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-vscode/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-white/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-theme-xcode/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
+
+    "@uiw/codemirror-themes-all/@uiw/codemirror-theme-github": ["@uiw/codemirror-theme-github@4.25.5", "", { "dependencies": { "@uiw/codemirror-themes": "4.25.5" } }, "sha512-0AyW9mYzrY+mZRU/V1ekx/zpyhlnSTZOLKTESzt++MMQLVFXd9yLyoZgZ49vaaNNphMfxw3wBeE+lOOMwHGrew=="],
+
+    "@uiw/codemirror-themes-all/@uiw/codemirror-themes": ["@uiw/codemirror-themes@4.25.5", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-mvNFy1eEkWTPSztL+N6cmOOZN26Wn9mGZUsFeIIRRkGqR4+Z9NBjzWF8JHqhZ73pEMOYe3UO+cRF/M9cxiTk9Q=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 


### PR DESCRIPTION
## Summary

Complete settings page implementation with editor customization and native Tauri menu integration. Users can now choose syntax themes with live CodeMirror previews, customize editor fonts, and toggle between light/dark/system appearance modes. Native macOS menu provides keyboard shortcut (Cmd+,) for quick access.

## Changes

- **Settings page** (`/settings`) with three configurable sections: syntax theme picker (20 curated themes), editor font customization, and appearance mode toggle
- **Reactive settings** stored in localStorage via `useSyncExternalStore` pattern, applied instantly to SQL editor across routes
- **Native Tauri menu** with Settings shortcut, dynamically emit events to navigate to settings page
- **Light mode fixes**: replace undefined `bg-sidebar-background` variable, add `bg-background` to layout wrappers to prevent dark vibrancy material from bleeding through in light theme

## Testing

- Settings persist across page navigation and browser refresh
- Switching themes/fonts immediately updates SQL editor in workspace
- Light mode no longer shows dark vibrancy bleed-through on pages and panel gaps
- Native menu Settings shortcut (Cmd+,) navigates to settings page