### PR TITLE
Add settings page tabs and CSV export settings

### DIFF
--- a/apps/web/src/components/workspace/workspace-content.tsx
+++ b/apps/web/src/components/workspace/workspace-content.tsx
@@ -27,6 +27,7 @@ import {
   QueryTabsProvider,
   useQueryTabsContext,
 } from "@/contexts/query-tabs-context";
+import { useExportSettings } from "@/hooks/use-export-settings";
 import { useQueryTabs } from "@/hooks/use-query-tabs";
 import { useSyntaxTree } from "@/hooks/use-syntax-tree";
 import { useWorkspaceHotkeys } from "@/hooks/use-workspace-hotkeys";
@@ -439,12 +440,19 @@ interface ResultsPanelProps {
 }
 
 const ResultsPanel = ({ status, result, error, isSql }: ResultsPanelProps) => {
+  const { settings: exportSettings } = useExportSettings();
+
   const handleDownloadCsv = useCallback(() => {
     if (result?.resultType === "tabular") {
-      const csv = tabularResultToCsv(result);
+      const csv = tabularResultToCsv(result, {
+        delimiter: exportSettings.csvDelimiter,
+        includeBom: exportSettings.includeBom,
+        includeHeaders: exportSettings.includeHeaders,
+        nullDisplay: exportSettings.nullDisplay,
+      });
       downloadCsv(csv, `query-results-${Date.now()}.csv`);
     }
-  }, [result]);
+  }, [result, exportSettings]);
 
   if (status === "running") {
     return (

--- a/apps/web/src/hooks/use-export-settings.ts
+++ b/apps/web/src/hooks/use-export-settings.ts
@@ -1,0 +1,36 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+import type { ExportSettings } from "@/lib/export-settings";
+
+import { getExportSettings, saveExportSettings } from "@/lib/export-settings";
+
+const listeners = new Set<() => void>();
+// oxlint-disable-next-line jest/require-hook -- module-level cache, not test code
+let cachedSettings = getExportSettings();
+
+const subscribe = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const getSnapshot = (): ExportSettings => cachedSettings;
+
+const notify = (): void => {
+  cachedSettings = getExportSettings();
+  for (const listener of listeners) {
+    listener();
+  }
+};
+
+export const useExportSettings = () => {
+  const settings = useSyncExternalStore(subscribe, getSnapshot);
+
+  const updateSettings = useCallback((partial: Partial<ExportSettings>) => {
+    const current = getExportSettings();
+    const next = { ...current, ...partial };
+    saveExportSettings(next);
+    notify();
+  }, []);
+
+  return { settings, updateSettings };
+};

--- a/apps/web/src/lib/csv.ts
+++ b/apps/web/src/lib/csv.ts
@@ -1,22 +1,51 @@
 import type { TabularResult } from "@/lib/tauri";
 
-const escapeCell = (value: unknown): string => {
-  if (value === null || value === undefined) {
-    return "";
-  }
-  const str = String(value);
-  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+interface CsvOptions {
+  delimiter: string;
+  nullDisplay: string;
+  includeHeaders: boolean;
+  includeBom: boolean;
+}
+
+const DEFAULT_OPTIONS: CsvOptions = {
+  delimiter: ",",
+  includeBom: false,
+  includeHeaders: true,
+  nullDisplay: "",
+};
+
+const escapeCell = (
+  value: unknown,
+  delimiter: string,
+  nullDisplay: string
+): string => {
+  const str =
+    value === null || value === undefined ? nullDisplay : String(value);
+  if (str.includes(delimiter) || str.includes('"') || str.includes("\n")) {
     return `"${str.replaceAll('"', '""')}"`;
   }
   return str;
 };
 
-export const tabularResultToCsv = (result: TabularResult): string => {
-  const header = result.columns.map((col) => escapeCell(col.name)).join(",");
-  const rows = result.rows.map((row) =>
-    row.map((cell) => escapeCell(cell)).join(",")
-  );
-  return [header, ...rows].join("\n");
+export const tabularResultToCsv = (
+  result: TabularResult,
+  options: Partial<CsvOptions> = {}
+): string => {
+  const { delimiter, nullDisplay, includeHeaders, includeBom } = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  };
+
+  const escape = (v: unknown) => escapeCell(v, delimiter, nullDisplay);
+
+  const rows = result.rows.map((row) => row.map(escape).join(delimiter));
+
+  const lines = includeHeaders
+    ? [result.columns.map((col) => escape(col.name)).join(delimiter), ...rows]
+    : rows;
+
+  const csv = lines.join("\n");
+  return includeBom ? `\uFEFF${csv}` : csv;
 };
 
 export const downloadCsv = (csv: string, filename: string): void => {

--- a/apps/web/src/lib/export-settings.ts
+++ b/apps/web/src/lib/export-settings.ts
@@ -1,0 +1,49 @@
+export type CsvDelimiter = "," | ";" | "\t" | "|";
+
+export interface ExportSettings {
+  csvDelimiter: CsvDelimiter;
+  includeBom: boolean;
+  nullDisplay: string;
+  includeHeaders: boolean;
+}
+
+const STORAGE_KEY = "oh-my-query-export-settings";
+
+const DEFAULT_SETTINGS: ExportSettings = {
+  csvDelimiter: ",",
+  includeBom: false,
+  includeHeaders: true,
+  nullDisplay: "",
+};
+
+export const CSV_DELIMITERS = [
+  { label: "Comma (,)", value: "," },
+  { label: "Semicolon (;)", value: ";" },
+  { label: "Tab (\\t)", value: "\t" },
+  { label: "Pipe (|)", value: "|" },
+] as const;
+
+export const NULL_DISPLAY_PRESETS = [
+  { label: "Empty string", value: "" },
+  { label: "NULL (uppercase)", value: "NULL" },
+  { label: "null (lowercase)", value: "null" },
+] as const;
+
+export const getExportSettings = (): ExportSettings => {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return DEFAULT_SETTINGS;
+  }
+  try {
+    return {
+      ...DEFAULT_SETTINGS,
+      ...(JSON.parse(raw) as Partial<ExportSettings>),
+    };
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+};
+
+export const saveExportSettings = (settings: ExportSettings): void => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+};

--- a/apps/web/src/routes/_default/-components/export-settings-section.tsx
+++ b/apps/web/src/routes/_default/-components/export-settings-section.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useState } from "react";
+
+import type { CsvDelimiter } from "@/lib/export-settings";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useExportSettings } from "@/hooks/use-export-settings";
+import { CSV_DELIMITERS, NULL_DISPLAY_PRESETS } from "@/lib/export-settings";
+
+const CUSTOM_NULL_SENTINEL = "__custom__";
+
+const CheckboxField = ({
+  id,
+  label,
+  checked,
+  onCheckedChange,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) => (
+  <div className="flex items-center gap-2">
+    <Checkbox id={id} checked={checked} onCheckedChange={onCheckedChange} />
+    <Label
+      htmlFor={id}
+      className="cursor-pointer text-xs text-muted-foreground"
+    >
+      {label}
+    </Label>
+  </div>
+);
+
+export const ExportSettingsSection = () => {
+  const { settings, updateSettings } = useExportSettings();
+
+  const isCustomNull = !NULL_DISPLAY_PRESETS.some(
+    (o) => o.value === settings.nullDisplay
+  );
+  const [customNullValue, setCustomNullValue] = useState(
+    isCustomNull ? settings.nullDisplay : ""
+  );
+
+  const handleDelimiterChange = useCallback(
+    (v: string | null) => {
+      if (v) {
+        updateSettings({ csvDelimiter: v as CsvDelimiter });
+      }
+    },
+    [updateSettings]
+  );
+
+  const handleNullPresetChange = useCallback(
+    (v: string | null) => {
+      if (v === CUSTOM_NULL_SENTINEL) {
+        updateSettings({ nullDisplay: customNullValue });
+        return;
+      }
+      if (v !== null) {
+        updateSettings({ nullDisplay: v });
+      }
+    },
+    [updateSettings, customNullValue]
+  );
+
+  const handleCustomNullChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = e.target.value;
+      setCustomNullValue(val);
+      updateSettings({ nullDisplay: val });
+    },
+    [updateSettings]
+  );
+
+  const handleIncludeBomChange = useCallback(
+    (checked: boolean) => {
+      updateSettings({ includeBom: checked });
+    },
+    [updateSettings]
+  );
+
+  const handleIncludeHeadersChange = useCallback(
+    (checked: boolean) => {
+      updateSettings({ includeHeaders: checked });
+    },
+    [updateSettings]
+  );
+
+  const nullSelectValue = isCustomNull
+    ? CUSTOM_NULL_SENTINEL
+    : settings.nullDisplay;
+
+  return (
+    <section>
+      <h2 className="mb-1 text-sm font-medium">CSV Export</h2>
+      <p className="mb-4 text-xs text-muted-foreground">
+        Configure how query results are exported as CSV files.
+      </p>
+
+      <div className="mb-4 flex items-end gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-xs text-muted-foreground">Delimiter</Label>
+          <Select
+            value={settings.csvDelimiter}
+            onValueChange={handleDelimiterChange}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start" alignItemWithTrigger={false}>
+              {CSV_DELIMITERS.map((d) => (
+                <SelectItem key={d.value} value={d.value}>
+                  {d.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-xs text-muted-foreground">
+            Null value display
+          </Label>
+          <Select
+            value={nullSelectValue}
+            onValueChange={handleNullPresetChange}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="start" alignItemWithTrigger={false}>
+              {NULL_DISPLAY_PRESETS.map((o) => (
+                <SelectItem key={`null-${o.label}`} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+              <SelectItem value={CUSTOM_NULL_SENTINEL}>Custom...</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {(isCustomNull || nullSelectValue === CUSTOM_NULL_SENTINEL) && (
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-xs text-muted-foreground">Custom text</Label>
+            <Input
+              value={customNullValue}
+              onChange={handleCustomNullChange}
+              placeholder="e.g. N/A"
+              className="h-7 w-24 text-xs"
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-6">
+        <CheckboxField
+          id="include-headers"
+          label="Include column headers"
+          checked={settings.includeHeaders}
+          onCheckedChange={handleIncludeHeadersChange}
+        />
+        <CheckboxField
+          id="include-bom"
+          label="Include BOM (Excel UTF-8)"
+          checked={settings.includeBom}
+          onCheckedChange={handleIncludeBomChange}
+        />
+      </div>
+    </section>
+  );
+};

--- a/apps/web/src/routes/_default/settings.tsx
+++ b/apps/web/src/routes/_default/settings.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { X } from "lucide-react";
-import { useCallback } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { useCallback, useState } from "react";
 
 import { Titlebar } from "@/components/titlebar/titlebar";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Tooltip,
   TooltipContent,
@@ -14,11 +16,13 @@ import {
 import { useEditorSettings } from "@/hooks/use-editor-settings";
 
 import { EditorFontSection } from "./-components/editor-font-section";
+import { ExportSettingsSection } from "./-components/export-settings-section";
 import { GeneralThemeSection } from "./-components/general-theme-section";
 import { SyntaxThemeSection } from "./-components/syntax-theme-section";
 
 const SettingsComponent = () => {
   const { settings, updateSettings } = useEditorSettings();
+  const [activeTab, setActiveTab] = useState("general");
 
   const handleClose = useCallback(() => {
     window.history.back();
@@ -69,26 +73,50 @@ const SettingsComponent = () => {
         <div className="mx-auto max-w-2xl px-6 py-8">
           <h1 className="mb-6 text-lg font-semibold">Settings</h1>
 
-          <GeneralThemeSection />
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList variant="segment" className="mb-8">
+              <TabsTrigger value="general">General</TabsTrigger>
+              <TabsTrigger value="editor">Editor</TabsTrigger>
+            </TabsList>
+          </Tabs>
 
-          <Separator className="my-8" />
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={activeTab}
+              initial={{ filter: "blur(4px)", opacity: 0 }}
+              animate={{ filter: "blur(0px)", opacity: 1 }}
+              exit={{ filter: "blur(4px)", opacity: 0 }}
+              transition={{ duration: 0.15 }}
+            >
+              {activeTab === "general" && (
+                <>
+                  <GeneralThemeSection />
+                  <Separator className="my-8" />
+                  <ExportSettingsSection />
+                </>
+              )}
+              {activeTab === "editor" && (
+                <>
+                  <SyntaxThemeSection
+                    value={settings.syntaxTheme}
+                    fontFamily={settings.fontFamily}
+                    fontSize={settings.fontSize}
+                    onChange={handleThemeChange}
+                  />
 
-          <SyntaxThemeSection
-            value={settings.syntaxTheme}
-            fontFamily={settings.fontFamily}
-            fontSize={settings.fontSize}
-            onChange={handleThemeChange}
-          />
+                  <Separator className="my-8" />
 
-          <Separator className="my-8" />
-
-          <EditorFontSection
-            fontFamily={settings.fontFamily}
-            fontSize={settings.fontSize}
-            syntaxTheme={settings.syntaxTheme}
-            onFontFamilyChange={handleFontFamilyChange}
-            onFontSizeChange={handleFontSizeChange}
-          />
+                  <EditorFontSection
+                    fontFamily={settings.fontFamily}
+                    fontSize={settings.fontSize}
+                    syntaxTheme={settings.syntaxTheme}
+                    onFontFamilyChange={handleFontFamilyChange}
+                    onFontSizeChange={handleFontSizeChange}
+                  />
+                </>
+              )}
+            </motion.div>
+          </AnimatePresence>
         </div>
       </ScrollArea>
     </>


### PR DESCRIPTION
## Summary

Reorganizes the settings page with native-feeling segment-style tabs (General/Editor) and smooth blur-fade animations. Adds comprehensive CSV export configuration with delimiter, BOM, null value representation, and header inclusion options.

**Settings page improvements:**
- Segment tabs split General (theme) and Editor (syntax theme, code font) for cleaner navigation
- AnimatePresence blur-fade transitions between tabs for native macOS feel

**CSV export settings:**
- Configurable delimiters (comma, semicolon, tab, pipe)
- Custom null value display (empty, NULL, null, or custom text)
- Optional BOM for Excel UTF-8 compatibility
- Optional column headers in export
- All settings persisted to localStorage