### PR TITLE
Add table context menu with pin, copy, and SQL options

### DIFF
--- a/apps/web/src/components/workspace/schema-tree.tsx
+++ b/apps/web/src/components/workspace/schema-tree.tsx
@@ -7,6 +7,8 @@ import { TableNode } from "./table-node";
 interface SchemaTreeProps {
   schema: SchemaInfo;
   filter: string;
+  pinnedTables: string[];
+  onTogglePin: (tableName: string) => void;
 }
 
 const filterSchema = (schema: SchemaItem, query: string): SchemaItem => {
@@ -18,7 +20,12 @@ const filterSchema = (schema: SchemaItem, query: string): SchemaItem => {
   };
 };
 
-export const SchemaTree = ({ schema, filter }: SchemaTreeProps) => {
+export const SchemaTree = ({
+  schema,
+  filter,
+  pinnedTables,
+  onTogglePin,
+}: SchemaTreeProps) => {
   const filtered = useMemo(() => {
     const [first] = schema.schemas;
     if (!first) {
@@ -26,6 +33,23 @@ export const SchemaTree = ({ schema, filter }: SchemaTreeProps) => {
     }
     return filter ? filterSchema(first, filter) : first;
   }, [schema, filter]);
+
+  const sortedTables = useMemo(() => {
+    if (!filtered) {
+      return [];
+    }
+    return [...filtered.tables].toSorted((a, b) => {
+      const aPinned = pinnedTables.includes(a.name);
+      const bPinned = pinnedTables.includes(b.name);
+      if (aPinned && !bPinned) {
+        return -1;
+      }
+      if (!aPinned && bPinned) {
+        return 1;
+      }
+      return 0;
+    });
+  }, [filtered, pinnedTables]);
 
   if (
     !filtered ||
@@ -40,13 +64,18 @@ export const SchemaTree = ({ schema, filter }: SchemaTreeProps) => {
 
   return (
     <div className="px-1 py-1">
-      {filtered.tables.length > 0 && (
+      {sortedTables.length > 0 && (
         <>
           <div className="mb-0.5 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-            Tables ({filtered.tables.length})
+            Tables ({sortedTables.length})
           </div>
-          {filtered.tables.map((table) => (
-            <TableNode key={table.name} table={table} />
+          {sortedTables.map((table) => (
+            <TableNode
+              key={table.name}
+              table={table}
+              isPinned={pinnedTables.includes(table.name)}
+              onTogglePin={onTogglePin}
+            />
           ))}
         </>
       )}

--- a/apps/web/src/components/workspace/table-context-menu.tsx
+++ b/apps/web/src/components/workspace/table-context-menu.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from "react";
+
+import { Clipboard, Copy, Pin, Play, Trash2 } from "lucide-react";
+import { useCallback } from "react";
+
+import type { TableItem, ViewItem } from "@/lib/tauri";
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { useEditorInsert } from "@/contexts/editor-insert-context";
+import {
+  generateCreateTable,
+  generateDropTable,
+  generateSelectTop100,
+  generateTruncateTable,
+} from "@/lib/sql-templates";
+
+interface TableContextMenuProps {
+  table: TableItem | ViewItem;
+  isView: boolean;
+  isPinned: boolean;
+  onTogglePin: (tableName: string) => void;
+  children: ReactNode;
+}
+
+export const TableContextMenu = ({
+  table,
+  isView,
+  isPinned,
+  onTogglePin,
+  children,
+}: TableContextMenuProps) => {
+  const { openQuery } = useEditorInsert();
+
+  const handleSelectTop100 = useCallback(() => {
+    openQuery(generateSelectTop100(table.name));
+  }, [openQuery, table.name]);
+
+  const handleCopyName = useCallback(() => {
+    navigator.clipboard.writeText(table.name);
+  }, [table.name]);
+
+  const handlePin = useCallback(() => {
+    onTogglePin(table.name);
+  }, [onTogglePin, table.name]);
+
+  const handleDrop = useCallback(() => {
+    openQuery(generateDropTable(table.name, isView));
+  }, [openQuery, table.name, isView]);
+
+  const handleCopyCreate = useCallback(() => {
+    navigator.clipboard.writeText(generateCreateTable(table, isView));
+  }, [table, isView]);
+
+  const handleCopyDrop = useCallback(() => {
+    navigator.clipboard.writeText(generateDropTable(table.name, isView));
+  }, [table.name, isView]);
+
+  const handleCopyTruncate = useCallback(() => {
+    navigator.clipboard.writeText(generateTruncateTable(table.name));
+  }, [table.name]);
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger className="block">{children}</ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onClick={handleSelectTop100}>
+          <Play />
+          Select top 100
+        </ContextMenuItem>
+        <ContextMenuItem onClick={handleCopyName}>
+          <Clipboard />
+          Copy name
+        </ContextMenuItem>
+        <ContextMenuItem onClick={handlePin}>
+          <Pin />
+          {isPinned ? "Unpin" : "Pin"}
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>
+            <Copy />
+            Copy as
+          </ContextMenuSubTrigger>
+          <ContextMenuSubContent>
+            <ContextMenuItem onClick={handleCopyCreate}>Create</ContextMenuItem>
+            <ContextMenuItem onClick={handleCopyDrop}>Drop</ContextMenuItem>
+            {!isView && (
+              <ContextMenuItem onClick={handleCopyTruncate}>
+                Truncate
+              </ContextMenuItem>
+            )}
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={handleDrop} variant="destructive">
+          <Trash2 />
+          Drop
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+};

--- a/apps/web/src/components/workspace/table-node.tsx
+++ b/apps/web/src/components/workspace/table-node.tsx
@@ -3,6 +3,7 @@ import {
   Eye,
   Link,
   ListOrdered,
+  Pin,
   Play,
   Table2,
 } from "lucide-react";
@@ -23,16 +24,24 @@ import {
 import { useEditorInsert } from "@/contexts/editor-insert-context";
 
 import { ColumnNode } from "./column-node";
+import { TableContextMenu } from "./table-context-menu";
 
 interface TableNodeProps {
   table: TableItem | ViewItem;
   isView?: boolean;
+  isPinned?: boolean;
+  onTogglePin?: (tableName: string) => void;
 }
 
 const isTableItem = (item: TableItem | ViewItem): item is TableItem =>
   "indexes" in item;
 
-export const TableNode = ({ table, isView = false }: TableNodeProps) => {
+export const TableNode = ({
+  table,
+  isView = false,
+  isPinned = false,
+  onTogglePin,
+}: TableNodeProps) => {
   const { queryTable } = useEditorInsert();
   const hasIndexes = isTableItem(table) && table.indexes.length > 0;
   const hasForeignKeys = isTableItem(table) && table.foreignKeys.length > 0;
@@ -41,85 +50,100 @@ export const TableNode = ({ table, isView = false }: TableNodeProps) => {
     queryTable(table.name);
   }, [queryTable, table.name]);
 
+  const handleTogglePin = useCallback(
+    (name: string) => {
+      onTogglePin?.(name);
+    },
+    [onTogglePin]
+  );
+
   return (
-    <Collapsible className="group/table">
-      <div className="flex items-center">
-        <CollapsibleTrigger className="flex flex-1 items-center gap-1.5 rounded-md px-2 py-1 text-xs hover:bg-sidebar-accent/50 [&[data-panel-open]>svg:first-child]:rotate-90">
-          <ChevronRight className="size-3 shrink-0 text-muted-foreground transition-transform" />
-          {isView ? (
-            <Eye className="size-3.5 shrink-0 text-muted-foreground" />
-          ) : (
-            <Table2 className="size-3.5 shrink-0 text-muted-foreground" />
-          )}
-          <span className="truncate">{table.name}</span>
-        </CollapsibleTrigger>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <button
-                type="button"
-                className="mr-1 rounded p-0.5 text-muted-foreground opacity-0 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground group-hover/table:opacity-100"
-                onClick={handleQueryTable}
-                aria-label={`Query ${table.name}`}
-              />
-            }
-          >
-            <Play className="size-3" />
-          </TooltipTrigger>
-          <TooltipContent>Query table</TooltipContent>
-        </Tooltip>
-      </div>
-      <CollapsibleContent>
-        <div className="ml-3 border-l border-sidebar-border pl-2">
-          <div className="mb-0.5 mt-1 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-            Columns ({table.columns.length})
-          </div>
-          {table.columns.map((col) => (
-            <ColumnNode key={col.name} column={col} />
-          ))}
-
-          {hasIndexes && (
-            <>
-              <div className="mb-0.5 mt-2 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                Indexes ({table.indexes.length})
-              </div>
-              {table.indexes.map((idx) => (
-                <div
-                  key={idx.name}
-                  className="flex items-center gap-2 px-2 py-1 text-xs text-muted-foreground"
-                >
-                  <ListOrdered className="size-3 shrink-0" />
-                  <span className="truncate">{idx.name}</span>
-                  {idx.isUnique && (
-                    <span className="ml-auto shrink-0 text-[10px] text-amber-500/70">
-                      unique
-                    </span>
-                  )}
-                </div>
-              ))}
-            </>
-          )}
-
-          {hasForeignKeys && (
-            <>
-              <div className="mb-0.5 mt-2 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                Foreign Keys ({table.foreignKeys.length})
-              </div>
-              {table.foreignKeys.map((fk) => (
-                <div
-                  key={fk.name}
-                  className="flex items-center gap-2 px-2 py-1 text-xs text-muted-foreground"
-                >
-                  <Link className="size-3 shrink-0" />
-                  <span className="truncate">
-                    {fk.columns.join(", ")} &rarr; {fk.referencedTable}
-                  </span>
-                </div>
-              ))}
-            </>
-          )}
+    <TableContextMenu
+      table={table}
+      isView={isView}
+      isPinned={isPinned}
+      onTogglePin={handleTogglePin}
+    >
+      <Collapsible className="group/table">
+        <div className="flex items-center">
+          <CollapsibleTrigger className="flex flex-1 items-center gap-1.5 rounded-md px-2 py-1 text-xs hover:bg-sidebar-accent/50 [&[data-panel-open]>svg:first-child]:rotate-90">
+            <ChevronRight className="size-3 shrink-0 text-muted-foreground transition-transform" />
+            {isView ? (
+              <Eye className="size-3.5 shrink-0 text-muted-foreground" />
+            ) : (
+              <Table2 className="size-3.5 shrink-0 text-muted-foreground" />
+            )}
+            <span className="truncate">{table.name}</span>
+            {isPinned && <Pin className="size-2.5 shrink-0 text-primary/60" />}
+          </CollapsibleTrigger>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  className="mr-1 rounded p-0.5 text-muted-foreground opacity-0 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground group-hover/table:opacity-100"
+                  onClick={handleQueryTable}
+                  aria-label={`Query ${table.name}`}
+                />
+              }
+            >
+              <Play className="size-3" />
+            </TooltipTrigger>
+            <TooltipContent>Query table</TooltipContent>
+          </Tooltip>
         </div>
-      </CollapsibleContent>
-    </Collapsible>
+        <CollapsibleContent>
+          <div className="ml-3 border-l border-sidebar-border pl-2">
+            <div className="mb-0.5 mt-1 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              Columns ({table.columns.length})
+            </div>
+            {table.columns.map((col) => (
+              <ColumnNode key={col.name} column={col} />
+            ))}
+
+            {hasIndexes && (
+              <>
+                <div className="mb-0.5 mt-2 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                  Indexes ({table.indexes.length})
+                </div>
+                {table.indexes.map((idx) => (
+                  <div
+                    key={idx.name}
+                    className="flex items-center gap-2 px-2 py-1 text-xs text-muted-foreground"
+                  >
+                    <ListOrdered className="size-3 shrink-0" />
+                    <span className="truncate">{idx.name}</span>
+                    {idx.isUnique && (
+                      <span className="ml-auto shrink-0 text-[10px] text-amber-500/70">
+                        unique
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </>
+            )}
+
+            {hasForeignKeys && (
+              <>
+                <div className="mb-0.5 mt-2 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                  Foreign Keys ({table.foreignKeys.length})
+                </div>
+                {table.foreignKeys.map((fk) => (
+                  <div
+                    key={fk.name}
+                    className="flex items-center gap-2 px-2 py-1 text-xs text-muted-foreground"
+                  >
+                    <Link className="size-3 shrink-0" />
+                    <span className="truncate">
+                      {fk.columns.join(", ")} &rarr; {fk.referencedTable}
+                    </span>
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </TableContextMenu>
   );
 };

--- a/apps/web/src/components/workspace/workspace-sidebar.tsx
+++ b/apps/web/src/components/workspace/workspace-sidebar.tsx
@@ -28,6 +28,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { usePinnedTables } from "@/hooks/use-pinned-tables";
 import { isTauri } from "@/lib/tauri";
 import { cn } from "@/lib/utils";
 
@@ -124,6 +125,8 @@ interface SchemaTabContentProps {
   filter: string;
   onFilterChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onRetry: () => void;
+  pinnedTables: string[];
+  onTogglePin: (tableName: string) => void;
 }
 
 const SchemaTabContent = ({
@@ -133,6 +136,8 @@ const SchemaTabContent = ({
   filter,
   onFilterChange,
   onRetry,
+  pinnedTables,
+  onTogglePin,
 }: SchemaTabContentProps) => (
   <>
     {schema && (
@@ -155,7 +160,14 @@ const SchemaTabContent = ({
     <ScrollArea className="min-h-0 flex-1">
       {isLoading && !schema && <SchemaLoadingState />}
       {error && <SchemaErrorState error={error} onRetry={onRetry} />}
-      {schema && <SchemaTree schema={schema} filter={filter} />}
+      {schema && (
+        <SchemaTree
+          schema={schema}
+          filter={filter}
+          pinnedTables={pinnedTables}
+          onTogglePin={onTogglePin}
+        />
+      )}
     </ScrollArea>
   </>
 );
@@ -171,6 +183,7 @@ export const WorkspaceSidebar = ({
   setSelectedDatabase,
 }: WorkspaceSidebarProps) => {
   const [filter, setFilter] = useState("");
+  const { pinnedTables, togglePin } = usePinnedTables(connection.id);
 
   const handleFilterChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -235,6 +248,8 @@ export const WorkspaceSidebar = ({
             filter={filter}
             onFilterChange={handleFilterChange}
             onRetry={refresh}
+            pinnedTables={pinnedTables}
+            onTogglePin={togglePin}
           />
         </TabsContent>
 

--- a/apps/web/src/hooks/use-pinned-tables.ts
+++ b/apps/web/src/hooks/use-pinned-tables.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+
+import { getPinnedTables, savePinnedTables } from "@/lib/pinned-tables";
+
+export const usePinnedTables = (connectionId: string) => {
+  const [pinnedTables, setPinnedTables] = useState<string[]>(() =>
+    getPinnedTables(connectionId)
+  );
+
+  const togglePin = useCallback(
+    (tableName: string) => {
+      setPinnedTables((prev) => {
+        const next = prev.includes(tableName)
+          ? prev.filter((t) => t !== tableName)
+          : [...prev, tableName];
+        savePinnedTables(connectionId, next);
+        return next;
+      });
+    },
+    [connectionId]
+  );
+
+  const isPinned = useCallback(
+    (tableName: string) => pinnedTables.includes(tableName),
+    [pinnedTables]
+  );
+
+  return { isPinned, pinnedTables, togglePin };
+};

--- a/apps/web/src/lib/pinned-tables.ts
+++ b/apps/web/src/lib/pinned-tables.ts
@@ -1,0 +1,23 @@
+const STORAGE_KEY_PREFIX = "oh-my-query-pinned-tables-";
+
+export const getPinnedTables = (connectionId: string): string[] => {
+  const raw = localStorage.getItem(`${STORAGE_KEY_PREFIX}${connectionId}`);
+  if (!raw) {
+    return [];
+  }
+  try {
+    return JSON.parse(raw) as string[];
+  } catch {
+    return [];
+  }
+};
+
+export const savePinnedTables = (
+  connectionId: string,
+  tables: string[]
+): void => {
+  localStorage.setItem(
+    `${STORAGE_KEY_PREFIX}${connectionId}`,
+    JSON.stringify(tables)
+  );
+};

--- a/apps/web/src/lib/sql-templates.ts
+++ b/apps/web/src/lib/sql-templates.ts
@@ -1,0 +1,35 @@
+import type { TableItem, ViewItem } from "@/lib/tauri";
+
+export const generateSelectTop100 = (tableName: string): string =>
+  `SELECT * FROM ${tableName} LIMIT 100;`;
+
+export const generateDropTable = (tableName: string, isView: boolean): string =>
+  isView ? `DROP VIEW ${tableName};` : `DROP TABLE ${tableName};`;
+
+export const generateTruncateTable = (tableName: string): string =>
+  `TRUNCATE TABLE ${tableName};`;
+
+export const generateCreateTable = (
+  table: TableItem | ViewItem,
+  isView: boolean
+): string => {
+  if (isView) {
+    return `-- CREATE VIEW statement not available from schema metadata\n-- View: ${table.name}`;
+  }
+
+  const columnDefs = table.columns.map((col) => {
+    const parts = [`  ${col.name} ${col.dataType}`];
+    if (col.isPrimaryKey) {
+      parts.push("PRIMARY KEY");
+    }
+    if (!col.isNullable) {
+      parts.push("NOT NULL");
+    }
+    if (col.defaultValue !== null) {
+      parts.push(`DEFAULT ${col.defaultValue}`);
+    }
+    return parts.join(" ");
+  });
+
+  return `CREATE TABLE ${table.name} (\n${columnDefs.join(",\n")}\n);`;
+};


### PR DESCRIPTION
## Summary
Implements right-click context menu for tables in the schema sidebar with quick actions: Select top 100, Copy name, Pin/Unpin, Copy as (Create/Drop/Truncate), and Drop. Pinned tables are persisted per connection and sort to the top with a visual pin icon indicator.

## Changes
- New utility functions for SQL generation (SELECT/DROP/TRUNCATE/CREATE)
- localStorage-based pin state management scoped per connection
- Context menu component with submenus for copy and destructive actions
- Pin sorting and indicator in table node display
- Pin state threaded through sidebar and schema tree components

## Testing
- Right-click table → context menu appears with all options
- "Select top 100" and "Drop" open new tabs without auto-executing
- "Copy name/Create/Drop/Truncate" copy to clipboard
- Pin toggle moves tables to top and shows icon
- Views hide Truncate option
- Left-click still expands/collapses normally