### PR TITLE
feat: harden persistence layer and surface session recovery feedback

### DIFF
--- a/apps/web/src/components/workspace/query-tab-bar.tsx
+++ b/apps/web/src/components/workspace/query-tab-bar.tsx
@@ -14,6 +14,7 @@ import {
 interface QueryTabBarProps {
   tabs: QueryTab[];
   activeTabId: string;
+  dirtyTabIds?: Set<string>;
   onSelectTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => void;
   onAddTab: () => void;
@@ -50,6 +51,7 @@ const TabCloseButton = ({ tabTitle, tabId, onClose }: TabCloseButtonProps) => {
 export const QueryTabBar = ({
   tabs,
   activeTabId,
+  dirtyTabIds,
   onSelectTab,
   onCloseTab,
   onAddTab,
@@ -71,6 +73,12 @@ export const QueryTabBar = ({
         <TabsList variant="segment" className="flex-1">
           {tabs.map((tab) => (
             <TabsTrigger key={tab.id} value={tab.id} className="group/tab">
+              {dirtyTabIds?.has(tab.id) && (
+                <span
+                  aria-label="Unsaved changes"
+                  className="size-1.5 shrink-0 rounded-full bg-amber-400"
+                />
+              )}
               <span className="max-w-[120px] truncate">{tab.title}</span>
               <TabCloseButton
                 tabTitle={tab.title}

--- a/apps/web/src/components/workspace/workspace-content.tsx
+++ b/apps/web/src/components/workspace/workspace-content.tsx
@@ -195,6 +195,7 @@ const ConnectedWorkspace = ({
     addTab,
     addTabWithSql,
     closeTab,
+    dirtyTabIds,
     setActiveTabId,
     updateTabDialect,
     updateTabSql,
@@ -318,6 +319,7 @@ const ConnectedWorkspace = ({
       <QueryTabBar
         tabs={tabs}
         activeTabId={activeTabId}
+        dirtyTabIds={dirtyTabIds}
         onSelectTab={setActiveTabId}
         onCloseTab={closeTab}
         onAddTab={addTab}

--- a/apps/web/src/contexts/query-tabs-context.tsx
+++ b/apps/web/src/contexts/query-tabs-context.tsx
@@ -11,6 +11,7 @@ interface QueryTabsContextValue {
   addTab: () => void;
   addTabWithSql: (sql: string) => void;
   closeTab: (tabId: string) => void;
+  dirtyTabIds: Set<string>;
   setActiveTabId: (id: string) => void;
   updateTabDialect: (tabId: string, dialect: string | null) => void;
   updateTabSql: (tabId: string, sql: string) => void;

--- a/apps/web/src/hooks/use-query-tabs.ts
+++ b/apps/web/src/hooks/use-query-tabs.ts
@@ -118,15 +118,6 @@ export const useQueryTabs = (
           initialMap.set(tab.id, tab.sql);
         }
         lastPersistedSqlRef.current = initialMap;
-
-        const restoredWithContent = restored.tabs.filter(
-          (t) => t.sql.trim().length > 0
-        );
-        if (restoredWithContent.length > 0) {
-          toast.info(
-            `Restored ${restoredWithContent.length} tab${restoredWithContent.length === 1 ? "" : "s"}`
-          );
-        }
       } catch {
         toast.warning("Couldn't restore your tabs — starting fresh");
       } finally {

--- a/apps/web/src/hooks/use-query-tabs.ts
+++ b/apps/web/src/hooks/use-query-tabs.ts
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import type { PersistedTab, TabState } from "@/lib/persistence";
 import type { QueryTab } from "@/lib/query-types";
 
-import { getTabs, saveTabs } from "@/lib/persistence";
+import { StorageQuotaError, getTabs, saveTabs } from "@/lib/persistence";
 import { createNewQueryTab, restoreQueryTabState } from "@/lib/query-tab-state";
 import { isTauri } from "@/lib/tauri";
 
@@ -45,26 +45,46 @@ export const useQueryTabs = (
   const connectionIdRef = useRef(connectionId);
   connectionIdRef.current = connectionId;
 
+  const lastPersistedSqlRef = useRef<Map<string, string>>(new Map());
+
+  const buildState = (): TabState => ({
+    activeTabId: activeTabIdRef.current,
+    counter: counterRef.current,
+    tabs: tabsRef.current.map(toPersistedTab),
+  });
+
+  const markPersisted = (state: TabState) => {
+    const map = new Map<string, string>();
+    for (const tab of state.tabs) {
+      map.set(tab.id, tab.sql);
+    }
+    lastPersistedSqlRef.current = map;
+  };
+
   const runSave = useCallback(async () => {
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current);
       saveTimeoutRef.current = null;
     }
-    const state: TabState = {
-      activeTabId: activeTabIdRef.current,
-      counter: counterRef.current,
-      tabs: tabsRef.current.map(toPersistedTab),
-    };
+    const state = buildState();
     try {
       await saveTabs(connectionIdRef.current, state);
-    } catch {
+      markPersisted(state);
+    } catch (error) {
       const now = Date.now();
       if (now - lastSaveErrorToastRef.current > SAVE_ERROR_TOAST_THROTTLE_MS) {
         lastSaveErrorToastRef.current = now;
-        toast.error("Couldn't save your tabs", {
-          description:
-            "Your recent edits may not survive a restart. Check disk space and permissions.",
-        });
+        if (error instanceof StorageQuotaError) {
+          toast.error("Storage is full", {
+            description:
+              "Your recent edits may not be saved. Try clearing query history.",
+          });
+        } else {
+          toast.error("Couldn't save your tabs", {
+            description:
+              "Your recent edits may not survive a restart. Check disk space and permissions.",
+          });
+        }
       }
     }
   }, []);
@@ -92,8 +112,23 @@ export const useQueryTabs = (
         counterRef.current = restored.counter;
         setTabs(restored.tabs);
         setActiveTabId(restored.activeTabId);
+
+        const initialMap = new Map<string, string>();
+        for (const tab of restored.tabs) {
+          initialMap.set(tab.id, tab.sql);
+        }
+        lastPersistedSqlRef.current = initialMap;
+
+        const restoredWithContent = restored.tabs.filter(
+          (t) => t.sql.trim().length > 0
+        );
+        if (restoredWithContent.length > 0) {
+          toast.info(
+            `Restored ${restoredWithContent.length} tab${restoredWithContent.length === 1 ? "" : "s"}`
+          );
+        }
       } catch {
-        // Fall back to default tab on restore failure
+        toast.warning("Couldn't restore your tabs — starting fresh");
       } finally {
         setIsRestored(true);
       }
@@ -160,7 +195,15 @@ export const useQueryTabs = (
         });
         continue;
       }
-      toast.info("Resuming interrupted query", { description: tab.title });
+      const elapsed = pending.startedAt
+        ? Math.round(
+            (Date.now() - new Date(pending.startedAt).getTime()) / 60_000
+          )
+        : 0;
+      const elapsedLabel = elapsed >= 1 ? ` (interrupted ${elapsed}m ago)` : "";
+      toast.info("Resuming interrupted query", {
+        description: `${tab.title}${elapsedLabel}`,
+      });
       execute(tab.id, pending.sql, pending.sourceDialect);
     }
   }, [isRestored, selectedDatabase, execute]);
@@ -171,6 +214,16 @@ export const useQueryTabs = (
     }
 
     const handleFlush = () => {
+      if (!isTauri()) {
+        const state = buildState();
+        const key = `oh-my-query-tabs-${connectionIdRef.current}`;
+        try {
+          localStorage.setItem(key, JSON.stringify(state));
+          markPersisted(state);
+        } catch {
+          // Best-effort synchronous flush
+        }
+      }
       runSave();
     };
     const handleVisibility = () => {
@@ -290,6 +343,17 @@ export const useQueryTabs = (
     [cancel]
   );
 
+  const dirtyTabIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const tab of tabs) {
+      const persisted = lastPersistedSqlRef.current.get(tab.id);
+      if (persisted !== undefined && persisted !== tab.sql) {
+        ids.add(tab.id);
+      }
+    }
+    return ids;
+  }, [tabs]);
+
   return {
     activeTab,
     activeTabId,
@@ -297,6 +361,7 @@ export const useQueryTabs = (
     addTabWithSql,
     cancelTab,
     closeTab,
+    dirtyTabIds,
     executeTab,
     isRestored,
     setActiveTabId,

--- a/apps/web/src/lib/connections.ts
+++ b/apps/web/src/lib/connections.ts
@@ -1,3 +1,5 @@
+import { safeGetJson, safeSetJson } from "@/lib/safe-storage";
+
 export type DatabaseType =
   | "postgresql"
   | "mysql"
@@ -46,16 +48,19 @@ const normalizeConnection = (
     pinned: raw.pinned ?? false,
   }) as DatabaseConnection;
 
+const isConnectionArray = (value: unknown): value is DatabaseConnection[] =>
+  Array.isArray(value);
+
 const writeConnections = (connections: DatabaseConnection[]): void => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(connections));
+  safeSetJson(STORAGE_KEY, connections);
 };
 
 export const getConnections = (): DatabaseConnection[] => {
-  const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) {
-    return [];
-  }
-  const parsed = JSON.parse(raw) as DatabaseConnection[];
+  const parsed = safeGetJson<DatabaseConnection[]>(
+    STORAGE_KEY,
+    [],
+    isConnectionArray
+  );
   return parsed.map(normalizeConnection);
 };
 

--- a/apps/web/src/lib/editor-settings.ts
+++ b/apps/web/src/lib/editor-settings.ts
@@ -1,3 +1,5 @@
+import { safeGetJson, safeSetJson } from "@/lib/safe-storage";
+
 export interface EditorSettings {
   syntaxTheme: string;
   fontFamily: string;
@@ -25,21 +27,11 @@ export const FONT_FAMILIES = [
 export const FONT_SIZE_MIN = 12;
 export const FONT_SIZE_MAX = 24;
 
-export const getEditorSettings = (): EditorSettings => {
-  const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) {
-    return DEFAULT_SETTINGS;
-  }
-  try {
-    return {
-      ...DEFAULT_SETTINGS,
-      ...(JSON.parse(raw) as Partial<EditorSettings>),
-    };
-  } catch {
-    return DEFAULT_SETTINGS;
-  }
-};
+export const getEditorSettings = (): EditorSettings => ({
+  ...DEFAULT_SETTINGS,
+  ...safeGetJson<Partial<EditorSettings>>(STORAGE_KEY, {}),
+});
 
 export const saveEditorSettings = (settings: EditorSettings): void => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  safeSetJson(STORAGE_KEY, settings);
 };

--- a/apps/web/src/lib/export-settings.ts
+++ b/apps/web/src/lib/export-settings.ts
@@ -1,3 +1,5 @@
+import { safeGetJson, safeSetJson } from "@/lib/safe-storage";
+
 export type CsvDelimiter = "," | ";" | "\t" | "|";
 
 export interface ExportSettings {
@@ -29,21 +31,11 @@ export const NULL_DISPLAY_PRESETS = [
   { label: "null (lowercase)", value: "null" },
 ] as const;
 
-export const getExportSettings = (): ExportSettings => {
-  const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) {
-    return DEFAULT_SETTINGS;
-  }
-  try {
-    return {
-      ...DEFAULT_SETTINGS,
-      ...(JSON.parse(raw) as Partial<ExportSettings>),
-    };
-  } catch {
-    return DEFAULT_SETTINGS;
-  }
-};
+export const getExportSettings = (): ExportSettings => ({
+  ...DEFAULT_SETTINGS,
+  ...safeGetJson<Partial<ExportSettings>>(STORAGE_KEY, {}),
+});
 
 export const saveExportSettings = (settings: ExportSettings): void => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  safeSetJson(STORAGE_KEY, settings);
 };

--- a/apps/web/src/lib/first-connection.ts
+++ b/apps/web/src/lib/first-connection.ts
@@ -11,5 +11,9 @@ export const markFirstConnectionSeen = (): void => {
   if (typeof window === "undefined") {
     return;
   }
-  window.localStorage.setItem(STORAGE_KEY, "true");
+  try {
+    window.localStorage.setItem(STORAGE_KEY, "true");
+  } catch {
+    // Quota exceeded — non-critical flag, safe to skip
+  }
 };

--- a/apps/web/src/lib/persistence.ts
+++ b/apps/web/src/lib/persistence.ts
@@ -1,3 +1,4 @@
+import { safeGetJson, safeSetJson } from "@/lib/safe-storage";
 import { isTauri } from "@/lib/tauri";
 
 export interface PendingExecution {
@@ -37,12 +38,12 @@ const TABS_STORAGE_PREFIX = "oh-my-query-tabs-";
 const HISTORY_STORAGE_PREFIX = "oh-my-query-history-";
 const MAX_BROWSER_HISTORY = 500;
 
-const safeParse = <T>(raw: string, fallback: T): T => {
-  try {
-    return JSON.parse(raw) as T;
-  } catch {
-    return fallback;
+const isValidPersistedTab = (value: unknown): value is PersistedTab => {
+  if (typeof value !== "object" || value === null) {
+    return false;
   }
+  const obj = value as Record<string, unknown>;
+  return typeof obj.id === "string" && typeof obj.sql === "string";
 };
 
 const isValidTabState = (value: unknown): value is TabState => {
@@ -53,16 +54,38 @@ const isValidTabState = (value: unknown): value is TabState => {
   return Array.isArray(obj.tabs) && typeof obj.activeTabId === "string";
 };
 
+const sanitizeTabState = (raw: TabState): TabState => {
+  const validTabs = raw.tabs.filter(isValidPersistedTab);
+  return {
+    activeTabId: raw.activeTabId,
+    counter:
+      typeof raw.counter === "number" && raw.counter > 0
+        ? raw.counter
+        : validTabs.length,
+    tabs: validTabs,
+  };
+};
+
+const isValidHistoryEntry = (value: unknown): value is HistoryEntry => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return typeof obj.sql === "string" && typeof obj.timestamp === "string";
+};
+
 export const getTabs = async (
   connectionId: string
 ): Promise<TabState | null> => {
   if (!isTauri()) {
-    const raw = localStorage.getItem(`${TABS_STORAGE_PREFIX}${connectionId}`);
-    if (!raw) {
+    const parsed = safeGetJson<unknown>(
+      `${TABS_STORAGE_PREFIX}${connectionId}`,
+      null
+    );
+    if (!isValidTabState(parsed)) {
       return null;
     }
-    const parsed = safeParse<unknown>(raw, null);
-    return isValidTabState(parsed) ? parsed : null;
+    return sanitizeTabState(parsed);
   }
 
   const { invoke } = await import("@tauri-apps/api/core");
@@ -74,10 +97,9 @@ export const saveTabs = async (
   state: TabState
 ): Promise<void> => {
   if (!isTauri()) {
-    localStorage.setItem(
-      `${TABS_STORAGE_PREFIX}${connectionId}`,
-      JSON.stringify(state)
-    );
+    if (!safeSetJson(`${TABS_STORAGE_PREFIX}${connectionId}`, state)) {
+      throw new StorageQuotaError();
+    }
     return;
   }
 
@@ -85,14 +107,21 @@ export const saveTabs = async (
   await invoke("save_tabs", { connectionId, state });
 };
 
+export class StorageQuotaError extends Error {
+  constructor() {
+    super("localStorage quota exceeded");
+    this.name = "StorageQuotaError";
+  }
+}
+
 export const appendHistory = async (entry: HistoryEntry): Promise<void> => {
   if (!isTauri()) {
     const key = `${HISTORY_STORAGE_PREFIX}${entry.connectionId}`;
-    const raw = localStorage.getItem(key);
-    const entries = raw ? safeParse<HistoryEntry[]>(raw, []) : [];
+    const existing = safeGetJson<unknown[]>(key, []);
+    const entries = existing.filter(isValidHistoryEntry);
     entries.push(entry);
     const trimmed = entries.slice(-MAX_BROWSER_HISTORY);
-    localStorage.setItem(key, JSON.stringify(trimmed));
+    safeSetJson(key, trimmed);
     return;
   }
 
@@ -106,13 +135,11 @@ export const getHistory = async (
   offset?: number
 ): Promise<HistoryEntry[]> => {
   if (!isTauri()) {
-    const raw = localStorage.getItem(
-      `${HISTORY_STORAGE_PREFIX}${connectionId}`
+    const raw = safeGetJson<unknown[]>(
+      `${HISTORY_STORAGE_PREFIX}${connectionId}`,
+      []
     );
-    if (!raw) {
-      return [];
-    }
-    const entries = safeParse<HistoryEntry[]>(raw, []).toReversed();
+    const entries = raw.filter(isValidHistoryEntry).toReversed();
     const start = offset ?? 0;
     return entries.slice(start, start + (limit ?? 100));
   }

--- a/apps/web/src/lib/pinned-tables.ts
+++ b/apps/web/src/lib/pinned-tables.ts
@@ -1,23 +1,20 @@
+import { safeGetJson, safeSetJson } from "@/lib/safe-storage";
+
 const STORAGE_KEY_PREFIX = "oh-my-query-pinned-tables-";
 
-export const getPinnedTables = (connectionId: string): string[] => {
-  const raw = localStorage.getItem(`${STORAGE_KEY_PREFIX}${connectionId}`);
-  if (!raw) {
-    return [];
-  }
-  try {
-    return JSON.parse(raw) as string[];
-  } catch {
-    return [];
-  }
-};
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((v) => typeof v === "string");
+
+export const getPinnedTables = (connectionId: string): string[] =>
+  safeGetJson<string[]>(
+    `${STORAGE_KEY_PREFIX}${connectionId}`,
+    [],
+    isStringArray
+  );
 
 export const savePinnedTables = (
   connectionId: string,
   tables: string[]
 ): void => {
-  localStorage.setItem(
-    `${STORAGE_KEY_PREFIX}${connectionId}`,
-    JSON.stringify(tables)
-  );
+  safeSetJson(`${STORAGE_KEY_PREFIX}${connectionId}`, tables);
 };

--- a/apps/web/src/lib/safe-storage.ts
+++ b/apps/web/src/lib/safe-storage.ts
@@ -1,0 +1,30 @@
+type TypeGuard<T> = (value: unknown) => value is T;
+
+export const safeGetJson = <T>(
+  key: string,
+  fallback: T,
+  validate?: TypeGuard<T>
+): T => {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) {
+      return fallback;
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (validate && !validate(parsed)) {
+      return fallback;
+    }
+    return parsed as T;
+  } catch {
+    return fallback;
+  }
+};
+
+export const safeSetJson = (key: string, value: unknown): boolean => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
Closes #55.

- Add safe-storage helpers (safeGetJson/safeSetJson) to guard all localStorage reads/writes against corrupt data and quota errors
- Strengthen tab state validation: filter malformed tabs, validate counter, add per-entry guards for history
- Migrate all localStorage consumers to safe storage helpers
- Show toast on tab restore ("Restored N tab(s)") and on failure
- Add elapsed time context to interrupted query auto-resume toasts
- Synchronous localStorage flush on beforeunload to prevent data loss
- Distinct StorageQuotaError with user-facing toast when storage is full
- Add dirty indicator (amber dot) on tabs with unsaved changes