### PR TITLE
feat(ai): wire active workspace context into chat

### DIFF
--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -23,9 +23,7 @@
         "hiddenTitle": true,
         "transparent": true,
         "windowEffects": {
-          "effects": [
-            "sidebar"
-          ],
+          "effects": ["sidebar"],
           "state": "followsWindowActiveState"
         }
       }

--- a/apps/web/src/components/workspace/chat/chat-sidebar.tsx
+++ b/apps/web/src/components/workspace/chat/chat-sidebar.tsx
@@ -1,5 +1,5 @@
 import { MessageSquare, RotateCw, X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type { AIAction } from "@/lib/ai-actions";
 import type { DatabaseConnection } from "@/lib/connections";
@@ -8,6 +8,7 @@ import type { SchemaInfo } from "@/lib/tauri";
 import { Suggestion, Suggestions } from "@/components/ai-elements/suggestion";
 import { Button } from "@/components/ui/button";
 import { AISettingsDialog } from "@/components/workspace/ai-settings-dialog";
+import { useOptionalActiveQuery } from "@/contexts/active-query-context";
 import { useEditorInsert } from "@/contexts/editor-insert-context";
 import { useAiChat } from "@/hooks/use-ai-chat";
 import { composeActionMessage } from "@/lib/ai-actions";
@@ -17,11 +18,52 @@ import { ChatError } from "./chat-error";
 import { ChatInput } from "./chat-input";
 import { ChatMessageList } from "./chat-message-list";
 
-const SQL_SUGGESTIONS = [
+const DEFAULT_SUGGESTIONS = [
   "Show all tables",
   "Count rows in each table",
   "Describe the schema",
 ];
+
+interface SuggestionContext {
+  hasError: boolean;
+  hasResult: boolean;
+  hasSelection: boolean;
+  hasSql: boolean;
+  isRunning: boolean;
+}
+
+const buildSuggestions = (ctx: SuggestionContext | null): string[] => {
+  if (!ctx) {
+    return DEFAULT_SUGGESTIONS;
+  }
+
+  const suggestions: string[] = [];
+
+  if (ctx.hasError) {
+    suggestions.push("Explain this error", "Fix the failing query");
+  }
+  if (ctx.hasSelection) {
+    suggestions.push("Explain the selected SQL");
+  }
+  if (ctx.hasSql && !ctx.hasSelection) {
+    suggestions.push("Explain my current query");
+  }
+  if (ctx.hasResult && !ctx.hasError) {
+    suggestions.push("Summarize these results", "Suggest a follow-up query");
+  }
+  if (ctx.isRunning) {
+    suggestions.push("What is this query doing?");
+  }
+  if (ctx.hasSql && !ctx.hasError) {
+    suggestions.push("Optimize this query");
+  }
+
+  if (suggestions.length === 0) {
+    return DEFAULT_SUGGESTIONS;
+  }
+
+  return suggestions.slice(0, 4);
+};
 
 interface ChatSidebarProps {
   connection: DatabaseConnection;
@@ -38,6 +80,7 @@ export const ChatSidebar = ({
   pendingAction,
   onPendingActionConsumed,
 }: ChatSidebarProps) => {
+  const activeQuery = useOptionalActiveQuery();
   const {
     messages,
     isStreaming,
@@ -49,8 +92,25 @@ export const ChatSidebar = ({
     clearMessages,
   } = useAiChat({
     databaseType: connection.type,
+    getSnapshot: activeQuery?.getSnapshot,
     schema,
   });
+
+  const suggestions = useMemo(
+    () =>
+      buildSuggestions(
+        activeQuery
+          ? {
+              hasError: activeQuery.meta.hasError,
+              hasResult: activeQuery.meta.hasResult,
+              hasSelection: activeQuery.meta.hasSelection,
+              hasSql: activeQuery.meta.hasSql,
+              isRunning: activeQuery.meta.isRunning,
+            }
+          : null
+      ),
+    [activeQuery]
+  );
 
   const {
     insertAtCursor,
@@ -144,7 +204,7 @@ export const ChatSidebar = ({
       />
       {messages.length === 0 && (
         <Suggestions className="flex-wrap justify-center px-3 pb-2">
-          {SQL_SUGGESTIONS.map((s) => (
+          {suggestions.map((s) => (
             <Suggestion key={s} suggestion={s} onClick={sendMessage} />
           ))}
         </Suggestions>

--- a/apps/web/src/components/workspace/workspace-content.tsx
+++ b/apps/web/src/components/workspace/workspace-content.tsx
@@ -17,12 +17,13 @@ import {
 } from "@/components/ui/resizable";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CloseConfirmDialog } from "@/components/workspace/close-confirm-dialog";
+import { useActiveQuery } from "@/contexts/active-query-context";
 import { useEditorInsert } from "@/contexts/editor-insert-context";
-import { useQueryExecution } from "@/contexts/query-execution-context";
 import {
   QueryTabsProvider,
   useQueryTabsContext,
 } from "@/contexts/query-tabs-context";
+import { useActiveQuerySync } from "@/hooks/use-active-query-sync";
 import { useExportSettings } from "@/hooks/use-export-settings";
 import { useQueryTabs } from "@/hooks/use-query-tabs";
 import { useSyntaxTree } from "@/hooks/use-syntax-tree";
@@ -72,7 +73,12 @@ interface WorkspaceContentProps {
   onReconnect: () => void;
   onAiAction?: (
     action: AIActionType,
-    context?: { sql?: string; error?: string }
+    context?: {
+      sql?: string;
+      error?: string;
+      errorCode?: string | null;
+      isSelection?: boolean;
+    }
   ) => void;
   schema: SchemaInfo | null;
   selectedDatabase: string | null;
@@ -190,7 +196,12 @@ interface ConnectedWorkspaceProps {
   isSql: boolean;
   onAiAction?: (
     action: AIActionType,
-    context?: { sql?: string; error?: string }
+    context?: {
+      sql?: string;
+      error?: string;
+      errorCode?: string | null;
+      isSelection?: boolean;
+    }
   ) => void;
 }
 
@@ -227,9 +238,11 @@ const ConnectedWorkspace = ({
     executeTab,
   } = useQueryTabsContext();
 
-  const { setExecutionState } = useQueryExecution();
+  const { setSelectedSql: setActiveSelectedSql } = useActiveQuery();
   const { getSelectedText, registerQueryTable, registerOpenQuery } =
     useEditorInsert();
+
+  useActiveQuerySync(activeTab);
 
   const [isSyntaxTreeOpen, setIsSyntaxTreeOpen] = useState(false);
   const [hasSelection, setHasSelection] = useState(false);
@@ -240,21 +253,6 @@ const ConnectedWorkspace = ({
   const toggleSyntaxTree = useCallback(() => {
     setIsSyntaxTreeOpen((prev) => !prev);
   }, []);
-
-  useEffect(() => {
-    if (activeTab?.status) {
-      setExecutionState({
-        error: activeTab.error ?? null,
-        result: activeTab.result ?? null,
-        status: activeTab.status,
-      });
-    }
-  }, [
-    activeTab?.status,
-    activeTab?.result,
-    activeTab?.error,
-    setExecutionState,
-  ]);
 
   const handleQueryTable = useCallback(
     (tableName: string) => {
@@ -285,12 +283,16 @@ const ConnectedWorkspace = ({
       if (syntaxTreeEnabled) {
         handleSyntaxTreeUpdate(update);
       }
-      if (update.selectionSet) {
+      if (update.selectionSet || update.docChanged) {
         const { from, to } = update.state.selection.main;
-        setHasSelection(from !== to);
+        const isSelecting = from !== to;
+        setHasSelection(isSelecting);
+        setActiveSelectedSql(
+          isSelecting ? update.state.sliceDoc(from, to) : null
+        );
       }
     },
-    [syntaxTreeEnabled, handleSyntaxTreeUpdate]
+    [syntaxTreeEnabled, handleSyntaxTreeUpdate, setActiveSelectedSql]
   );
 
   const editorDialect = resolveEditorDialect(
@@ -332,9 +334,16 @@ const ConnectedWorkspace = ({
 
   const handleAiAction = useCallback(
     (action: AIActionType) => {
-      const sql = getSelectedText() || activeTab?.sql || "";
+      const selected = getSelectedText();
+      const sql = selected || activeTab?.sql || "";
       const error = activeTab?.error ?? undefined;
-      onAiAction?.(action, { error, sql });
+      const errorCode = activeTab?.errorCode ?? null;
+      onAiAction?.(action, {
+        error,
+        errorCode,
+        isSelection: Boolean(selected),
+        sql,
+      });
     },
     [activeTab, getSelectedText, onAiAction]
   );
@@ -342,7 +351,8 @@ const ConnectedWorkspace = ({
   const handleAiExplainError = useCallback(() => {
     const sql = activeTab?.executedSql ?? activeTab?.sql ?? "";
     const error = activeTab?.error ?? undefined;
-    onAiAction?.("fix", { error, sql });
+    const errorCode = activeTab?.errorCode ?? null;
+    onAiAction?.("fix", { error, errorCode, sql });
   }, [activeTab, onAiAction]);
 
   useWorkspaceHotkeys({

--- a/apps/web/src/components/workspace/workspace-layout.tsx
+++ b/apps/web/src/components/workspace/workspace-layout.tsx
@@ -143,9 +143,19 @@ export const WorkspaceLayout = ({
   }, [chatPanelRef]);
 
   const handleAiAction = useCallback(
-    (action: AIActionType, context?: { sql?: string; error?: string }) => {
+    (
+      action: AIActionType,
+      context?: {
+        sql?: string;
+        error?: string;
+        errorCode?: string | null;
+        isSelection?: boolean;
+      }
+    ) => {
       const aiAction: AIAction = {
         error: context?.error,
+        errorCode: context?.errorCode ?? null,
+        isSelection: context?.isSelection,
         sql: context?.sql,
         type: action,
       };

--- a/apps/web/src/contexts/active-query-context.tsx
+++ b/apps/web/src/contexts/active-query-context.tsx
@@ -1,0 +1,192 @@
+import type { ReactNode } from "react";
+
+import {
+  createContext,
+  use,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import type { ExecuteResult } from "@/lib/tauri";
+
+export type ActiveQueryStatus = "idle" | "running" | "success" | "error";
+
+export interface ActiveQuerySnapshot {
+  activeSql: string;
+  selectedSql: string | null;
+  executedSql: string | null;
+  runningSql: string | null;
+  result: ExecuteResult | null;
+  error: string | null;
+  errorCode: string | null;
+  status: ActiveQueryStatus;
+  tabTitle: string | null;
+}
+
+interface ActiveQueryMeta {
+  hasSql: boolean;
+  hasSelection: boolean;
+  hasResult: boolean;
+  hasError: boolean;
+  isRunning: boolean;
+  status: ActiveQueryStatus;
+  tabTitle: string | null;
+}
+
+interface ActiveQueryContextValue {
+  meta: ActiveQueryMeta;
+  getSnapshot: () => ActiveQuerySnapshot;
+  setActiveSql: (sql: string) => void;
+  setSelectedSql: (text: string | null) => void;
+  setExecutionSnapshot: (input: {
+    executedSql: string | null;
+    runningSql: string | null;
+    result: ExecuteResult | null;
+    error: string | null;
+    errorCode: string | null;
+    status: ActiveQueryStatus;
+  }) => void;
+  setTabTitle: (title: string | null) => void;
+}
+
+const EMPTY_SNAPSHOT: ActiveQuerySnapshot = {
+  activeSql: "",
+  error: null,
+  errorCode: null,
+  executedSql: null,
+  result: null,
+  runningSql: null,
+  selectedSql: null,
+  status: "idle",
+  tabTitle: null,
+};
+
+const EMPTY_META: ActiveQueryMeta = {
+  hasError: false,
+  hasResult: false,
+  hasSelection: false,
+  hasSql: false,
+  isRunning: false,
+  status: "idle",
+  tabTitle: null,
+};
+
+const ActiveQueryContext = createContext<ActiveQueryContextValue | null>(null);
+
+const deriveMeta = (snapshot: ActiveQuerySnapshot): ActiveQueryMeta => ({
+  hasError: Boolean(snapshot.error),
+  hasResult: Boolean(snapshot.result),
+  hasSelection: Boolean(snapshot.selectedSql?.trim()),
+  hasSql: Boolean(snapshot.activeSql.trim()),
+  isRunning: snapshot.status === "running",
+  status: snapshot.status,
+  tabTitle: snapshot.tabTitle,
+});
+
+const metaEquals = (a: ActiveQueryMeta, b: ActiveQueryMeta): boolean =>
+  a.hasError === b.hasError &&
+  a.hasResult === b.hasResult &&
+  a.hasSelection === b.hasSelection &&
+  a.hasSql === b.hasSql &&
+  a.isRunning === b.isRunning &&
+  a.status === b.status &&
+  a.tabTitle === b.tabTitle;
+
+export const ActiveQueryProvider = ({ children }: { children: ReactNode }) => {
+  const snapshotRef = useRef<ActiveQuerySnapshot>(EMPTY_SNAPSHOT);
+  const [meta, setMeta] = useState<ActiveQueryMeta>(EMPTY_META);
+
+  const writeSnapshot = useCallback((next: ActiveQuerySnapshot) => {
+    snapshotRef.current = next;
+    const nextMeta = deriveMeta(next);
+    setMeta((prev) => (metaEquals(prev, nextMeta) ? prev : nextMeta));
+  }, []);
+
+  const getSnapshot = useCallback(() => snapshotRef.current, []);
+
+  const setActiveSql = useCallback(
+    (sql: string) => {
+      writeSnapshot({ ...snapshotRef.current, activeSql: sql });
+    },
+    [writeSnapshot]
+  );
+
+  const setSelectedSql = useCallback(
+    (text: string | null) => {
+      const normalized = text?.trim() ? text : null;
+      if (snapshotRef.current.selectedSql === normalized) {
+        return;
+      }
+      writeSnapshot({ ...snapshotRef.current, selectedSql: normalized });
+    },
+    [writeSnapshot]
+  );
+
+  const setExecutionSnapshot = useCallback(
+    (input: {
+      executedSql: string | null;
+      runningSql: string | null;
+      result: ExecuteResult | null;
+      error: string | null;
+      errorCode: string | null;
+      status: ActiveQueryStatus;
+    }) => {
+      writeSnapshot({
+        ...snapshotRef.current,
+        error: input.error,
+        errorCode: input.errorCode,
+        executedSql: input.executedSql,
+        result: input.result,
+        runningSql: input.runningSql,
+        status: input.status,
+      });
+    },
+    [writeSnapshot]
+  );
+
+  const setTabTitle = useCallback(
+    (title: string | null) => {
+      if (snapshotRef.current.tabTitle === title) {
+        return;
+      }
+      writeSnapshot({ ...snapshotRef.current, tabTitle: title });
+    },
+    [writeSnapshot]
+  );
+
+  const value = useMemo<ActiveQueryContextValue>(
+    () => ({
+      getSnapshot,
+      meta,
+      setActiveSql,
+      setExecutionSnapshot,
+      setSelectedSql,
+      setTabTitle,
+    }),
+    [
+      getSnapshot,
+      meta,
+      setActiveSql,
+      setExecutionSnapshot,
+      setSelectedSql,
+      setTabTitle,
+    ]
+  );
+
+  return <ActiveQueryContext value={value}>{children}</ActiveQueryContext>;
+};
+
+export const useActiveQuery = (): ActiveQueryContextValue => {
+  const ctx = use(ActiveQueryContext);
+  if (!ctx) {
+    throw new Error(
+      "useActiveQuery must be used within an ActiveQueryProvider"
+    );
+  }
+  return ctx;
+};
+
+export const useOptionalActiveQuery = (): ActiveQueryContextValue | null =>
+  use(ActiveQueryContext);

--- a/apps/web/src/hooks/use-active-query-sync.ts
+++ b/apps/web/src/hooks/use-active-query-sync.ts
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+
+import type { QueryTab } from "@/lib/query-types";
+
+import { useActiveQuery } from "@/contexts/active-query-context";
+import { useQueryExecution } from "@/contexts/query-execution-context";
+
+export const useActiveQuerySync = (activeTab: QueryTab | undefined) => {
+  const { setExecutionState } = useQueryExecution();
+  const { setActiveSql, setExecutionSnapshot, setSelectedSql, setTabTitle } =
+    useActiveQuery();
+
+  useEffect(() => {
+    if (activeTab?.status) {
+      setExecutionState({
+        error: activeTab.error ?? null,
+        result: activeTab.result ?? null,
+        status: activeTab.status,
+      });
+    }
+  }, [
+    activeTab?.status,
+    activeTab?.result,
+    activeTab?.error,
+    setExecutionState,
+  ]);
+
+  useEffect(() => {
+    setActiveSql(activeTab?.sql ?? "");
+  }, [activeTab?.id, activeTab?.sql, setActiveSql]);
+
+  useEffect(() => {
+    setTabTitle(activeTab?.title ?? null);
+  }, [activeTab?.title, setTabTitle]);
+
+  useEffect(() => {
+    setSelectedSql(null);
+  }, [activeTab?.id, setSelectedSql]);
+
+  useEffect(() => {
+    setExecutionSnapshot({
+      error: activeTab?.error ?? null,
+      errorCode: activeTab?.errorCode ?? null,
+      executedSql: activeTab?.executedSql ?? null,
+      result: activeTab?.result ?? null,
+      runningSql: activeTab?.pendingExecution?.sql ?? null,
+      status: activeTab?.status ?? "idle",
+    });
+  }, [
+    activeTab?.status,
+    activeTab?.result,
+    activeTab?.error,
+    activeTab?.errorCode,
+    activeTab?.executedSql,
+    activeTab?.pendingExecution?.sql,
+    setExecutionSnapshot,
+  ]);
+};

--- a/apps/web/src/hooks/use-ai-chat.ts
+++ b/apps/web/src/hooks/use-ai-chat.ts
@@ -1,9 +1,11 @@
 import { streamText } from "ai";
 import { useCallback, useRef, useState } from "react";
 
+import type { ActiveQuerySnapshot } from "@/contexts/active-query-context";
 import type { AIError } from "@/lib/ai-errors";
 import type { SchemaInfo } from "@/lib/tauri";
 
+import { formatActiveQueryContext } from "@/lib/ai-context";
 import { classifyAIError } from "@/lib/ai-errors";
 import { createAIModel } from "@/lib/ai-provider";
 import { buildSystemPrompt } from "@/lib/ai-schema-formatter";
@@ -24,6 +26,7 @@ interface AiChatState {
 interface UseAiChatOptions {
   schema: SchemaInfo | null;
   databaseType: string;
+  getSnapshot?: () => ActiveQuerySnapshot;
 }
 
 const NOT_CONFIGURED_ERROR: AIError = {
@@ -33,7 +36,11 @@ const NOT_CONFIGURED_ERROR: AIError = {
   type: "auth",
 };
 
-export const useAiChat = ({ schema, databaseType }: UseAiChatOptions) => {
+export const useAiChat = ({
+  schema,
+  databaseType,
+  getSnapshot,
+}: UseAiChatOptions) => {
   const [state, setState] = useState<AiChatState>({
     error: null,
     isStreaming: false,
@@ -76,9 +83,16 @@ export const useAiChat = ({ schema, databaseType }: UseAiChatOptions) => {
 
       try {
         const model = createAIModel(settings);
-        const system = schema
+        const baseSystem = schema
           ? buildSystemPrompt(schema, databaseType)
           : `You are a SQL assistant for a ${databaseType} database. Help users write queries, explain SQL, diagnose errors, and suggest optimizations. Wrap SQL in \`\`\`sql code blocks.`;
+
+        const contextBlock = getSnapshot
+          ? formatActiveQueryContext(getSnapshot())
+          : null;
+        const system = contextBlock
+          ? `${baseSystem}\n\n${contextBlock}`
+          : baseSystem;
 
         const allMessages = [
           ...state.messages.map((m) => ({
@@ -137,7 +151,7 @@ export const useAiChat = ({ schema, databaseType }: UseAiChatOptions) => {
         abortRef.current = null;
       }
     },
-    [schema, databaseType, state.messages]
+    [schema, databaseType, state.messages, getSnapshot]
   );
 
   const retry = useCallback(() => {

--- a/apps/web/src/lib/ai-actions.ts
+++ b/apps/web/src/lib/ai-actions.ts
@@ -1,9 +1,13 @@
+import { classifyError } from "@/lib/query-error";
+
 export type AIActionType = "generate" | "explain" | "fix";
 
 export interface AIAction {
   type: AIActionType;
   sql?: string;
   error?: string;
+  errorCode?: string | null;
+  isSelection?: boolean;
 }
 
 export const composeActionMessage = (action: AIAction): string | null => {
@@ -12,15 +16,32 @@ export const composeActionMessage = (action: AIAction): string | null => {
       if (!action.sql?.trim()) {
         return null;
       }
-      return `Explain this SQL query:\n\`\`\`sql\n${action.sql.trim()}\n\`\`\``;
+      const scope = action.isSelection
+        ? "the highlighted selection"
+        : "this SQL query";
+      return `Explain ${scope}, step by step. Call out any tables, joins, or filters that might be non-obvious.\n\n\`\`\`sql\n${action.sql.trim()}\n\`\`\``;
     }
     case "fix": {
       if (!action.sql?.trim() && !action.error?.trim()) {
         return null;
       }
-      const parts = ["Fix this SQL query."];
+      const parts: string[] = [];
       if (action.error?.trim()) {
+        const classification = classifyError(
+          action.error,
+          action.errorCode ?? null
+        );
+        parts.push(
+          `The last query failed with a ${classification.label.toLowerCase()} error. Diagnose the cause and propose a corrected query.`
+        );
         parts.push(`Error: ${action.error.trim()}`);
+        if (classification.hint) {
+          parts.push(`Likely cause: ${classification.hint}`);
+        }
+      } else {
+        parts.push(
+          "Review this SQL query, find issues, and propose a corrected version."
+        );
       }
       if (action.sql?.trim()) {
         parts.push(`\`\`\`sql\n${action.sql.trim()}\n\`\`\``);

--- a/apps/web/src/lib/ai-context.ts
+++ b/apps/web/src/lib/ai-context.ts
@@ -1,0 +1,194 @@
+import type { ActiveQuerySnapshot } from "@/contexts/active-query-context";
+import type { ExecuteResult } from "@/lib/tauri";
+
+import { classifyError } from "@/lib/query-error";
+
+const MAX_QUERY_CHARS = 2000;
+const MAX_SELECTION_CHARS = 1000;
+const MAX_PREVIEW_ROWS = 5;
+const MAX_CELL_CHARS = 80;
+const MAX_DOCUMENT_PREVIEW_CHARS = 600;
+
+const truncate = (text: string, max: number): string =>
+  text.length <= max ? text : `${text.slice(0, max)}… [truncated]`;
+
+const formatCell = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "NULL";
+  }
+  if (typeof value === "string") {
+    return truncate(value, MAX_CELL_CHARS);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return truncate(JSON.stringify(value), MAX_CELL_CHARS);
+  } catch {
+    return "[unserializable]";
+  }
+};
+
+const formatTabularPreview = (
+  result: Extract<ExecuteResult, { resultType: "tabular" }>
+): string => {
+  const totalRows = result.rowCount;
+  const previewCount = Math.min(totalRows, MAX_PREVIEW_ROWS);
+  const columnSummary = result.columns
+    .map((c) => `${c.name} (${c.typeName})`)
+    .join(", ");
+
+  const lines: string[] = [
+    `Last result: ${totalRows} row${totalRows === 1 ? "" : "s"} in ${result.executionTimeMs}ms${result.isTruncated ? " (truncated by engine)" : ""}`,
+    `Columns: ${columnSummary}`,
+  ];
+
+  if (previewCount === 0) {
+    lines.push("(no rows returned)");
+    return lines.join("\n");
+  }
+
+  const header = `| ${result.columns.map((c) => c.name).join(" | ")} |`;
+  const divider = `| ${result.columns.map(() => "---").join(" | ")} |`;
+  lines.push(
+    `Preview (first ${previewCount} of ${totalRows}):`,
+    header,
+    divider
+  );
+
+  for (let i = 0; i < previewCount; i += 1) {
+    const row = result.rows[i];
+    if (!row) {
+      continue;
+    }
+    const cells = result.columns.map((_, idx) => formatCell(row[idx]));
+    lines.push(`| ${cells.join(" | ")} |`);
+  }
+
+  if (totalRows > previewCount) {
+    lines.push(`… and ${totalRows - previewCount} more rows not shown`);
+  }
+
+  return lines.join("\n");
+};
+
+const formatDocumentPreview = (
+  result: Extract<ExecuteResult, { resultType: "documents" }>
+): string => {
+  const total = result.count;
+  const previewCount = Math.min(total, MAX_PREVIEW_ROWS);
+  const lines: string[] = [
+    `Last result: ${total} document${total === 1 ? "" : "s"} in ${result.executionTimeMs}ms${result.isTruncated ? " (truncated by engine)" : ""}`,
+  ];
+
+  if (previewCount === 0) {
+    lines.push("(no documents returned)");
+    return lines.join("\n");
+  }
+
+  lines.push(`Preview (first ${previewCount} of ${total}):`);
+  for (let i = 0; i < previewCount; i += 1) {
+    const doc = result.documents[i];
+    try {
+      lines.push(truncate(JSON.stringify(doc), MAX_DOCUMENT_PREVIEW_CHARS));
+    } catch {
+      lines.push("[unserializable document]");
+    }
+  }
+
+  if (total > previewCount) {
+    lines.push(`… and ${total - previewCount} more documents not shown`);
+  }
+
+  return lines.join("\n");
+};
+
+const formatResult = (result: ExecuteResult): string =>
+  result.resultType === "tabular"
+    ? formatTabularPreview(result)
+    : formatDocumentPreview(result);
+
+const formatError = (error: string, errorCode: string | null): string => {
+  const classification = classifyError(error, errorCode);
+  const lines: string[] = [
+    `Last error (${classification.label}${errorCode ? `, code ${errorCode}` : ""}): ${error.trim()}`,
+  ];
+  if (classification.summary) {
+    lines.push(`Summary: ${classification.summary}`);
+  }
+  if (classification.hint) {
+    lines.push(`Hint: ${classification.hint}`);
+  }
+  return lines.join("\n");
+};
+
+export const hasMeaningfulContext = (snapshot: ActiveQuerySnapshot): boolean =>
+  Boolean(
+    snapshot.activeSql.trim() ||
+    snapshot.selectedSql?.trim() ||
+    snapshot.executedSql?.trim() ||
+    snapshot.result ||
+    snapshot.error ||
+    snapshot.runningSql
+  );
+
+export const formatActiveQueryContext = (
+  snapshot: ActiveQuerySnapshot
+): string | null => {
+  if (!hasMeaningfulContext(snapshot)) {
+    return null;
+  }
+
+  const sections: string[] = ["## Current workspace context"];
+
+  if (snapshot.tabTitle) {
+    sections.push(`Active tab: ${snapshot.tabTitle}`);
+  }
+
+  sections.push(`Status: ${snapshot.status}`);
+
+  if (snapshot.activeSql.trim()) {
+    sections.push(
+      `Active query (what the user is editing right now):\n\`\`\`sql\n${truncate(snapshot.activeSql.trim(), MAX_QUERY_CHARS)}\n\`\`\``
+    );
+  }
+
+  if (snapshot.selectedSql?.trim()) {
+    sections.push(
+      `Selected text (user highlighted this portion):\n\`\`\`sql\n${truncate(snapshot.selectedSql.trim(), MAX_SELECTION_CHARS)}\n\`\`\``
+    );
+  }
+
+  if (
+    snapshot.status === "running" &&
+    snapshot.runningSql?.trim() &&
+    snapshot.runningSql.trim() !== snapshot.activeSql.trim()
+  ) {
+    sections.push(
+      `Running query (currently executing):\n\`\`\`sql\n${truncate(snapshot.runningSql.trim(), MAX_QUERY_CHARS)}\n\`\`\``
+    );
+  }
+
+  if (
+    snapshot.executedSql?.trim() &&
+    snapshot.executedSql.trim() !== snapshot.activeSql.trim()
+  ) {
+    sections.push(
+      `Last executed query:\n\`\`\`sql\n${truncate(snapshot.executedSql.trim(), MAX_QUERY_CHARS)}\n\`\`\``
+    );
+  }
+
+  if (snapshot.result) {
+    sections.push(formatResult(snapshot.result));
+  }
+
+  if (snapshot.error) {
+    sections.push(formatError(snapshot.error, snapshot.errorCode));
+  }
+
+  sections.push(
+    "Use this context to ground your answer in what the user is actually working on. Reference specific tables, columns, values, or errors when relevant. Do not invent data you don't see here."
+  );
+
+  return sections.join("\n\n");
+};

--- a/apps/web/src/routes/workspace/$connectionId.tsx
+++ b/apps/web/src/routes/workspace/$connectionId.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
 import { WorkspaceLayout } from "@/components/workspace/workspace-layout";
+import { ActiveQueryProvider } from "@/contexts/active-query-context";
 import { EditorInsertProvider } from "@/contexts/editor-insert-context";
 import { QueryExecutionProvider } from "@/contexts/query-execution-context";
 import { SafeModeProvider } from "@/contexts/safe-mode-context";
@@ -21,17 +22,19 @@ const WorkspacePage = () => {
   return (
     <SafeModeProvider>
       <QueryExecutionProvider>
-        <EditorInsertProvider>
-          <WorkspaceLayout
-            connection={connection}
-            connectionError={error}
-            isConnected={isConnected}
-            isConnecting={isConnecting}
-            isReconnecting={isReconnecting}
-            onReconnect={reconnect}
-            serverVersion={serverVersion}
-          />
-        </EditorInsertProvider>
+        <ActiveQueryProvider>
+          <EditorInsertProvider>
+            <WorkspaceLayout
+              connection={connection}
+              connectionError={error}
+              isConnected={isConnected}
+              isConnecting={isConnecting}
+              isReconnecting={isReconnecting}
+              onReconnect={reconnect}
+              serverVersion={serverVersion}
+            />
+          </EditorInsertProvider>
+        </ActiveQueryProvider>
       </QueryExecutionProvider>
     </SafeModeProvider>
   );


### PR DESCRIPTION
## Summary
- New `ActiveQueryContext` tracks active/selected/executed SQL, last result, classified error, status, and tab title with a ref-backed snapshot plus a lightweight meta for UI subscribers (so keystrokes don't re-render the chat panel).
- `lib/ai-context.ts` formats a concise "## Current workspace context" block — active query, selection, last result preview (columns + first 5 rows, truncated cells), and classified error hint — which `useAiChat` appends to the system prompt on every send.
- `composeActionMessage` uses the error classification for richer "fix" prompts and distinguishes whole-query vs. selection explanations.
- Chat suggestions are derived from workspace state: error → "Explain this error" / "Fix the failing query"; selection → "Explain the selected SQL"; result → "Summarize these results" / "Suggest a follow-up query"; always → "Optimize this query" when a query is present.

Closes #59

## Test plan
- [ ] Open workspace, type a query, open chat → send any message → verify AI mentions the query
- [ ] Select a portion of SQL → open chat → "Explain the selected SQL" suggestion appears and produces a scoped explanation
- [ ] Run a query that returns rows → open chat → "Summarize these results" returns a grounded summary referencing actual column names
- [ ] Run a query that errors (e.g. typo in table name) → "Fix the failing query" suggestion appears; message references the classification
- [ ] Switch tabs → selection suggestion disappears; snapshot updates to new tab
- [ ] `bun run check-types` passes
- [ ] `bun run fix` reports 0 errors
- [ ] `bun run build` succeeds