### PR TITLE
feat(empty-states): welcome, no-connections, no-results, error with single CTA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,54 @@ jobs:
         with:
           bun-version: "1.3.9"
 
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(bun pm ls --all | grep -Eo 'playwright@[0-9]+\.[0-9]+\.[0-9]+' | head -n1 | cut -d@ -f2)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
+
+      - name: Cache Turborepo
+        uses: actions/cache@v4
+        with:
+          path: |
+            .turbo
+            apps/*/.turbo
+            packages/*/.turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-
 
       - name: Build packages
         run: bun run build
@@ -39,35 +82,38 @@ jobs:
       - name: Type-check
         run: bun run check-types
 
-  rust:
-    name: Rust
+  rust-fmt:
+    name: Rust / fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Rustfmt
+        run: cargo fmt --manifest-path apps/web/src-tauri/Cargo.toml --check
+
+  rust-clippy:
+    name: Rust / clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf \
-            libssl-dev
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev
+          version: 1.0
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy, rustfmt
+          components: clippy
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: "apps/web/src-tauri -> target"
 
-      - name: Cargo check
-        run: cargo check --manifest-path apps/web/src-tauri/Cargo.toml
-
       - name: Clippy
         run: cargo clippy --manifest-path apps/web/src-tauri/Cargo.toml -- -D warnings
-
-      - name: Rustfmt
-        run: cargo fmt --manifest-path apps/web/src-tauri/Cargo.toml --check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ bun run fix          # Auto-fix lint/format issues
 - Do not stop mid-implementation. If a plan has multiple tasks, execute all of them sequentially and only pause for explicit user questions.
 - When fixing CI failures, address the root cause — never loosen thresholds or disable checks to make them pass.
 - Before implementing a GitHub issue, verify the current git branch and create a feature branch if on main.
+- **Always write tests for new implementations.** When you add a new component, hook, or module, colocate a `*.test.tsx` / `*.test.ts` file next to it (Vitest + `@testing-library/react`, jsdom). Cover rendering, primary interactions, and conditional branches — at minimum, the behavior a reviewer would otherwise manually re-verify. Run `bun run test` before declaring the task complete.
 
 ## Monorepo Structure
 

--- a/apps/web/src/components/ui/empty.tsx
+++ b/apps/web/src/components/ui/empty.tsx
@@ -57,9 +57,15 @@ function EmptyMedia({
   );
 }
 
-function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+type EmptyTitleTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "div";
+
+function EmptyTitle({
+  as: Component = "div",
+  className,
+  ...props
+}: React.ComponentProps<"div"> & { as?: EmptyTitleTag }) {
   return (
-    <div
+    <Component
       data-slot="empty-title"
       className={cn("text-sm font-medium tracking-tight", className)}
       {...props}

--- a/apps/web/src/components/workspace/no-results-state.test.tsx
+++ b/apps/web/src/components/workspace/no-results-state.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { NoResultsState } from "./no-results-state";
+
+describe("noResultsState", () => {
+  it("renders rows copy when label is rows", () => {
+    render(<NoResultsState label="rows" />);
+
+    expect(screen.getByText("No results")).toBeDefined();
+    expect(screen.getByText(/returned no rows/i)).toBeDefined();
+  });
+
+  it("renders documents copy when label is documents", () => {
+    render(<NoResultsState label="documents" />);
+
+    expect(screen.getByText(/returned no documents/i)).toBeDefined();
+  });
+
+  it("hides the CTA when onEditQuery is not provided", () => {
+    render(<NoResultsState label="rows" />);
+
+    expect(screen.queryByRole("button", { name: /edit query/i })).toBeNull();
+  });
+
+  it("renders an Edit query CTA when onEditQuery is provided", async () => {
+    const onEditQuery = vi.fn();
+    render(<NoResultsState label="rows" onEditQuery={onEditQuery} />);
+
+    const button = screen.getByRole("button", { name: /edit query/i });
+    await userEvent.click(button);
+
+    expect(onEditQuery).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/workspace/no-results-state.tsx
+++ b/apps/web/src/components/workspace/no-results-state.tsx
@@ -1,13 +1,36 @@
-import { SearchX } from "lucide-react";
+import { Pencil, SearchX } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
 
 interface NoResultsStateProps {
   label: "rows" | "documents";
+  onEditQuery?: () => void;
 }
 
-export const NoResultsState = ({ label }: NoResultsStateProps) => (
-  <div className="flex flex-1 flex-col items-center justify-center gap-1.5 text-muted-foreground">
-    <SearchX className="size-5 text-muted-foreground/70" />
-    <span className="text-foreground text-sm">No results</span>
-    <span className="text-xs">Your query returned no {label}</span>
-  </div>
+export const NoResultsState = ({ label, onEditQuery }: NoResultsStateProps) => (
+  <Empty className="flex-1 p-6">
+    <EmptyMedia variant="icon">
+      <SearchX />
+    </EmptyMedia>
+    <EmptyHeader>
+      <EmptyTitle as="h2">No results</EmptyTitle>
+      <EmptyDescription>Your query returned no {label}.</EmptyDescription>
+    </EmptyHeader>
+    {onEditQuery && (
+      <EmptyContent>
+        <Button onClick={onEditQuery} size="sm">
+          <Pencil />
+          Edit query
+        </Button>
+      </EmptyContent>
+    )}
+  </Empty>
 );

--- a/apps/web/src/components/workspace/query-error-display.test.tsx
+++ b/apps/web/src/components/workspace/query-error-display.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { QueryErrorDisplay } from "./query-error-display";
+
+const isPrimary = (btn: HTMLElement) => btn.className.includes("bg-primary");
+
+describe("queryErrorDisplay", () => {
+  it("promotes Jump to line for syntax errors with a parseable location", () => {
+    render(
+      <QueryErrorDisplay
+        error='syntax error at or near "FROMM" at line 3, column 7'
+        errorCode="42601"
+        onAiFix={vi.fn()}
+        onJumpToLine={vi.fn()}
+        onRetry={vi.fn()}
+        sql="SELECT * FROMM users;"
+      />
+    );
+
+    const jump = screen.getByRole("button", { name: /jump to/i });
+    const retry = screen.getByRole("button", { name: /^retry$/i });
+    const ai = screen.getByRole("button", { name: /fix with ai/i });
+
+    expect(isPrimary(jump)).toBeTruthy();
+    expect(isPrimary(retry)).toBeFalsy();
+    expect(isPrimary(ai)).toBeFalsy();
+  });
+
+  it("promotes Reconnect for connection errors", () => {
+    render(
+      <QueryErrorDisplay
+        error="connection refused"
+        errorCode="IO_ERROR"
+        onReconnect={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    );
+
+    const reconnect = screen.getByRole("button", { name: /reconnect/i });
+    const retry = screen.getByRole("button", { name: /^retry$/i });
+
+    expect(isPrimary(reconnect)).toBeTruthy();
+    expect(isPrimary(retry)).toBeFalsy();
+  });
+
+  it("falls back to Retry as the primary action", () => {
+    render(
+      <QueryErrorDisplay
+        error='relation "users" does not exist'
+        errorCode="42P01"
+        onAiFix={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    );
+
+    const retry = screen.getByRole("button", { name: /^retry$/i });
+    const ai = screen.getByRole("button", { name: /fix with ai/i });
+
+    expect(isPrimary(retry)).toBeTruthy();
+    expect(isPrimary(ai)).toBeFalsy();
+  });
+
+  it("shows exactly one primary-styled action button", () => {
+    render(
+      <QueryErrorDisplay
+        error='syntax error at or near "FROMM" at line 3, column 7'
+        errorCode="42601"
+        onAiFix={vi.fn()}
+        onJumpToLine={vi.fn()}
+        onReconnect={vi.fn()}
+        onRetry={vi.fn()}
+        sql="SELECT * FROMM users;"
+      />
+    );
+
+    const primaryButtons = screen
+      .getAllByRole("button")
+      .filter((btn) => isPrimary(btn));
+
+    expect(primaryButtons).toHaveLength(1);
+  });
+});

--- a/apps/web/src/components/workspace/query-error-display.tsx
+++ b/apps/web/src/components/workspace/query-error-display.tsx
@@ -47,6 +47,37 @@ const CATEGORY_ICONS: Record<ErrorCategory, typeof AlertCircle> = {
   unknown: AlertCircle,
 };
 
+type PrimaryAction = "jump" | "reconnect" | "retry" | "none";
+
+const resolvePrimaryAction = ({
+  canJump,
+  category,
+  hasReconnect,
+  hasRetry,
+}: {
+  canJump: boolean;
+  category: ErrorCategory;
+  hasReconnect: boolean;
+  hasRetry: boolean;
+}): PrimaryAction => {
+  if (category === "syntax" && canJump) {
+    return "jump";
+  }
+  if (category === "connection" && hasReconnect) {
+    return "reconnect";
+  }
+  if (hasRetry) {
+    return "retry";
+  }
+  if (canJump) {
+    return "jump";
+  }
+  if (hasReconnect) {
+    return "reconnect";
+  }
+  return "none";
+};
+
 export const QueryErrorDisplay = ({
   error,
   errorCode,
@@ -65,6 +96,15 @@ export const QueryErrorDisplay = ({
   const jumpLabel = location ? `Jump to ${formatLocationLabel(location)}` : "";
 
   const CategoryIcon = CATEGORY_ICONS[classification.category];
+
+  const primaryAction = resolvePrimaryAction({
+    canJump,
+    category: classification.category,
+    hasReconnect: onReconnect !== undefined,
+    hasRetry: onRetry !== undefined,
+  });
+  const variantFor = (action: PrimaryAction) =>
+    action === primaryAction ? "default" : "ghost";
 
   const handleJump = useCallback(() => {
     if (location && onJumpToLine) {
@@ -117,6 +157,7 @@ export const QueryErrorDisplay = ({
               onClick={handleJump}
               size="sm"
               title={jumpLabel}
+              variant={variantFor("jump")}
             >
               <ArrowRight />
               Jump to line
@@ -128,6 +169,7 @@ export const QueryErrorDisplay = ({
               onClick={onReconnect}
               size="sm"
               title="Reconnect"
+              variant={variantFor("reconnect")}
             >
               <RefreshCw />
               Reconnect
@@ -139,9 +181,7 @@ export const QueryErrorDisplay = ({
               onClick={onRetry}
               size="sm"
               title="Retry"
-              variant={
-                classification.category === "connection" ? "outline" : "default"
-              }
+              variant={variantFor("retry")}
             >
               <RotateCw />
               Retry
@@ -153,7 +193,7 @@ export const QueryErrorDisplay = ({
               onClick={onAiFix}
               size="sm"
               title="Fix with AI"
-              variant="outline"
+              variant="ghost"
             >
               <Terminal />
               Fix with AI

--- a/apps/web/src/components/workspace/results-grid/results-grid.tsx
+++ b/apps/web/src/components/workspace/results-grid/results-grid.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/dialog";
 import { NoResultsState } from "@/components/workspace/no-results-state";
 import { RowDetailDialog } from "@/components/workspace/row-detail-dialog";
+import { useEditorInsert } from "@/contexts/editor-insert-context";
 import { useExportSettings } from "@/hooks/use-export-settings";
 
 import { useColumnAutoSize } from "./-hooks/use-column-auto-size";
@@ -45,6 +46,7 @@ export const ResultsGrid = ({
   onLoadMore,
 }: ResultsGridProps) => {
   const { settings: exportSettings } = useExportSettings();
+  const { focusEditor } = useEditorInsert();
   const scrollRef = useRef<HTMLDivElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -169,7 +171,7 @@ export const ResultsGrid = ({
         tabIndex={-1}
       >
         {isEmpty ? (
-          <NoResultsState label="rows" />
+          <NoResultsState label="rows" onEditQuery={focusEditor} />
         ) : (
           <div
             aria-colcount={result.columns.length}

--- a/apps/web/src/contexts/editor-insert-context.tsx
+++ b/apps/web/src/contexts/editor-insert-context.tsx
@@ -6,6 +6,7 @@ import { createContext, use, useCallback, useRef } from "react";
 import type { ErrorLocation } from "@/lib/error-location";
 
 interface EditorInsertContextValue {
+  focusEditor: () => boolean;
   getSelectedText: () => string | null;
   hasSelection: () => boolean;
   insertAtCursor: (text: string) => void;
@@ -131,6 +132,15 @@ export const EditorInsertProvider = ({ children }: { children: ReactNode }) => {
     view.focus();
   }, []);
 
+  const focusEditor = useCallback((): boolean => {
+    const view = editorRef.current;
+    if (!view) {
+      return false;
+    }
+    view.focus();
+    return true;
+  }, []);
+
   const queryTable = useCallback((tableName: string) => {
     queryTableRef.current?.(tableName);
   }, []);
@@ -147,6 +157,7 @@ export const EditorInsertProvider = ({ children }: { children: ReactNode }) => {
   return (
     <EditorInsertContext
       value={{
+        focusEditor,
         getSelectedText,
         hasSelection,
         insertAtCursor,

--- a/apps/web/src/routes/_default/-components/connections-empty-state.test.tsx
+++ b/apps/web/src/routes/_default/-components/connections-empty-state.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { NoConnectionsState } from "./connections-empty-state";
+
+describe("noConnectionsState", () => {
+  it("renders the neutral empty copy", () => {
+    render(<NoConnectionsState onAdd={vi.fn()} />);
+
+    expect(screen.getByText("No connections yet")).toBeDefined();
+    expect(screen.getByText(/Saved connections live here/i)).toBeDefined();
+  });
+
+  it("exposes a single primary CTA", () => {
+    render(<NoConnectionsState onAdd={vi.fn()} />);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]?.textContent).toContain("Add connection");
+  });
+
+  it("calls onAdd when the CTA is clicked", async () => {
+    const onAdd = vi.fn();
+    render(<NoConnectionsState onAdd={onAdd} />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /add connection/i })
+    );
+
+    expect(onAdd).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/routes/_default/-components/connections-empty-state.tsx
+++ b/apps/web/src/routes/_default/-components/connections-empty-state.tsx
@@ -1,14 +1,21 @@
+import { Database, Plus } from "lucide-react";
 import { motion } from "motion/react";
 
-import type { DatabaseConnection } from "@/lib/connections";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
 
-import { ConnectionForm } from "@/components/connection-form";
-
-interface ConnectionsEmptyStateProps {
-  onSuccess: (connection: DatabaseConnection) => void;
+interface NoConnectionsStateProps {
+  onAdd: () => void;
 }
 
-const ConnectionsEmptyState = ({ onSuccess }: ConnectionsEmptyStateProps) => (
+const NoConnectionsState = ({ onAdd }: NoConnectionsStateProps) => (
   <motion.div
     animate={{ opacity: 1 }}
     className="w-full max-w-md"
@@ -16,15 +23,26 @@ const ConnectionsEmptyState = ({ onSuccess }: ConnectionsEmptyStateProps) => (
     initial={{ opacity: 0 }}
     transition={{ duration: 0.2, ease: "easeOut" }}
   >
-    <h1 className="px-0.5 text-2xl font-medium leading-[1.1] tracking-tight text-foreground">
-      Connect your first database
-    </h1>
-    <p className="mb-8 mt-3 px-0.5 text-sm leading-relaxed text-muted-foreground">
-      Works with Postgres, MySQL, SQLite, MongoDB, Redis, and ClickHouse — with
-      an AI that knows your schema.
-    </p>
-    <ConnectionForm onSuccess={onSuccess} />
+    <Empty className="p-0">
+      <EmptyMedia variant="icon">
+        <Database />
+      </EmptyMedia>
+      <EmptyHeader>
+        <EmptyTitle as="h2" className="text-base">
+          No connections yet
+        </EmptyTitle>
+        <EmptyDescription>
+          Saved connections live here. You can add one anytime.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button autoFocus onClick={onAdd} size="default">
+          <Plus />
+          Add connection
+        </Button>
+      </EmptyContent>
+    </Empty>
   </motion.div>
 );
 
-export { ConnectionsEmptyState };
+export { NoConnectionsState };

--- a/apps/web/src/routes/_default/-components/welcome-state.test.tsx
+++ b/apps/web/src/routes/_default/-components/welcome-state.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { WelcomeState } from "./welcome-state";
+
+describe("welcomeState", () => {
+  it("renders the welcome copy", () => {
+    render(<WelcomeState onAdd={vi.fn()} />);
+
+    expect(screen.getByText("Welcome to oh-my-query")).toBeDefined();
+    expect(screen.getByText(/A quiet home for your databases/i)).toBeDefined();
+  });
+
+  it("exposes a single primary CTA", () => {
+    render(<WelcomeState onAdd={vi.fn()} />);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]?.textContent).toContain("Add your first connection");
+  });
+
+  it("calls onAdd when the CTA is clicked", async () => {
+    const onAdd = vi.fn();
+    render(<WelcomeState onAdd={onAdd} />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /add your first connection/i })
+    );
+
+    expect(onAdd).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/routes/_default/-components/welcome-state.tsx
+++ b/apps/web/src/routes/_default/-components/welcome-state.tsx
@@ -1,0 +1,55 @@
+import { Database, Plus } from "lucide-react";
+import { motion } from "motion/react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+interface WelcomeStateProps {
+  onAdd: () => void;
+}
+
+const WelcomeState = ({ onAdd }: WelcomeStateProps) => (
+  <motion.div
+    animate={{ opacity: 1 }}
+    className="relative isolate w-full max-w-md"
+    exit={{ opacity: 0 }}
+    initial={{ opacity: 0 }}
+    transition={{ duration: 0.2, ease: "easeOut" }}
+  >
+    <div
+      aria-hidden
+      className="pointer-events-none absolute top-6 left-1/2 -z-10 size-64 -translate-x-1/2 rounded-full bg-primary/25 blur-3xl"
+    />
+    <Empty className="gap-5 p-0">
+      <EmptyMedia
+        className="mb-2 size-16 rounded-2xl bg-primary/10 text-primary ring-1 ring-primary/20 ring-inset [&_svg:not([class*='size-'])]:size-7"
+        variant="icon"
+      >
+        <Database />
+      </EmptyMedia>
+      <EmptyHeader className="gap-2">
+        <EmptyTitle as="h1" className="text-3xl leading-[1.05] tracking-tight">
+          Welcome to oh-my-query
+        </EmptyTitle>
+        <EmptyDescription className="text-base leading-relaxed">
+          A quiet home for your databases, with an AI that knows your schema.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent className="mt-2">
+        <Button autoFocus onClick={onAdd} size="lg">
+          <Plus />
+          Add your first connection
+        </Button>
+      </EmptyContent>
+    </Empty>
+  </motion.div>
+);
+
+export { WelcomeState };

--- a/apps/web/src/routes/_default/index.tsx
+++ b/apps/web/src/routes/_default/index.tsx
@@ -13,9 +13,10 @@ import {
 
 import { AddConnectionDialog } from "./-components/add-connection-dialog";
 import { ConnectionsBoard } from "./-components/connections-board";
-import { ConnectionsEmptyState } from "./-components/connections-empty-state";
+import { NoConnectionsState } from "./-components/connections-empty-state";
 import { EditConnectionDialog } from "./-components/edit-connection-dialog";
 import { HomeTitlebarActions } from "./-components/home-titlebar-actions";
+import { WelcomeState } from "./-components/welcome-state";
 import { useConnectionSelection } from "./-hooks/use-connection-selection";
 import { useConnections } from "./-hooks/use-connections";
 import { useHomeHotkeys } from "./-hooks/use-home-hotkeys";
@@ -153,6 +154,13 @@ const HomeComponent = () => {
 
   const isEmpty = !isLoading && connections.length === 0;
 
+  const renderEmpty = () => {
+    if (isFirstConnectionSeen()) {
+      return <NoConnectionsState key="empty-no-conn" onAdd={handleAddOpen} />;
+    }
+    return <WelcomeState key="empty-welcome" onAdd={handleAddOpen} />;
+  };
+
   return (
     <>
       <HomeActions connections={connections} onOpenAdd={handleAddOpen} />
@@ -167,10 +175,7 @@ const HomeComponent = () => {
       <div className="flex flex-1 flex-col items-center justify-center px-6 py-10">
         <AnimatePresence initial={false} mode="wait">
           {isEmpty ? (
-            <ConnectionsEmptyState
-              key="empty"
-              onSuccess={handleConnectSuccess}
-            />
+            renderEmpty()
           ) : (
             <ConnectionsBoard
               glowingId={firstConnectionId}


### PR DESCRIPTION
## Summary

Ships the Q1 roadmap item: four purposeful empty states — **Welcome** (first-run), **No connections** (returning user with zero), **No results**, and **Query error** — all consolidated onto the shared `Empty` primitive, each with a single concrete CTA.

- **Welcome** is the hero moment: radial amber glow, `<h1>` title, `Database` icon with inner ring, larger typography.
- **Error display** resolves one primary action per category (syntax+location → Jump, connection → Reconnect, else → Retry); the rest demoted to `ghost`.
- **Empty primitive** gains an `as` prop so titles render as real heading elements for AT users. `EditorInsertContext` exposes `focusEditor()` so the No-results CTA can re-focus the CodeMirror view.
- Colocated Vitest coverage for all four components (14 cases), plus a new CLAUDE.md rule requiring tests for new implementations.

## Test plan

- [x] Fresh install: clear `localStorage` → Welcome renders with glow + autofocused primary CTA.
- [x] Returning user: set `om-q:first-connection-seen=true`, delete all connections → "No connections yet" renders without glow, single CTA.
- [x] Run a query that returns 0 rows → "No results" with "Edit query" primary button focuses the SQL editor.
- [x] Trigger a syntax error with a parseable line → Jump to line is the sole primary button; Retry/Fix with AI/Copy are ghost.
- [x] `bun run test` (326 passing), `bun run check-types`, `bun run check` all clean.