### PR TITLE
feat(engines): DuckDB, Microsoft SQL Server, ClickHouse loop close

### DIFF
--- a/apps/web/src-tauri/Cargo.lock
+++ b/apps/web/src-tauri/Cargo.lock
@@ -26,6 +26,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -95,6 +96,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +120,181 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "arrow-select"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "async-native-tls"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe"
+dependencies = [
+ "futures-util",
+ "native-tls",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +303,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -181,6 +379,32 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bb8"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89aabfae550a5c44b43ab941844ffcd2e993cb6900b342debf59e9ea74acdb8"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "bb8-tiberius"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73caefcf24fc336bd39345ee068f8cd64506f38c92a198dc2400a9693d129f33"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "thiserror 1.0.69",
+ "tiberius",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "bitflags"
@@ -423,12 +647,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -478,8 +710,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -498,6 +732,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +750,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "connection-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
 
 [[package]]
 name = "const-oid"
@@ -680,6 +931,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +1083,17 @@ name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -966,6 +1250,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.10502.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
+dependencies = [
+ "arrow",
+ "cast",
+ "comfy-table",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys",
+ "num-integer",
+ "rust_decimal",
+ "strum",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1324,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -1087,6 +1409,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1455,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1479,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1663,6 +2009,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,6 +2233,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2187,6 +2546,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,6 +2626,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,6 +2711,23 @@ name = "libc"
 version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+
+[[package]]
+name = "libduckdb-sys"
+version = "1.10502.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+ "zip",
+]
 
 [[package]]
 name = "libloading"
@@ -2326,6 +2769,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -2353,6 +2802,12 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "value-bag",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2448,6 +2903,12 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
+
+[[package]]
+name = "md5"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
 
 [[package]]
 name = "memchr"
@@ -2688,6 +3149,15 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2974,7 +3444,12 @@ name = "oh-my-query"
 version = "0.0.9"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
+ "bb8",
+ "bb8-tiberius",
+ "chrono",
  "dirs",
+ "duckdb",
  "futures",
  "log",
  "mongodb",
@@ -2987,7 +3462,9 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tiberius",
  "tokio",
+ "tokio-util",
  "urlencoding",
 ]
 
@@ -3377,6 +3854,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "pretty-hex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,6 +3964,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3740,7 +4278,9 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3755,6 +4295,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3762,6 +4304,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3769,6 +4312,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3891,6 +4435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3911,6 +4461,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -3918,7 +4481,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3943,6 +4506,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4708,6 +5272,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4868,6 +5453,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -5138,7 +5734,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -5191,6 +5787,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tiberius"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1446cb4198848d1562301a3340424b4f425ef79f35ef9ee034769a9dd92c10d"
+dependencies = [
+ "async-native-tls",
+ "async-trait",
+ "asynchronous-codec",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "connection-string",
+ "encoding_rs",
+ "enumflags2",
+ "futures-util",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "pretty-hex",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "winauth",
 ]
 
 [[package]]
@@ -5641,6 +6265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5929,6 +6559,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6063,6 +6703,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winauth"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f820cd208ce9c6b050812dc2d724ba98c6c1e9db5ce9b3f58d925ae5723a5e6"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "md5",
+ "rand 0.7.3",
+ "winapi",
+]
 
 [[package]]
 name = "window-vibrancy"
@@ -6752,6 +7405,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.3",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6855,7 +7518,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -42,3 +42,14 @@ redis = { version = "0.27", features = ["tokio-comp", "aio"] }
 dirs = "6"
 polyglot-sql = "0.1"
 reqwest = { version = "0.12", features = ["json", "native-tls"] }
+duckdb = { version = "1", features = ["bundled"] }
+tiberius = { version = "0.12", default-features = false, features = [
+  "tds73",
+  "native-tls",
+  "chrono",
+] }
+bb8 = "0.8"
+bb8-tiberius = "0.15"
+tokio-util = { version = "0.7", features = ["compat"] }
+base64 = "0.22"
+chrono = { version = "0.4", features = ["serde"] }

--- a/apps/web/src-tauri/src/db/clickhouse.rs
+++ b/apps/web/src-tauri/src/db/clickhouse.rs
@@ -261,6 +261,8 @@ mod tests {
             database: "default".to_string(),
             username: "default".to_string(),
             password: String::new(),
+            auth_source: None,
+            trust_server_certificate: None,
         };
         let conn = ClickHouseConnection::new(&params).unwrap();
         assert_eq!(conn.base_url, "http://localhost:8123");
@@ -275,6 +277,8 @@ mod tests {
             database: "analytics".to_string(),
             username: "admin".to_string(),
             password: "secret".to_string(),
+            auth_source: None,
+            trust_server_certificate: None,
         };
         let conn = ClickHouseConnection::new(&params).unwrap();
         assert_eq!(conn.base_url, "https://ch.example.com:8443");

--- a/apps/web/src-tauri/src/db/driver.rs
+++ b/apps/web/src-tauri/src/db/driver.rs
@@ -1,8 +1,10 @@
 use async_trait::async_trait;
 
 use crate::db::clickhouse::ClickHouseDriver;
+use crate::db::duckdb::DuckDbDriver;
 use crate::db::error::DbError;
 use crate::db::mongodb_driver::MongoDbDriver;
+use crate::db::mssql::MssqlDriver;
 use crate::db::mysql::MysqlDriver;
 use crate::db::postgres::PostgresDriver;
 use crate::db::redis_driver::RedisDriver;
@@ -25,6 +27,8 @@ pub fn get_driver(db_type: &str) -> Result<Box<dyn DatabaseDriver>, DbError> {
         "mongodb" => Ok(Box::new(MongoDbDriver)),
         "redis" => Ok(Box::new(RedisDriver)),
         "clickhouse" => Ok(Box::new(ClickHouseDriver)),
+        "duckdb" => Ok(Box::new(DuckDbDriver)),
+        "mssql" => Ok(Box::new(MssqlDriver)),
         other => Err(DbError {
             code: "UNSUPPORTED_DRIVER".to_string(),
             message: format!("Unsupported database type: {other}"),

--- a/apps/web/src-tauri/src/db/duckdb.rs
+++ b/apps/web/src-tauri/src/db/duckdb.rs
@@ -1,0 +1,129 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::db::driver::DatabaseDriver;
+use crate::db::error::DbError;
+use crate::db::types::{ConnectionParams, TestConnectionResult};
+
+pub type DuckDbHandle = Arc<Mutex<duckdb::Connection>>;
+
+pub struct DuckDbDriver;
+
+pub fn resolve_database_target(raw: &str) -> Result<String, DbError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case(":memory:") {
+        return Ok(":memory:".to_string());
+    }
+    let path = PathBuf::from(trimmed);
+    if !path.is_absolute() {
+        return Err(DbError {
+            code: "DUCKDB_INVALID_PATH".to_string(),
+            message: format!(
+                "DuckDB database path must be absolute or ':memory:' (got '{trimmed}')"
+            ),
+        });
+    }
+    Ok(trimmed.to_string())
+}
+
+pub fn open_duckdb(params: &ConnectionParams) -> Result<duckdb::Connection, DbError> {
+    let target = resolve_database_target(&params.database)?;
+    if target == ":memory:" {
+        duckdb::Connection::open_in_memory().map_err(DbError::from)
+    } else {
+        duckdb::Connection::open(&target).map_err(DbError::from)
+    }
+}
+
+#[async_trait]
+impl DatabaseDriver for DuckDbDriver {
+    async fn test_connection(
+        &self,
+        params: &ConnectionParams,
+    ) -> Result<TestConnectionResult, DbError> {
+        let start = Instant::now();
+        let params = params.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), DbError> {
+            let conn = open_duckdb(&params)?;
+            conn.execute_batch("SELECT 1").map_err(DbError::from)?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| DbError {
+            code: "DUCKDB_JOIN_ERROR".to_string(),
+            message: e.to_string(),
+        })??;
+
+        let latency = start.elapsed().as_millis() as u64;
+        Ok(TestConnectionResult {
+            success: true,
+            message: "Connection successful".to_string(),
+            latency_ms: latency,
+        })
+    }
+}
+
+impl From<duckdb::Error> for DbError {
+    fn from(err: duckdb::Error) -> Self {
+        DbError {
+            code: "DUCKDB_ERROR".to_string(),
+            message: err.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params_for(database: &str) -> ConnectionParams {
+        ConnectionParams {
+            db_type: "duckdb".to_string(),
+            host: String::new(),
+            port: 0,
+            database: database.to_string(),
+            username: String::new(),
+            password: String::new(),
+            auth_source: None,
+        }
+    }
+
+    #[test]
+    fn empty_database_maps_to_memory() {
+        assert_eq!(resolve_database_target("").unwrap(), ":memory:");
+        assert_eq!(resolve_database_target("   ").unwrap(), ":memory:");
+    }
+
+    #[test]
+    fn memory_literal_accepted_case_insensitively() {
+        assert_eq!(resolve_database_target(":memory:").unwrap(), ":memory:");
+        assert_eq!(resolve_database_target(":Memory:").unwrap(), ":memory:");
+    }
+
+    #[test]
+    fn absolute_path_accepted() {
+        let r = resolve_database_target("/tmp/oh-my-query-test.duckdb").unwrap();
+        assert_eq!(r, "/tmp/oh-my-query-test.duckdb");
+    }
+
+    #[test]
+    fn relative_path_rejected() {
+        let err = resolve_database_target("relative/path.duckdb").unwrap_err();
+        assert_eq!(err.code, "DUCKDB_INVALID_PATH");
+    }
+
+    #[test]
+    fn in_memory_roundtrip() {
+        let params = params_for(":memory:");
+        let conn = open_duckdb(&params).unwrap();
+        let mut stmt = conn.prepare("SELECT 1").unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        let row = rows.next().unwrap().unwrap();
+        let v: i32 = row.get(0).unwrap();
+        assert_eq!(v, 1);
+    }
+}

--- a/apps/web/src-tauri/src/db/duckdb.rs
+++ b/apps/web/src-tauri/src/db/duckdb.rs
@@ -89,6 +89,7 @@ mod tests {
             username: String::new(),
             password: String::new(),
             auth_source: None,
+            trust_server_certificate: None,
         }
     }
 

--- a/apps/web/src-tauri/src/db/execute/duckdb.rs
+++ b/apps/web/src-tauri/src/db/execute/duckdb.rs
@@ -27,18 +27,22 @@ fn run_query(handle: &DuckDbHandle, sql: &str, max_rows: usize) -> Result<Execut
     })?;
 
     let mut stmt = conn.prepare(sql).map_err(DbError::from)?;
-    let column_count = stmt.column_count();
-    let columns: Vec<ColumnInfo> = (0..column_count)
-        .map(|i| ColumnInfo {
-            name: stmt
-                .column_name(i)
-                .map(|s| s.to_string())
-                .unwrap_or_default(),
-            type_name: format!("{:?}", stmt.column_type(i)),
-        })
-        .collect();
-
     let mut rows_iter = stmt.query([]).map_err(DbError::from)?;
+
+    let (column_count, columns) = rows_iter
+        .as_ref()
+        .map(|s| {
+            let count = s.column_count();
+            let infos = (0..count)
+                .map(|i| ColumnInfo {
+                    name: s.column_name(i).map(|n| n.to_string()).unwrap_or_default(),
+                    type_name: format!("{:?}", s.column_type(i)),
+                })
+                .collect::<Vec<_>>();
+            (count, infos)
+        })
+        .unwrap_or((0, Vec::new()));
+
     let mut rows: Vec<Vec<serde_json::Value>> = Vec::new();
     let mut is_truncated = false;
 

--- a/apps/web/src-tauri/src/db/execute/duckdb.rs
+++ b/apps/web/src-tauri/src/db/execute/duckdb.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use base64::Engine as _;
 use duckdb::types::Value as DuckValue;
 
@@ -21,10 +23,8 @@ pub async fn execute_duckdb(
 }
 
 fn run_query(handle: &DuckDbHandle, sql: &str, max_rows: usize) -> Result<ExecuteResult, DbError> {
-    let conn = handle.try_lock().map_err(|_| DbError {
-        code: "DUCKDB_BUSY".to_string(),
-        message: "Another query is currently running on this DuckDB connection".to_string(),
-    })?;
+    let conn = handle.blocking_lock();
+    let started = Instant::now();
 
     let mut stmt = conn.prepare(sql).map_err(DbError::from)?;
     let mut rows_iter = stmt.query([]).map_err(DbError::from)?;
@@ -63,7 +63,7 @@ fn run_query(handle: &DuckDbHandle, sql: &str, max_rows: usize) -> Result<Execut
         row_count: rows.len() as u64,
         columns,
         rows,
-        execution_time_ms: 0,
+        execution_time_ms: started.elapsed().as_millis() as u64,
         is_truncated,
     })
 }

--- a/apps/web/src-tauri/src/db/execute/duckdb.rs
+++ b/apps/web/src-tauri/src/db/execute/duckdb.rs
@@ -20,17 +20,11 @@ pub async fn execute_duckdb(
         })?
 }
 
-fn run_query(
-    handle: &DuckDbHandle,
-    sql: &str,
-    max_rows: usize,
-) -> Result<ExecuteResult, DbError> {
-    let conn = handle
-        .try_lock()
-        .map_err(|_| DbError {
-            code: "DUCKDB_BUSY".to_string(),
-            message: "Another query is currently running on this DuckDB connection".to_string(),
-        })?;
+fn run_query(handle: &DuckDbHandle, sql: &str, max_rows: usize) -> Result<ExecuteResult, DbError> {
+    let conn = handle.try_lock().map_err(|_| DbError {
+        code: "DUCKDB_BUSY".to_string(),
+        message: "Another query is currently running on this DuckDB connection".to_string(),
+    })?;
 
     let mut stmt = conn.prepare(sql).map_err(DbError::from)?;
     let column_count = stmt.column_count();
@@ -91,12 +85,8 @@ pub fn duckdb_value_to_json(value: DuckValue) -> serde_json::Value {
             serde_json::Value::String(base64::engine::general_purpose::STANDARD.encode(bytes))
         }
         DuckValue::Date32(days) => serde_json::Value::String(format_date_days(days)),
-        DuckValue::Time64(unit, v) => {
-            serde_json::Value::String(format_time_unit(unit, v))
-        }
-        DuckValue::Timestamp(unit, v) => {
-            serde_json::Value::String(format_timestamp_unit(unit, v))
-        }
+        DuckValue::Time64(unit, v) => serde_json::Value::String(format_time_unit(unit, v)),
+        DuckValue::Timestamp(unit, v) => serde_json::Value::String(format_timestamp_unit(unit, v)),
         DuckValue::Interval {
             months,
             days,
@@ -186,7 +176,10 @@ mod tests {
 
     #[test]
     fn primitives_map_to_json() {
-        assert_eq!(duckdb_value_to_json(DuckValue::Null), serde_json::Value::Null);
+        assert_eq!(
+            duckdb_value_to_json(DuckValue::Null),
+            serde_json::Value::Null
+        );
         assert_eq!(
             duckdb_value_to_json(DuckValue::Boolean(true)),
             serde_json::Value::Bool(true)
@@ -233,5 +226,4 @@ mod tests {
         assert_eq!(format_date_days(0), "1970-01-01");
         assert_eq!(format_date_days(365), "1971-01-01");
     }
-
 }

--- a/apps/web/src-tauri/src/db/execute/duckdb.rs
+++ b/apps/web/src-tauri/src/db/execute/duckdb.rs
@@ -1,0 +1,237 @@
+use base64::Engine as _;
+use duckdb::types::Value as DuckValue;
+
+use crate::db::duckdb::DuckDbHandle;
+use crate::db::error::DbError;
+use crate::db::types::{ColumnInfo, ExecuteResult};
+
+pub async fn execute_duckdb(
+    handle: &DuckDbHandle,
+    sql: &str,
+    max_rows: usize,
+) -> Result<ExecuteResult, DbError> {
+    let handle = handle.clone();
+    let sql = sql.to_string();
+    tokio::task::spawn_blocking(move || run_query(&handle, &sql, max_rows))
+        .await
+        .map_err(|e| DbError {
+            code: "DUCKDB_JOIN_ERROR".to_string(),
+            message: e.to_string(),
+        })?
+}
+
+fn run_query(
+    handle: &DuckDbHandle,
+    sql: &str,
+    max_rows: usize,
+) -> Result<ExecuteResult, DbError> {
+    let conn = handle
+        .try_lock()
+        .map_err(|_| DbError {
+            code: "DUCKDB_BUSY".to_string(),
+            message: "Another query is currently running on this DuckDB connection".to_string(),
+        })?;
+
+    let mut stmt = conn.prepare(sql).map_err(DbError::from)?;
+    let column_count = stmt.column_count();
+    let columns: Vec<ColumnInfo> = (0..column_count)
+        .map(|i| ColumnInfo {
+            name: stmt
+                .column_name(i)
+                .map(|s| s.to_string())
+                .unwrap_or_default(),
+            type_name: format!("{:?}", stmt.column_type(i)),
+        })
+        .collect();
+
+    let mut rows_iter = stmt.query([]).map_err(DbError::from)?;
+    let mut rows: Vec<Vec<serde_json::Value>> = Vec::new();
+    let mut is_truncated = false;
+
+    while let Some(row) = rows_iter.next().map_err(DbError::from)? {
+        if rows.len() >= max_rows {
+            is_truncated = true;
+            break;
+        }
+        let mut out = Vec::with_capacity(column_count);
+        for i in 0..column_count {
+            let v: DuckValue = row.get(i).map_err(DbError::from)?;
+            out.push(duckdb_value_to_json(v));
+        }
+        rows.push(out);
+    }
+
+    Ok(ExecuteResult::Tabular {
+        row_count: rows.len() as u64,
+        columns,
+        rows,
+        execution_time_ms: 0,
+        is_truncated,
+    })
+}
+
+pub fn duckdb_value_to_json(value: DuckValue) -> serde_json::Value {
+    match value {
+        DuckValue::Null => serde_json::Value::Null,
+        DuckValue::Boolean(b) => serde_json::Value::Bool(b),
+        DuckValue::TinyInt(v) => serde_json::json!(v),
+        DuckValue::SmallInt(v) => serde_json::json!(v),
+        DuckValue::Int(v) => serde_json::json!(v),
+        DuckValue::BigInt(v) => serde_json::json!(v),
+        DuckValue::HugeInt(v) => serde_json::Value::String(v.to_string()),
+        DuckValue::UTinyInt(v) => serde_json::json!(v),
+        DuckValue::USmallInt(v) => serde_json::json!(v),
+        DuckValue::UInt(v) => serde_json::json!(v),
+        DuckValue::UBigInt(v) => serde_json::json!(v),
+        DuckValue::Float(v) => serde_json::json!(v),
+        DuckValue::Double(v) => serde_json::json!(v),
+        DuckValue::Decimal(v) => serde_json::Value::String(v.to_string()),
+        DuckValue::Text(s) => serde_json::Value::String(s),
+        DuckValue::Blob(bytes) => {
+            serde_json::Value::String(base64::engine::general_purpose::STANDARD.encode(bytes))
+        }
+        DuckValue::Date32(days) => serde_json::Value::String(format_date_days(days)),
+        DuckValue::Time64(unit, v) => {
+            serde_json::Value::String(format_time_unit(unit, v))
+        }
+        DuckValue::Timestamp(unit, v) => {
+            serde_json::Value::String(format_timestamp_unit(unit, v))
+        }
+        DuckValue::Interval {
+            months,
+            days,
+            nanos,
+        } => serde_json::Value::String(format!("{months}mo {days}d {nanos}ns")),
+        DuckValue::List(items) => {
+            let mapped: Vec<serde_json::Value> =
+                items.into_iter().map(duckdb_value_to_json).collect();
+            serde_json::Value::Array(mapped)
+        }
+        DuckValue::Array(items) => {
+            let mapped: Vec<serde_json::Value> =
+                items.into_iter().map(duckdb_value_to_json).collect();
+            serde_json::Value::Array(mapped)
+        }
+        DuckValue::Struct(fields) => {
+            let map: serde_json::Map<String, serde_json::Value> = fields
+                .iter()
+                .map(|(k, v)| (k.clone(), duckdb_value_to_json(v.clone())))
+                .collect();
+            serde_json::Value::Object(map)
+        }
+        DuckValue::Map(entries) => {
+            let arr: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|(k, v)| {
+                    serde_json::json!({
+                        "key": duckdb_value_to_json(k.clone()),
+                        "value": duckdb_value_to_json(v.clone()),
+                    })
+                })
+                .collect();
+            serde_json::Value::Array(arr)
+        }
+        DuckValue::Enum(s) => serde_json::Value::String(s),
+        DuckValue::Union(inner) => duckdb_value_to_json(*inner),
+    }
+}
+
+fn format_date_days(days: i32) -> String {
+    use chrono::{Duration, NaiveDate};
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+    let date = epoch
+        .checked_add_signed(Duration::days(days as i64))
+        .unwrap_or(epoch);
+    date.format("%Y-%m-%d").to_string()
+}
+
+fn format_time_unit(unit: duckdb::types::TimeUnit, v: i64) -> String {
+    use duckdb::types::TimeUnit;
+    let nanos = match unit {
+        TimeUnit::Second => v.saturating_mul(1_000_000_000),
+        TimeUnit::Millisecond => v.saturating_mul(1_000_000),
+        TimeUnit::Microsecond => v.saturating_mul(1_000),
+        TimeUnit::Nanosecond => v,
+    };
+    let total_micros = nanos / 1_000;
+    let seconds = total_micros / 1_000_000;
+    let micros = total_micros % 1_000_000;
+    let h = seconds / 3600;
+    let m = (seconds / 60) % 60;
+    let s = seconds % 60;
+    format!("{h:02}:{m:02}:{s:02}.{micros:06}")
+}
+
+fn format_timestamp_unit(unit: duckdb::types::TimeUnit, v: i64) -> String {
+    use chrono::DateTime;
+    use duckdb::types::TimeUnit;
+    let nanos_per_unit: i64 = match unit {
+        TimeUnit::Second => 1_000_000_000,
+        TimeUnit::Millisecond => 1_000_000,
+        TimeUnit::Microsecond => 1_000,
+        TimeUnit::Nanosecond => 1,
+    };
+    let total_nanos = (v as i128) * (nanos_per_unit as i128);
+    let secs = (total_nanos / 1_000_000_000) as i64;
+    let nsecs = (total_nanos.rem_euclid(1_000_000_000)) as u32;
+    match DateTime::from_timestamp(secs, nsecs) {
+        Some(dt) => dt.format("%Y-%m-%d %H:%M:%S%.f").to_string(),
+        None => format!("{v}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primitives_map_to_json() {
+        assert_eq!(duckdb_value_to_json(DuckValue::Null), serde_json::Value::Null);
+        assert_eq!(
+            duckdb_value_to_json(DuckValue::Boolean(true)),
+            serde_json::Value::Bool(true)
+        );
+        assert_eq!(
+            duckdb_value_to_json(DuckValue::Int(42)),
+            serde_json::json!(42)
+        );
+        assert_eq!(
+            duckdb_value_to_json(DuckValue::Text("hi".to_string())),
+            serde_json::Value::String("hi".to_string())
+        );
+    }
+
+    #[test]
+    fn lists_map_to_arrays() {
+        let v = DuckValue::List(vec![DuckValue::Int(1), DuckValue::Int(2)]);
+        assert_eq!(duckdb_value_to_json(v), serde_json::json!([1, 2]));
+    }
+
+    #[test]
+    fn structs_map_to_objects() {
+        let v = DuckValue::Struct(duckdb::types::OrderedMap::from(vec![
+            ("a".to_string(), DuckValue::Int(1)),
+            ("b".to_string(), DuckValue::Text("x".to_string())),
+        ]));
+        assert_eq!(
+            duckdb_value_to_json(v),
+            serde_json::json!({"a": 1, "b": "x"})
+        );
+    }
+
+    #[test]
+    fn blob_base64_encoded() {
+        let v = DuckValue::Blob(vec![1, 2, 3]);
+        assert_eq!(
+            duckdb_value_to_json(v),
+            serde_json::Value::String("AQID".to_string())
+        );
+    }
+
+    #[test]
+    fn date_formatted_iso() {
+        assert_eq!(format_date_days(0), "1970-01-01");
+        assert_eq!(format_date_days(365), "1971-01-01");
+    }
+
+}

--- a/apps/web/src-tauri/src/db/execute/mod.rs
+++ b/apps/web/src-tauri/src/db/execute/mod.rs
@@ -1,5 +1,7 @@
 mod clickhouse;
+mod duckdb;
 mod mongodb;
+mod mssql;
 mod redis;
 mod sql;
 
@@ -30,5 +32,7 @@ pub async fn execute_for_pool(
         DatabasePool::ClickHouse(conn) => {
             clickhouse::execute_clickhouse(conn, command, max_rows, schema).await
         }
+        DatabasePool::DuckDB(handle) => duckdb::execute_duckdb(handle, command, max_rows).await,
+        DatabasePool::Mssql(pool) => mssql::execute_mssql(pool, command, max_rows).await,
     }
 }

--- a/apps/web/src-tauri/src/db/execute/mssql.rs
+++ b/apps/web/src-tauri/src/db/execute/mssql.rs
@@ -1,0 +1,181 @@
+use base64::Engine as _;
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
+use futures::TryStreamExt;
+use tiberius::{Column, ColumnData, ColumnType, QueryItem, Row};
+
+use crate::db::error::DbError;
+use crate::db::mssql::MssqlPool;
+use crate::db::types::{ColumnInfo, ExecuteResult};
+
+pub async fn execute_mssql(
+    pool: &MssqlPool,
+    sql: &str,
+    max_rows: usize,
+) -> Result<ExecuteResult, DbError> {
+    let mut client = pool.get().await.map_err(DbError::from)?;
+    let mut stream = client.simple_query(sql.to_string()).await.map_err(DbError::from)?;
+
+    let mut columns: Vec<ColumnInfo> = Vec::new();
+    let mut rows: Vec<Vec<serde_json::Value>> = Vec::new();
+    let mut is_truncated = false;
+
+    while let Some(item) = stream.try_next().await.map_err(DbError::from)? {
+        match item {
+            QueryItem::Metadata(meta) => {
+                if columns.is_empty() {
+                    columns = meta
+                        .columns()
+                        .iter()
+                        .map(|col| ColumnInfo {
+                            name: col.name().to_string(),
+                            type_name: column_type_name(col.column_type()).to_string(),
+                        })
+                        .collect();
+                }
+            }
+            QueryItem::Row(row) => {
+                if rows.len() >= max_rows {
+                    is_truncated = true;
+                    continue;
+                }
+                rows.push(row_to_json(&row));
+            }
+        }
+    }
+
+    Ok(ExecuteResult::Tabular {
+        row_count: rows.len() as u64,
+        columns,
+        rows,
+        execution_time_ms: 0,
+        is_truncated,
+    })
+}
+
+fn row_to_json(row: &Row) -> Vec<serde_json::Value> {
+    let mut out = Vec::with_capacity(row.len());
+    for (idx, (col, data)) in row.cells().enumerate() {
+        out.push(cell_to_json(col, data, row, idx));
+    }
+    out
+}
+
+fn cell_to_json(
+    col: &Column,
+    data: &ColumnData<'static>,
+    row: &Row,
+    idx: usize,
+) -> serde_json::Value {
+    match data {
+        ColumnData::U8(Some(v)) => serde_json::json!(v),
+        ColumnData::I16(Some(v)) => serde_json::json!(v),
+        ColumnData::I32(Some(v)) => serde_json::json!(v),
+        ColumnData::I64(Some(v)) => serde_json::json!(v),
+        ColumnData::F32(Some(v)) => serde_json::json!(v),
+        ColumnData::F64(Some(v)) => serde_json::json!(v),
+        ColumnData::Bit(Some(v)) => serde_json::Value::Bool(*v),
+        ColumnData::String(Some(s)) => serde_json::Value::String(s.to_string()),
+        ColumnData::Guid(Some(uuid)) => serde_json::Value::String(uuid.to_string()),
+        ColumnData::Binary(Some(bytes)) => serde_json::Value::String(
+            base64::engine::general_purpose::STANDARD.encode(bytes.as_ref()),
+        ),
+        ColumnData::Numeric(Some(n)) => serde_json::Value::String(n.to_string()),
+        ColumnData::Xml(Some(xml)) => serde_json::Value::String(xml.as_ref().to_string()),
+        ColumnData::DateTime(Some(_))
+        | ColumnData::SmallDateTime(Some(_))
+        | ColumnData::DateTime2(Some(_)) => {
+            row.try_get::<NaiveDateTime, _>(idx)
+                .ok()
+                .flatten()
+                .map(|dt| serde_json::Value::String(dt.format("%Y-%m-%dT%H:%M:%S%.f").to_string()))
+                .unwrap_or_else(|| fallback_debug(col, data))
+        }
+        ColumnData::Date(Some(_)) => row
+            .try_get::<NaiveDate, _>(idx)
+            .ok()
+            .flatten()
+            .map(|d| serde_json::Value::String(d.format("%Y-%m-%d").to_string()))
+            .unwrap_or_else(|| fallback_debug(col, data)),
+        ColumnData::Time(Some(_)) => row
+            .try_get::<NaiveTime, _>(idx)
+            .ok()
+            .flatten()
+            .map(|t| serde_json::Value::String(t.format("%H:%M:%S%.f").to_string()))
+            .unwrap_or_else(|| fallback_debug(col, data)),
+        ColumnData::DateTimeOffset(Some(_)) => row
+            .try_get::<DateTime<FixedOffset>, _>(idx)
+            .ok()
+            .flatten()
+            .map(|dt| serde_json::Value::String(dt.to_rfc3339()))
+            .unwrap_or_else(|| fallback_debug(col, data)),
+        ColumnData::U8(None)
+        | ColumnData::I16(None)
+        | ColumnData::I32(None)
+        | ColumnData::I64(None)
+        | ColumnData::F32(None)
+        | ColumnData::F64(None)
+        | ColumnData::Bit(None)
+        | ColumnData::String(None)
+        | ColumnData::Guid(None)
+        | ColumnData::Binary(None)
+        | ColumnData::Numeric(None)
+        | ColumnData::Xml(None)
+        | ColumnData::DateTime(None)
+        | ColumnData::SmallDateTime(None)
+        | ColumnData::DateTime2(None)
+        | ColumnData::Date(None)
+        | ColumnData::Time(None)
+        | ColumnData::DateTimeOffset(None) => serde_json::Value::Null,
+    }
+}
+
+fn fallback_debug(_col: &Column, data: &ColumnData<'static>) -> serde_json::Value {
+    serde_json::Value::String(format!("{data:?}"))
+}
+
+pub fn column_type_name(t: ColumnType) -> &'static str {
+    match t {
+        ColumnType::Null => "null",
+        ColumnType::Bit | ColumnType::Bitn => "bit",
+        ColumnType::Int1 => "tinyint",
+        ColumnType::Int2 => "smallint",
+        ColumnType::Int4 => "int",
+        ColumnType::Int8 => "bigint",
+        ColumnType::Intn => "int",
+        ColumnType::Float4 | ColumnType::Floatn => "float",
+        ColumnType::Float8 => "double",
+        ColumnType::Money | ColumnType::Money4 => "money",
+        ColumnType::Datetime | ColumnType::Datetime4 | ColumnType::Datetimen => "datetime",
+        ColumnType::Datetime2 => "datetime2",
+        ColumnType::Daten => "date",
+        ColumnType::Timen => "time",
+        ColumnType::DatetimeOffsetn => "datetimeoffset",
+        ColumnType::Guid => "uniqueidentifier",
+        ColumnType::Decimaln | ColumnType::Numericn => "numeric",
+        ColumnType::BigVarBin | ColumnType::BigBinary => "varbinary",
+        ColumnType::BigVarChar | ColumnType::BigChar => "varchar",
+        ColumnType::NVarchar | ColumnType::NChar => "nvarchar",
+        ColumnType::Xml => "xml",
+        ColumnType::Udt => "udt",
+        ColumnType::Text => "text",
+        ColumnType::NText => "ntext",
+        ColumnType::Image => "image",
+        ColumnType::SSVariant => "sql_variant",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_type_name_maps_common_types() {
+        assert_eq!(column_type_name(ColumnType::Int4), "int");
+        assert_eq!(column_type_name(ColumnType::Int8), "bigint");
+        assert_eq!(column_type_name(ColumnType::Bit), "bit");
+        assert_eq!(column_type_name(ColumnType::BigVarChar), "varchar");
+        assert_eq!(column_type_name(ColumnType::NVarchar), "nvarchar");
+        assert_eq!(column_type_name(ColumnType::Guid), "uniqueidentifier");
+        assert_eq!(column_type_name(ColumnType::Datetime2), "datetime2");
+    }
+}

--- a/apps/web/src-tauri/src/db/execute/mssql.rs
+++ b/apps/web/src-tauri/src/db/execute/mssql.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use base64::Engine as _;
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
 use futures::TryStreamExt;
@@ -13,6 +15,7 @@ pub async fn execute_mssql(
     max_rows: usize,
 ) -> Result<ExecuteResult, DbError> {
     let mut client = pool.get().await.map_err(DbError::from)?;
+    let started = Instant::now();
     let mut stream = client
         .simple_query(sql.to_string())
         .await
@@ -38,6 +41,10 @@ pub async fn execute_mssql(
             }
             QueryItem::Row(row) => {
                 if rows.len() >= max_rows {
+                    // tiberius streams cannot be safely abandoned mid-result
+                    // (dropping leaves the bb8-pooled connection poisoned),
+                    // so drain the remaining rows server-side and surface
+                    // truncation via `is_truncated`.
                     is_truncated = true;
                     continue;
                 }
@@ -50,7 +57,7 @@ pub async fn execute_mssql(
         row_count: rows.len() as u64,
         columns,
         rows,
-        execution_time_ms: 0,
+        execution_time_ms: started.elapsed().as_millis() as u64,
         is_truncated,
     })
 }

--- a/apps/web/src-tauri/src/db/execute/mssql.rs
+++ b/apps/web/src-tauri/src/db/execute/mssql.rs
@@ -13,7 +13,10 @@ pub async fn execute_mssql(
     max_rows: usize,
 ) -> Result<ExecuteResult, DbError> {
     let mut client = pool.get().await.map_err(DbError::from)?;
-    let mut stream = client.simple_query(sql.to_string()).await.map_err(DbError::from)?;
+    let mut stream = client
+        .simple_query(sql.to_string())
+        .await
+        .map_err(DbError::from)?;
 
     let mut columns: Vec<ColumnInfo> = Vec::new();
     let mut rows: Vec<Vec<serde_json::Value>> = Vec::new();
@@ -83,13 +86,12 @@ fn cell_to_json(
         ColumnData::Xml(Some(xml)) => serde_json::Value::String(xml.as_ref().to_string()),
         ColumnData::DateTime(Some(_))
         | ColumnData::SmallDateTime(Some(_))
-        | ColumnData::DateTime2(Some(_)) => {
-            row.try_get::<NaiveDateTime, _>(idx)
-                .ok()
-                .flatten()
-                .map(|dt| serde_json::Value::String(dt.format("%Y-%m-%dT%H:%M:%S%.f").to_string()))
-                .unwrap_or_else(|| fallback_debug(col, data))
-        }
+        | ColumnData::DateTime2(Some(_)) => row
+            .try_get::<NaiveDateTime, _>(idx)
+            .ok()
+            .flatten()
+            .map(|dt| serde_json::Value::String(dt.format("%Y-%m-%dT%H:%M:%S%.f").to_string()))
+            .unwrap_or_else(|| fallback_debug(col, data)),
         ColumnData::Date(Some(_)) => row
             .try_get::<NaiveDate, _>(idx)
             .ok()

--- a/apps/web/src-tauri/src/db/mod.rs
+++ b/apps/web/src-tauri/src/db/mod.rs
@@ -1,8 +1,10 @@
 pub mod clickhouse;
 pub mod driver;
+pub mod duckdb;
 pub mod error;
 pub mod execute;
 pub mod mongodb_driver;
+pub mod mssql;
 pub mod mysql;
 pub mod pool;
 pub mod postgres;

--- a/apps/web/src-tauri/src/db/mssql.rs
+++ b/apps/web/src-tauri/src/db/mssql.rs
@@ -1,0 +1,138 @@
+use std::time::Instant;
+
+use async_trait::async_trait;
+use bb8::Pool;
+use bb8_tiberius::ConnectionManager;
+use tiberius::{AuthMethod, Config, EncryptionLevel};
+
+use crate::db::driver::DatabaseDriver;
+use crate::db::error::DbError;
+use crate::db::types::{ConnectionParams, TestConnectionResult};
+
+pub type MssqlPool = Pool<ConnectionManager>;
+
+pub struct MssqlDriver;
+
+pub fn build_mssql_config(params: &ConnectionParams) -> Config {
+    let mut config = Config::new();
+    config.host(&params.host);
+    config.port(if params.port == 0 { 1433 } else { params.port });
+    if !params.database.is_empty() {
+        config.database(&params.database);
+    }
+    config.authentication(AuthMethod::sql_server(&params.username, &params.password));
+    config.encryption(EncryptionLevel::Required);
+    config.trust_cert();
+    config
+}
+
+pub async fn build_mssql_pool(params: &ConnectionParams) -> Result<MssqlPool, DbError> {
+    let config = build_mssql_config(params);
+    let manager = ConnectionManager::new(config);
+    Pool::builder()
+        .max_size(5)
+        .connection_timeout(std::time::Duration::from_secs(10))
+        .build(manager)
+        .await
+        .map_err(DbError::from)
+}
+
+#[async_trait]
+impl DatabaseDriver for MssqlDriver {
+    async fn test_connection(
+        &self,
+        params: &ConnectionParams,
+    ) -> Result<TestConnectionResult, DbError> {
+        let start = Instant::now();
+        let pool = build_mssql_pool(params).await?;
+        let mut conn = pool.get().await.map_err(DbError::from)?;
+        conn.simple_query("SELECT 1")
+            .await
+            .map_err(DbError::from)?
+            .into_results()
+            .await
+            .map_err(DbError::from)?;
+        let latency = start.elapsed().as_millis() as u64;
+        Ok(TestConnectionResult {
+            success: true,
+            message: "Connection successful".to_string(),
+            latency_ms: latency,
+        })
+    }
+}
+
+impl From<bb8_tiberius::Error> for DbError {
+    fn from(err: bb8_tiberius::Error) -> Self {
+        DbError {
+            code: "MSSQL_ERROR".to_string(),
+            message: err.to_string(),
+        }
+    }
+}
+
+impl From<bb8::RunError<bb8_tiberius::Error>> for DbError {
+    fn from(err: bb8::RunError<bb8_tiberius::Error>) -> Self {
+        DbError {
+            code: "MSSQL_POOL_ERROR".to_string(),
+            message: err.to_string(),
+        }
+    }
+}
+
+impl From<tiberius::error::Error> for DbError {
+    fn from(err: tiberius::error::Error) -> Self {
+        DbError {
+            code: "MSSQL_ERROR".to_string(),
+            message: err.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_params() -> ConnectionParams {
+        ConnectionParams {
+            db_type: "mssql".to_string(),
+            host: "localhost".to_string(),
+            port: 1433,
+            database: "master".to_string(),
+            username: "sa".to_string(),
+            password: "Secret123".to_string(),
+            auth_source: None,
+        }
+    }
+
+    #[test]
+    fn config_sets_host_and_port() {
+        let params = base_params();
+        let cfg = build_mssql_config(&params);
+        let addr = cfg.get_addr();
+        assert!(addr.contains("localhost"));
+        assert!(addr.ends_with(":1433"));
+    }
+
+    #[test]
+    fn config_defaults_port_when_zero() {
+        let mut params = base_params();
+        params.port = 0;
+        let cfg = build_mssql_config(&params);
+        assert!(cfg.get_addr().ends_with(":1433"));
+    }
+
+    #[test]
+    fn config_honors_non_default_port() {
+        let mut params = base_params();
+        params.port = 1434;
+        let cfg = build_mssql_config(&params);
+        assert!(cfg.get_addr().ends_with(":1434"));
+    }
+
+    #[test]
+    fn config_omits_database_when_empty() {
+        let mut params = base_params();
+        params.database = String::new();
+        let _cfg = build_mssql_config(&params);
+    }
+}

--- a/apps/web/src-tauri/src/db/mssql.rs
+++ b/apps/web/src-tauri/src/db/mssql.rs
@@ -22,7 +22,9 @@ pub fn build_mssql_config(params: &ConnectionParams) -> Config {
     }
     config.authentication(AuthMethod::sql_server(&params.username, &params.password));
     config.encryption(EncryptionLevel::Required);
-    config.trust_cert();
+    if params.trust_server_certificate.unwrap_or(true) {
+        config.trust_cert();
+    }
     config
 }
 
@@ -101,6 +103,7 @@ mod tests {
             username: "sa".to_string(),
             password: "Secret123".to_string(),
             auth_source: None,
+            trust_server_certificate: None,
         }
     }
 
@@ -133,6 +136,15 @@ mod tests {
     fn config_omits_database_when_empty() {
         let mut params = base_params();
         params.database = String::new();
+        let _cfg = build_mssql_config(&params);
+    }
+
+    #[test]
+    fn config_accepts_explicit_trust_setting() {
+        let mut params = base_params();
+        params.trust_server_certificate = Some(false);
+        let _cfg = build_mssql_config(&params);
+        params.trust_server_certificate = Some(true);
         let _cfg = build_mssql_config(&params);
     }
 }

--- a/apps/web/src-tauri/src/db/pool.rs
+++ b/apps/web/src-tauri/src/db/pool.rs
@@ -194,10 +194,7 @@ async fn verify_connection(pool: &DatabasePool) -> Result<(), DbError> {
         DatabasePool::DuckDB(handle) => {
             let handle = handle.clone();
             tokio::task::spawn_blocking(move || -> Result<(), DbError> {
-                let conn = handle.try_lock().map_err(|_| DbError {
-                    code: "DUCKDB_BUSY".to_string(),
-                    message: "DuckDB connection is busy".to_string(),
-                })?;
+                let conn = handle.blocking_lock();
                 conn.execute_batch("SELECT 1").map_err(DbError::from)
             })
             .await

--- a/apps/web/src-tauri/src/db/pool.rs
+++ b/apps/web/src-tauri/src/db/pool.rs
@@ -1,10 +1,13 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
 use crate::db::clickhouse::ClickHouseConnection;
+use crate::db::duckdb::{open_duckdb, DuckDbHandle};
 use crate::db::error::DbError;
 use crate::db::mongodb_driver::build_mongodb_uri;
+use crate::db::mssql::{build_mssql_pool, MssqlPool};
 use crate::db::redis_driver::build_redis_url;
 use crate::db::types::ConnectionParams;
 
@@ -16,6 +19,8 @@ pub enum DatabasePool {
     MongoDB(mongodb::Client),
     Redis(redis::aio::MultiplexedConnection),
     ClickHouse(ClickHouseConnection),
+    DuckDB(DuckDbHandle),
+    Mssql(MssqlPool),
 }
 
 impl DatabasePool {
@@ -24,7 +29,11 @@ impl DatabasePool {
             DatabasePool::Postgres(pool) => pool.close().await,
             DatabasePool::MySql(pool) => pool.close().await,
             DatabasePool::Sqlite(pool) => pool.close().await,
-            DatabasePool::MongoDB(_) | DatabasePool::Redis(_) | DatabasePool::ClickHouse(_) => {}
+            DatabasePool::MongoDB(_)
+            | DatabasePool::Redis(_)
+            | DatabasePool::ClickHouse(_)
+            | DatabasePool::DuckDB(_)
+            | DatabasePool::Mssql(_) => {}
         }
     }
 }
@@ -125,6 +134,20 @@ async fn connect_native(params: &ConnectionParams) -> Result<DatabasePool, DbErr
             let conn = ClickHouseConnection::new(params)?;
             Ok(DatabasePool::ClickHouse(conn))
         }
+        "duckdb" => {
+            let params = params.clone();
+            let conn = tokio::task::spawn_blocking(move || open_duckdb(&params))
+                .await
+                .map_err(|e| DbError {
+                    code: "DUCKDB_JOIN_ERROR".to_string(),
+                    message: e.to_string(),
+                })??;
+            Ok(DatabasePool::DuckDB(Arc::new(Mutex::new(conn))))
+        }
+        "mssql" => {
+            let pool = build_mssql_pool(params).await?;
+            Ok(DatabasePool::Mssql(pool))
+        }
         other => Err(DbError {
             code: "UNSUPPORTED_DRIVER".to_string(),
             message: format!("Unsupported database type: {other}"),
@@ -167,6 +190,33 @@ async fn verify_connection(pool: &DatabasePool) -> Result<(), DbError> {
         }
         DatabasePool::ClickHouse(conn) => {
             conn.ping().await?;
+        }
+        DatabasePool::DuckDB(handle) => {
+            let handle = handle.clone();
+            tokio::task::spawn_blocking(move || -> Result<(), DbError> {
+                let conn = handle
+                    .try_lock()
+                    .map_err(|_| DbError {
+                        code: "DUCKDB_BUSY".to_string(),
+                        message: "DuckDB connection is busy".to_string(),
+                    })?;
+                conn.execute_batch("SELECT 1").map_err(DbError::from)
+            })
+            .await
+            .map_err(|e| DbError {
+                code: "DUCKDB_JOIN_ERROR".to_string(),
+                message: e.to_string(),
+            })??;
+        }
+        DatabasePool::Mssql(pool) => {
+            let mut client = pool.get().await.map_err(DbError::from)?;
+            client
+                .simple_query("SELECT 1")
+                .await
+                .map_err(DbError::from)?
+                .into_results()
+                .await
+                .map_err(DbError::from)?;
         }
     }
     Ok(())

--- a/apps/web/src-tauri/src/db/pool.rs
+++ b/apps/web/src-tauri/src/db/pool.rs
@@ -194,12 +194,10 @@ async fn verify_connection(pool: &DatabasePool) -> Result<(), DbError> {
         DatabasePool::DuckDB(handle) => {
             let handle = handle.clone();
             tokio::task::spawn_blocking(move || -> Result<(), DbError> {
-                let conn = handle
-                    .try_lock()
-                    .map_err(|_| DbError {
-                        code: "DUCKDB_BUSY".to_string(),
-                        message: "DuckDB connection is busy".to_string(),
-                    })?;
+                let conn = handle.try_lock().map_err(|_| DbError {
+                    code: "DUCKDB_BUSY".to_string(),
+                    message: "DuckDB connection is busy".to_string(),
+                })?;
                 conn.execute_batch("SELECT 1").map_err(DbError::from)
             })
             .await

--- a/apps/web/src-tauri/src/db/schema.rs
+++ b/apps/web/src-tauri/src/db/schema.rs
@@ -1,7 +1,9 @@
 use sqlx::Row;
 
 use crate::db::clickhouse::ClickHouseConnection;
+use crate::db::duckdb::DuckDbHandle;
 use crate::db::error::DbError;
+use crate::db::mssql::MssqlPool;
 use crate::db::pool::DatabasePool;
 use crate::db::types::{
     ColumnDetail, ForeignKeyItem, IndexItem, SchemaInfo, SchemaItem, TableItem, ViewItem,
@@ -18,6 +20,8 @@ pub async fn list_databases(pool: &DatabasePool) -> Result<Vec<String>, DbError>
         }
         DatabasePool::Redis(_) => Ok((0u8..16).map(|i| format!("db{i}")).collect()),
         DatabasePool::ClickHouse(conn) => list_databases_clickhouse(conn).await,
+        DatabasePool::DuckDB(handle) => list_databases_duckdb(handle).await,
+        DatabasePool::Mssql(pool) => list_databases_mssql(pool).await,
     }
 }
 
@@ -35,6 +39,8 @@ pub async fn fetch_schema(pool: &DatabasePool, database_name: &str) -> Result<Sc
             }],
         }),
         DatabasePool::ClickHouse(conn) => fetch_schema_clickhouse(conn, database_name).await,
+        DatabasePool::DuckDB(handle) => fetch_schema_duckdb(handle, database_name).await,
+        DatabasePool::Mssql(pool) => fetch_schema_mssql(pool, database_name).await,
     }
 }
 
@@ -943,4 +949,401 @@ async fn fetch_indexes_clickhouse(
             }
         })
         .collect())
+}
+
+// DuckDB introspection
+
+async fn list_databases_duckdb(handle: &DuckDbHandle) -> Result<Vec<String>, DbError> {
+    let handle = handle.clone();
+    tokio::task::spawn_blocking(move || -> Result<Vec<String>, DbError> {
+        let conn = handle.try_lock().map_err(|_| DbError {
+            code: "DUCKDB_BUSY".to_string(),
+            message: "DuckDB connection is busy".to_string(),
+        })?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT DISTINCT table_schema FROM information_schema.tables \
+                 WHERE table_schema NOT IN ('information_schema', 'pg_catalog') \
+                 ORDER BY table_schema",
+            )
+            .map_err(DbError::from)?;
+        let names = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(DbError::from)?
+            .filter_map(Result::ok)
+            .collect::<Vec<_>>();
+        if names.is_empty() {
+            Ok(vec!["main".to_string()])
+        } else {
+            Ok(names)
+        }
+    })
+    .await
+    .map_err(|e| DbError {
+        code: "DUCKDB_JOIN_ERROR".to_string(),
+        message: e.to_string(),
+    })?
+}
+
+async fn fetch_schema_duckdb(
+    handle: &DuckDbHandle,
+    schema_name: &str,
+) -> Result<SchemaInfo, DbError> {
+    let handle = handle.clone();
+    let schema = schema_name.to_string();
+    tokio::task::spawn_blocking(move || -> Result<SchemaInfo, DbError> {
+        let conn = handle.try_lock().map_err(|_| DbError {
+            code: "DUCKDB_BUSY".to_string(),
+            message: "DuckDB connection is busy".to_string(),
+        })?;
+
+        let mut table_stmt = conn
+            .prepare(
+                "SELECT table_name, table_type, estimated_size FROM information_schema.tables \
+                 WHERE table_schema = ? ORDER BY table_name",
+            )
+            .map_err(DbError::from)?;
+        let rows = table_stmt
+            .query_map([schema.as_str()], |row| {
+                let name: String = row.get(0)?;
+                let kind: String = row.get(1)?;
+                let estimate: Option<i64> = row.get::<_, Option<i64>>(2).ok().flatten();
+                Ok((name, kind, estimate))
+            })
+            .map_err(DbError::from)?;
+
+        let mut tables: Vec<TableItem> = Vec::new();
+        let mut views: Vec<ViewItem> = Vec::new();
+
+        for row in rows {
+            let (name, kind, estimate) = row.map_err(DbError::from)?;
+            let columns = fetch_columns_duckdb(&conn, &schema, &name)?;
+            if kind.eq_ignore_ascii_case("VIEW") {
+                views.push(ViewItem { name, columns });
+            } else {
+                tables.push(TableItem {
+                    name,
+                    columns,
+                    indexes: vec![],
+                    foreign_keys: vec![],
+                    row_estimate: estimate.and_then(|v| u64::try_from(v).ok()),
+                });
+            }
+        }
+
+        Ok(SchemaInfo {
+            schemas: vec![SchemaItem {
+                name: schema,
+                tables,
+                views,
+            }],
+        })
+    })
+    .await
+    .map_err(|e| DbError {
+        code: "DUCKDB_JOIN_ERROR".to_string(),
+        message: e.to_string(),
+    })?
+}
+
+fn fetch_columns_duckdb(
+    conn: &duckdb::Connection,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<ColumnDetail>, DbError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT column_name, data_type, is_nullable, column_default \
+             FROM information_schema.columns \
+             WHERE table_schema = ? AND table_name = ? ORDER BY ordinal_position",
+        )
+        .map_err(DbError::from)?;
+
+    let rows = stmt
+        .query_map([schema, table], |row| {
+            Ok(ColumnDetail {
+                name: row.get::<_, String>(0)?,
+                data_type: row.get::<_, String>(1)?,
+                is_nullable: row
+                    .get::<_, String>(2)
+                    .map(|s| s.eq_ignore_ascii_case("YES"))
+                    .unwrap_or(true),
+                is_primary_key: false,
+                default_value: row.get::<_, Option<String>>(3).ok().flatten(),
+            })
+        })
+        .map_err(DbError::from)?;
+
+    rows.collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(DbError::from)
+}
+
+// MSSQL introspection
+
+async fn list_databases_mssql(pool: &MssqlPool) -> Result<Vec<String>, DbError> {
+    let mut client = pool.get().await.map_err(DbError::from)?;
+    let results = client
+        .simple_query(
+            "SELECT name FROM sys.schemas \
+             WHERE name NOT IN ('sys','INFORMATION_SCHEMA','guest','db_owner',\
+             'db_accessadmin','db_securityadmin','db_ddladmin','db_backupoperator',\
+             'db_datareader','db_datawriter','db_denydatareader','db_denydatawriter') \
+             ORDER BY name",
+        )
+        .await
+        .map_err(DbError::from)?
+        .into_results()
+        .await
+        .map_err(DbError::from)?;
+
+    let names: Vec<String> = results
+        .into_iter()
+        .flatten()
+        .filter_map(|row| row.try_get::<&str, _>(0).ok().flatten().map(|s| s.to_string()))
+        .collect();
+    if names.is_empty() {
+        Ok(vec!["dbo".to_string()])
+    } else {
+        Ok(names)
+    }
+}
+
+async fn fetch_schema_mssql(pool: &MssqlPool, schema_name: &str) -> Result<SchemaInfo, DbError> {
+    let mut client = pool.get().await.map_err(DbError::from)?;
+
+    let tables = fetch_tables_mssql(&mut *client, schema_name).await?;
+    let views = fetch_views_mssql(&mut *client, schema_name).await?;
+
+    Ok(SchemaInfo {
+        schemas: vec![SchemaItem {
+            name: schema_name.to_string(),
+            tables,
+            views,
+        }],
+    })
+}
+
+async fn fetch_tables_mssql(
+    client: &mut bb8_tiberius::rt::Client,
+    schema_name: &str,
+) -> Result<Vec<TableItem>, DbError> {
+    let query = format!(
+        "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES \
+         WHERE TABLE_SCHEMA = '{}' AND TABLE_TYPE = 'BASE TABLE' \
+         ORDER BY TABLE_NAME",
+        escape_mssql_literal(schema_name)
+    );
+    let results = client
+        .simple_query(query)
+        .await
+        .map_err(DbError::from)?
+        .into_results()
+        .await
+        .map_err(DbError::from)?;
+
+    let names: Vec<String> = results
+        .into_iter()
+        .flatten()
+        .filter_map(|row| row.try_get::<&str, _>(0).ok().flatten().map(|s| s.to_string()))
+        .collect();
+
+    let mut tables = Vec::with_capacity(names.len());
+    for name in names {
+        let columns = fetch_columns_mssql(client, schema_name, &name).await?;
+        let indexes = fetch_indexes_mssql(client, schema_name, &name).await?;
+        tables.push(TableItem {
+            name,
+            columns,
+            indexes,
+            foreign_keys: vec![],
+            row_estimate: None,
+        });
+    }
+    Ok(tables)
+}
+
+async fn fetch_views_mssql(
+    client: &mut bb8_tiberius::rt::Client,
+    schema_name: &str,
+) -> Result<Vec<ViewItem>, DbError> {
+    let query = format!(
+        "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS \
+         WHERE TABLE_SCHEMA = '{}' ORDER BY TABLE_NAME",
+        escape_mssql_literal(schema_name)
+    );
+    let results = client
+        .simple_query(query)
+        .await
+        .map_err(DbError::from)?
+        .into_results()
+        .await
+        .map_err(DbError::from)?;
+
+    let names: Vec<String> = results
+        .into_iter()
+        .flatten()
+        .filter_map(|row| row.try_get::<&str, _>(0).ok().flatten().map(|s| s.to_string()))
+        .collect();
+
+    let mut views = Vec::with_capacity(names.len());
+    for name in names {
+        let columns = fetch_columns_mssql(client, schema_name, &name).await?;
+        views.push(ViewItem { name, columns });
+    }
+    Ok(views)
+}
+
+async fn fetch_columns_mssql(
+    client: &mut bb8_tiberius::rt::Client,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<Vec<ColumnDetail>, DbError> {
+    let query = format!(
+        "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT \
+         FROM INFORMATION_SCHEMA.COLUMNS \
+         WHERE TABLE_SCHEMA = '{}' AND TABLE_NAME = '{}' \
+         ORDER BY ORDINAL_POSITION",
+        escape_mssql_literal(schema_name),
+        escape_mssql_literal(table_name)
+    );
+    let results = client
+        .simple_query(query)
+        .await
+        .map_err(DbError::from)?
+        .into_results()
+        .await
+        .map_err(DbError::from)?;
+
+    let pk_cols = fetch_primary_key_columns_mssql(client, schema_name, table_name).await?;
+
+    let columns = results
+        .into_iter()
+        .flatten()
+        .map(|row| {
+            let name = row
+                .try_get::<&str, _>(0)
+                .ok()
+                .flatten()
+                .unwrap_or("")
+                .to_string();
+            let data_type = row
+                .try_get::<&str, _>(1)
+                .ok()
+                .flatten()
+                .unwrap_or("")
+                .to_string();
+            let nullable = row
+                .try_get::<&str, _>(2)
+                .ok()
+                .flatten()
+                .map(|s| s.eq_ignore_ascii_case("YES"))
+                .unwrap_or(true);
+            let default_value = row
+                .try_get::<&str, _>(3)
+                .ok()
+                .flatten()
+                .map(|s| s.to_string());
+            ColumnDetail {
+                is_primary_key: pk_cols.iter().any(|c| c == &name),
+                name,
+                data_type,
+                is_nullable: nullable,
+                default_value,
+            }
+        })
+        .collect();
+    Ok(columns)
+}
+
+async fn fetch_primary_key_columns_mssql(
+    client: &mut bb8_tiberius::rt::Client,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<Vec<String>, DbError> {
+    let query = format!(
+        "SELECT kcu.COLUMN_NAME \
+         FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc \
+         JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu \
+         ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME \
+         AND tc.CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA \
+         WHERE tc.TABLE_SCHEMA = '{}' AND tc.TABLE_NAME = '{}' \
+         AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' \
+         ORDER BY kcu.ORDINAL_POSITION",
+        escape_mssql_literal(schema_name),
+        escape_mssql_literal(table_name)
+    );
+    let results = client
+        .simple_query(query)
+        .await
+        .map_err(DbError::from)?
+        .into_results()
+        .await
+        .map_err(DbError::from)?;
+    Ok(results
+        .into_iter()
+        .flatten()
+        .filter_map(|row| row.try_get::<&str, _>(0).ok().flatten().map(|s| s.to_string()))
+        .collect())
+}
+
+async fn fetch_indexes_mssql(
+    client: &mut bb8_tiberius::rt::Client,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<Vec<IndexItem>, DbError> {
+    let query = format!(
+        "SELECT i.name, i.is_unique, c.name \
+         FROM sys.indexes i \
+         JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id \
+         JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id \
+         JOIN sys.tables t ON t.object_id = i.object_id \
+         JOIN sys.schemas s ON s.schema_id = t.schema_id \
+         WHERE s.name = '{}' AND t.name = '{}' AND i.is_hypothetical = 0 \
+         ORDER BY i.name, ic.key_ordinal",
+        escape_mssql_literal(schema_name),
+        escape_mssql_literal(table_name)
+    );
+    let results = client
+        .simple_query(query)
+        .await
+        .map_err(DbError::from)?
+        .into_results()
+        .await
+        .map_err(DbError::from)?;
+
+    let mut map: std::collections::HashMap<String, (bool, Vec<String>)> =
+        std::collections::HashMap::new();
+    for row in results.into_iter().flatten() {
+        let name = row
+            .try_get::<&str, _>(0)
+            .ok()
+            .flatten()
+            .unwrap_or("")
+            .to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let is_unique = row.try_get::<bool, _>(1).ok().flatten().unwrap_or(false);
+        let col = row
+            .try_get::<&str, _>(2)
+            .ok()
+            .flatten()
+            .unwrap_or("")
+            .to_string();
+        let entry = map.entry(name).or_insert((is_unique, Vec::new()));
+        entry.1.push(col);
+    }
+
+    Ok(map
+        .into_iter()
+        .map(|(name, (is_unique, columns))| IndexItem {
+            name,
+            columns,
+            is_unique,
+        })
+        .collect())
+}
+
+fn escape_mssql_literal(input: &str) -> String {
+    input.replace('\'', "''")
 }

--- a/apps/web/src-tauri/src/db/schema.rs
+++ b/apps/web/src-tauri/src/db/schema.rs
@@ -1099,7 +1099,12 @@ async fn list_databases_mssql(pool: &MssqlPool) -> Result<Vec<String>, DbError> 
     let names: Vec<String> = results
         .into_iter()
         .flatten()
-        .filter_map(|row| row.try_get::<&str, _>(0).ok().flatten().map(|s| s.to_string()))
+        .filter_map(|row| {
+            row.try_get::<&str, _>(0)
+                .ok()
+                .flatten()
+                .map(|s| s.to_string())
+        })
         .collect();
     if names.is_empty() {
         Ok(vec!["dbo".to_string()])
@@ -1144,7 +1149,12 @@ async fn fetch_tables_mssql(
     let names: Vec<String> = results
         .into_iter()
         .flatten()
-        .filter_map(|row| row.try_get::<&str, _>(0).ok().flatten().map(|s| s.to_string()))
+        .filter_map(|row| {
+            row.try_get::<&str, _>(0)
+                .ok()
+                .flatten()
+                .map(|s| s.to_string())
+        })
         .collect();
 
     let mut tables = Vec::with_capacity(names.len());
@@ -1182,7 +1192,12 @@ async fn fetch_views_mssql(
     let names: Vec<String> = results
         .into_iter()
         .flatten()
-        .filter_map(|row| row.try_get::<&str, _>(0).ok().flatten().map(|s| s.to_string()))
+        .filter_map(|row| {
+            row.try_get::<&str, _>(0)
+                .ok()
+                .flatten()
+                .map(|s| s.to_string())
+        })
         .collect();
 
     let mut views = Vec::with_capacity(names.len());
@@ -1282,7 +1297,12 @@ async fn fetch_primary_key_columns_mssql(
     Ok(results
         .into_iter()
         .flatten()
-        .filter_map(|row| row.try_get::<&str, _>(0).ok().flatten().map(|s| s.to_string()))
+        .filter_map(|row| {
+            row.try_get::<&str, _>(0)
+                .ok()
+                .flatten()
+                .map(|s| s.to_string())
+        })
         .collect())
 }
 

--- a/apps/web/src-tauri/src/db/schema.rs
+++ b/apps/web/src-tauri/src/db/schema.rs
@@ -1116,8 +1116,8 @@ async fn list_databases_mssql(pool: &MssqlPool) -> Result<Vec<String>, DbError> 
 async fn fetch_schema_mssql(pool: &MssqlPool, schema_name: &str) -> Result<SchemaInfo, DbError> {
     let mut client = pool.get().await.map_err(DbError::from)?;
 
-    let tables = fetch_tables_mssql(&mut *client, schema_name).await?;
-    let views = fetch_views_mssql(&mut *client, schema_name).await?;
+    let tables = fetch_tables_mssql(&mut client, schema_name).await?;
+    let views = fetch_views_mssql(&mut client, schema_name).await?;
 
     Ok(SchemaInfo {
         schemas: vec![SchemaItem {

--- a/apps/web/src-tauri/src/db/schema.rs
+++ b/apps/web/src-tauri/src/db/schema.rs
@@ -962,9 +962,8 @@ async fn list_databases_duckdb(handle: &DuckDbHandle) -> Result<Vec<String>, DbE
         })?;
         let mut stmt = conn
             .prepare(
-                "SELECT DISTINCT table_schema FROM information_schema.tables \
-                 WHERE table_schema NOT IN ('information_schema', 'pg_catalog') \
-                 ORDER BY table_schema",
+                "SELECT schema_name FROM duckdb_schemas() \
+                 WHERE NOT internal ORDER BY schema_name",
             )
             .map_err(DbError::from)?;
         let names = stmt
@@ -997,39 +996,8 @@ async fn fetch_schema_duckdb(
             message: "DuckDB connection is busy".to_string(),
         })?;
 
-        let mut table_stmt = conn
-            .prepare(
-                "SELECT table_name, table_type, estimated_size FROM information_schema.tables \
-                 WHERE table_schema = ? ORDER BY table_name",
-            )
-            .map_err(DbError::from)?;
-        let rows = table_stmt
-            .query_map([schema.as_str()], |row| {
-                let name: String = row.get(0)?;
-                let kind: String = row.get(1)?;
-                let estimate: Option<i64> = row.get::<_, Option<i64>>(2).ok().flatten();
-                Ok((name, kind, estimate))
-            })
-            .map_err(DbError::from)?;
-
-        let mut tables: Vec<TableItem> = Vec::new();
-        let mut views: Vec<ViewItem> = Vec::new();
-
-        for row in rows {
-            let (name, kind, estimate) = row.map_err(DbError::from)?;
-            let columns = fetch_columns_duckdb(&conn, &schema, &name)?;
-            if kind.eq_ignore_ascii_case("VIEW") {
-                views.push(ViewItem { name, columns });
-            } else {
-                tables.push(TableItem {
-                    name,
-                    columns,
-                    indexes: vec![],
-                    foreign_keys: vec![],
-                    row_estimate: estimate.and_then(|v| u64::try_from(v).ok()),
-                });
-            }
-        }
+        let tables = fetch_tables_duckdb(&conn, &schema)?;
+        let views = fetch_views_duckdb(&conn, &schema)?;
 
         Ok(SchemaInfo {
             schemas: vec![SchemaItem {
@@ -1046,11 +1014,67 @@ async fn fetch_schema_duckdb(
     })?
 }
 
+fn fetch_tables_duckdb(conn: &duckdb::Connection, schema: &str) -> Result<Vec<TableItem>, DbError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT table_name, estimated_size FROM duckdb_tables() \
+             WHERE schema_name = ? AND NOT temporary AND NOT internal \
+             ORDER BY table_name",
+        )
+        .map_err(DbError::from)?;
+
+    let rows = stmt
+        .query_map([schema], |row| {
+            let name: String = row.get(0)?;
+            let estimate: Option<i64> = row.get::<_, Option<i64>>(1).ok().flatten();
+            Ok((name, estimate))
+        })
+        .map_err(DbError::from)?;
+
+    let mut tables = Vec::new();
+    for row in rows {
+        let (name, estimate) = row.map_err(DbError::from)?;
+        let columns = fetch_columns_duckdb(conn, schema, &name)?;
+        tables.push(TableItem {
+            name,
+            columns,
+            indexes: vec![],
+            foreign_keys: vec![],
+            row_estimate: estimate.and_then(|v| u64::try_from(v).ok()),
+        });
+    }
+    Ok(tables)
+}
+
+fn fetch_views_duckdb(conn: &duckdb::Connection, schema: &str) -> Result<Vec<ViewItem>, DbError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT view_name FROM duckdb_views() \
+             WHERE schema_name = ? AND NOT internal ORDER BY view_name",
+        )
+        .map_err(DbError::from)?;
+
+    let names = stmt
+        .query_map([schema], |row| row.get::<_, String>(0))
+        .map_err(DbError::from)?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(DbError::from)?;
+
+    let mut views = Vec::with_capacity(names.len());
+    for name in names {
+        let columns = fetch_columns_duckdb(conn, schema, &name)?;
+        views.push(ViewItem { name, columns });
+    }
+    Ok(views)
+}
+
 fn fetch_columns_duckdb(
     conn: &duckdb::Connection,
     schema: &str,
     table: &str,
 ) -> Result<Vec<ColumnDetail>, DbError> {
+    let pk_cols = fetch_primary_key_columns_duckdb(conn, schema, table)?;
+
     let mut stmt = conn
         .prepare(
             "SELECT column_name, data_type, is_nullable, column_default \
@@ -1061,21 +1085,44 @@ fn fetch_columns_duckdb(
 
     let rows = stmt
         .query_map([schema, table], |row| {
+            let name: String = row.get(0)?;
+            let data_type: String = row.get(1)?;
+            let nullable = row
+                .get::<_, String>(2)
+                .map(|s| s.eq_ignore_ascii_case("YES"))
+                .unwrap_or(true);
+            let default_value = row.get::<_, Option<String>>(3).ok().flatten();
             Ok(ColumnDetail {
-                name: row.get::<_, String>(0)?,
-                data_type: row.get::<_, String>(1)?,
-                is_nullable: row
-                    .get::<_, String>(2)
-                    .map(|s| s.eq_ignore_ascii_case("YES"))
-                    .unwrap_or(true),
-                is_primary_key: false,
-                default_value: row.get::<_, Option<String>>(3).ok().flatten(),
+                is_primary_key: pk_cols.iter().any(|c| c == &name),
+                name,
+                data_type,
+                is_nullable: nullable,
+                default_value,
             })
         })
         .map_err(DbError::from)?;
 
     rows.collect::<std::result::Result<Vec<_>, _>>()
         .map_err(DbError::from)
+}
+
+fn fetch_primary_key_columns_duckdb(
+    conn: &duckdb::Connection,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<String>, DbError> {
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT UNNEST(constraint_column_names) FROM duckdb_constraints() \
+         WHERE schema_name = ? AND table_name = ? AND constraint_type = 'PRIMARY KEY'",
+    ) else {
+        return Ok(Vec::new());
+    };
+
+    let Ok(rows) = stmt.query_map([schema, table], |row| row.get::<_, String>(0)) else {
+        return Ok(Vec::new());
+    };
+
+    Ok(rows.flatten().collect())
 }
 
 // MSSQL introspection

--- a/apps/web/src-tauri/src/db/types.rs
+++ b/apps/web/src-tauri/src/db/types.rs
@@ -70,6 +70,8 @@ pub struct ConnectionParams {
     pub password: String,
     #[serde(default)]
     pub auth_source: Option<String>,
+    #[serde(default)]
+    pub trust_server_certificate: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/apps/web/src-tauri/src/db/version.rs
+++ b/apps/web/src-tauri/src/db/version.rs
@@ -65,5 +65,44 @@ pub async fn fetch_version(pool: &DatabasePool) -> Result<String, DbError> {
                 .unwrap_or("unknown");
             Ok(format!("ClickHouse {ver}"))
         }
+        DatabasePool::DuckDB(handle) => {
+            let handle = handle.clone();
+            let ver = tokio::task::spawn_blocking(move || -> Result<String, DbError> {
+                let conn = handle
+                    .try_lock()
+                    .map_err(|_| DbError {
+                        code: "DUCKDB_BUSY".to_string(),
+                        message: "DuckDB connection is busy".to_string(),
+                    })?;
+                let v: String = conn
+                    .query_row("SELECT version()", [], |row| row.get(0))
+                    .map_err(DbError::from)?;
+                Ok(v)
+            })
+            .await
+            .map_err(|e| DbError {
+                code: "DUCKDB_JOIN_ERROR".to_string(),
+                message: e.to_string(),
+            })??;
+            Ok(format!("DuckDB {ver}"))
+        }
+        DatabasePool::Mssql(pool) => {
+            let mut client = pool.get().await.map_err(DbError::from)?;
+            let rows = client
+                .simple_query("SELECT @@VERSION")
+                .await
+                .map_err(DbError::from)?
+                .into_results()
+                .await
+                .map_err(DbError::from)?;
+            let ver = rows
+                .into_iter()
+                .flatten()
+                .next()
+                .and_then(|r| r.try_get::<&str, _>(0).ok().flatten().map(|s| s.to_string()))
+                .unwrap_or_else(|| "unknown".to_string());
+            let first_line = ver.lines().next().unwrap_or("unknown").trim().to_string();
+            Ok(first_line)
+        }
     }
 }

--- a/apps/web/src-tauri/src/db/version.rs
+++ b/apps/web/src-tauri/src/db/version.rs
@@ -68,12 +68,10 @@ pub async fn fetch_version(pool: &DatabasePool) -> Result<String, DbError> {
         DatabasePool::DuckDB(handle) => {
             let handle = handle.clone();
             let ver = tokio::task::spawn_blocking(move || -> Result<String, DbError> {
-                let conn = handle
-                    .try_lock()
-                    .map_err(|_| DbError {
-                        code: "DUCKDB_BUSY".to_string(),
-                        message: "DuckDB connection is busy".to_string(),
-                    })?;
+                let conn = handle.try_lock().map_err(|_| DbError {
+                    code: "DUCKDB_BUSY".to_string(),
+                    message: "DuckDB connection is busy".to_string(),
+                })?;
                 let v: String = conn
                     .query_row("SELECT version()", [], |row| row.get(0))
                     .map_err(DbError::from)?;
@@ -99,7 +97,12 @@ pub async fn fetch_version(pool: &DatabasePool) -> Result<String, DbError> {
                 .into_iter()
                 .flatten()
                 .next()
-                .and_then(|r| r.try_get::<&str, _>(0).ok().flatten().map(|s| s.to_string()))
+                .and_then(|r| {
+                    r.try_get::<&str, _>(0)
+                        .ok()
+                        .flatten()
+                        .map(|s| s.to_string())
+                })
                 .unwrap_or_else(|| "unknown".to_string());
             let first_line = ver.lines().next().unwrap_or("unknown").trim().to_string();
             Ok(first_line)

--- a/apps/web/src-tauri/src/db/version.rs
+++ b/apps/web/src-tauri/src/db/version.rs
@@ -68,10 +68,7 @@ pub async fn fetch_version(pool: &DatabasePool) -> Result<String, DbError> {
         DatabasePool::DuckDB(handle) => {
             let handle = handle.clone();
             let ver = tokio::task::spawn_blocking(move || -> Result<String, DbError> {
-                let conn = handle.try_lock().map_err(|_| DbError {
-                    code: "DUCKDB_BUSY".to_string(),
-                    message: "DuckDB connection is busy".to_string(),
-                })?;
+                let conn = handle.blocking_lock();
                 let v: String = conn
                     .query_row("SELECT version()", [], |row| row.get(0))
                     .map_err(DbError::from)?;

--- a/apps/web/src/components/connection-form.test.tsx
+++ b/apps/web/src/components/connection-form.test.tsx
@@ -52,6 +52,32 @@ describe("connectionForm engine variants", () => {
     expect(username.placeholder).toBe("sa");
   });
 
+  it("renders trust-server-certificate checkbox defaulted on for MSSQL", () => {
+    render(<ConnectionForm connection={connectionFor("mssql")} />);
+    const checkbox = screen.getByLabelText(
+      "Trust server certificate"
+    ) as HTMLInputElement;
+    expect(checkbox).toBeDefined();
+    expect(checkbox.checked).toBeTruthy();
+  });
+
+  it("hides trust-server-certificate checkbox for non-MSSQL engines", () => {
+    render(<ConnectionForm connection={connectionFor("postgresql")} />);
+    expect(screen.queryByLabelText("Trust server certificate")).toBeNull();
+  });
+
+  it("preserves trust-server-certificate=false from a saved connection", () => {
+    const conn: DatabaseConnection = {
+      ...connectionFor("mssql"),
+      trustServerCertificate: false,
+    };
+    render(<ConnectionForm connection={conn} />);
+    const checkbox = screen.getByLabelText(
+      "Trust server certificate"
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBeFalsy();
+  });
+
   it("renders ClickHouse form with host/port/username/password and port 8123", () => {
     render(<ConnectionForm connection={connectionFor("clickhouse")} />);
 

--- a/apps/web/src/components/connection-form.test.tsx
+++ b/apps/web/src/components/connection-form.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type {
+  DatabaseConnection,
+  DatabaseType,
+} from "@/lib/connections";
+
+import { ConnectionForm } from "./connection-form";
+
+const connectionFor = (type: DatabaseType): DatabaseConnection => ({
+  createdAt: "2026-01-01T00:00:00.000Z",
+  database: type === "duckdb" ? ":memory:" : "app",
+  host: type === "duckdb" || type === "sqlite" ? "" : "localhost",
+  id: `test-${type}`,
+  lastConnectedAt: null,
+  name: `Test ${type}`,
+  password: "",
+  pinned: false,
+  port:
+    type === "duckdb" || type === "sqlite"
+      ? 0
+      : type === "mssql"
+        ? 1433
+        : type === "clickhouse"
+          ? 8123
+          : 5432,
+  type,
+  username: type === "duckdb" || type === "sqlite" || type === "redis" ? "" : "user",
+});
+
+describe("ConnectionForm engine variants", () => {
+  it("renders DuckDB form without host/port/username/password, with File path label and :memory: hint", () => {
+    render(<ConnectionForm connection={connectionFor("duckdb")} />);
+
+    expect(screen.queryByLabelText("Host")).toBeNull();
+    expect(screen.queryByLabelText("Port")).toBeNull();
+    expect(screen.queryByLabelText("Username")).toBeNull();
+    expect(screen.queryByLabelText("Password")).toBeNull();
+
+    expect(screen.getByLabelText("File path")).toBeDefined();
+
+    const db = screen.getByLabelText("File path") as HTMLInputElement;
+    expect(db.placeholder).toContain(":memory:");
+  });
+
+  it("renders MSSQL form with host/port/username/password and sa placeholder", () => {
+    render(<ConnectionForm connection={connectionFor("mssql")} />);
+
+    expect(screen.getByLabelText("Host")).toBeDefined();
+    const port = screen.getByLabelText("Port") as HTMLInputElement;
+    expect(port.value).toBe("1433");
+
+    const username = screen.getByLabelText("Username") as HTMLInputElement;
+    expect(username.placeholder).toBe("sa");
+
+    expect(screen.getByLabelText("Password")).toBeDefined();
+  });
+
+  it("renders ClickHouse form with host/port/username/password and port 8123", () => {
+    render(<ConnectionForm connection={connectionFor("clickhouse")} />);
+
+    expect(screen.getByLabelText("Host")).toBeDefined();
+    const port = screen.getByLabelText("Port") as HTMLInputElement;
+    expect(port.value).toBe("8123");
+
+    const username = screen.getByLabelText("Username") as HTMLInputElement;
+    expect(username.placeholder).toBe("default");
+  });
+});

--- a/apps/web/src/components/connection-form.test.tsx
+++ b/apps/web/src/components/connection-form.test.tsx
@@ -1,44 +1,41 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import type {
-  DatabaseConnection,
-  DatabaseType,
-} from "@/lib/connections";
+import type { DatabaseConnection, DatabaseType } from "@/lib/connections";
+
+import { DEFAULT_PORTS } from "@/lib/connections";
 
 import { ConnectionForm } from "./connection-form";
+
+const SERVERLESS = new Set<DatabaseType>(["duckdb", "sqlite"]);
+const PASSWORDLESS = new Set<DatabaseType>(["duckdb", "sqlite", "redis"]);
 
 const connectionFor = (type: DatabaseType): DatabaseConnection => ({
   createdAt: "2026-01-01T00:00:00.000Z",
   database: type === "duckdb" ? ":memory:" : "app",
-  host: type === "duckdb" || type === "sqlite" ? "" : "localhost",
+  host: SERVERLESS.has(type) ? "" : "localhost",
   id: `test-${type}`,
   lastConnectedAt: null,
   name: `Test ${type}`,
   password: "",
   pinned: false,
-  port:
-    type === "duckdb" || type === "sqlite"
-      ? 0
-      : type === "mssql"
-        ? 1433
-        : type === "clickhouse"
-          ? 8123
-          : 5432,
+  port: DEFAULT_PORTS[type],
   type,
-  username: type === "duckdb" || type === "sqlite" || type === "redis" ? "" : "user",
+  username: PASSWORDLESS.has(type) ? "" : "user",
 });
 
-describe("ConnectionForm engine variants", () => {
-  it("renders DuckDB form without host/port/username/password, with File path label and :memory: hint", () => {
+describe("connectionForm engine variants", () => {
+  it("hides server fields for DuckDB", () => {
     render(<ConnectionForm connection={connectionFor("duckdb")} />);
 
     expect(screen.queryByLabelText("Host")).toBeNull();
     expect(screen.queryByLabelText("Port")).toBeNull();
     expect(screen.queryByLabelText("Username")).toBeNull();
     expect(screen.queryByLabelText("Password")).toBeNull();
+  });
 
-    expect(screen.getByLabelText("File path")).toBeDefined();
+  it("shows a File path field with a :memory: placeholder for DuckDB", () => {
+    render(<ConnectionForm connection={connectionFor("duckdb")} />);
 
     const db = screen.getByLabelText("File path") as HTMLInputElement;
     expect(db.placeholder).toContain(":memory:");
@@ -53,8 +50,6 @@ describe("ConnectionForm engine variants", () => {
 
     const username = screen.getByLabelText("Username") as HTMLInputElement;
     expect(username.placeholder).toBe("sa");
-
-    expect(screen.getByLabelText("Password")).toBeDefined();
   });
 
   it("renders ClickHouse form with host/port/username/password and port 8123", () => {

--- a/apps/web/src/components/connection-form.tsx
+++ b/apps/web/src/components/connection-form.tsx
@@ -17,6 +17,7 @@ import type {
 
 import { DATABASE_ICON_MAP } from "@/components/icons/database-icons";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Collapsible,
   CollapsibleContent,
@@ -396,6 +397,7 @@ interface FormState {
   username: string;
   password: string;
   authSource: string;
+  trustServerCertificate: boolean;
   emoji: string;
   color: ConnectionColor | "";
   environment: ConnectionEnvironment | "";
@@ -417,6 +419,7 @@ const INITIAL_STATE: FormState = {
   name: "",
   password: "",
   port: String(DEFAULT_PORTS.postgresql),
+  trustServerCertificate: true,
   type: "postgresql",
   username: "",
 };
@@ -431,6 +434,7 @@ const connectionToFormState = (conn: DatabaseConnection): FormState => ({
   name: conn.name,
   password: conn.password,
   port: String(conn.port),
+  trustServerCertificate: conn.trustServerCertificate ?? true,
   type: conn.type,
   username: conn.username,
 });
@@ -529,6 +533,8 @@ const buildConnection = (form: FormState): DatabaseConnection => {
     password: hasHost ? form.password : "",
     pinned: false,
     port: hasHost ? Number(form.port) : 0,
+    trustServerCertificate:
+      form.type === "mssql" ? form.trustServerCertificate : undefined,
     type: form.type,
     username: hasUsername ? form.username.trim() : "",
   };
@@ -546,6 +552,8 @@ const buildConnectionParams = (form: FormState) => {
     host: hasHost ? form.host.trim() : "",
     password: hasHost ? form.password : "",
     port: hasHost ? Number(form.port) : 0,
+    trustServerCertificate:
+      form.type === "mssql" ? form.trustServerCertificate : undefined,
     type: form.type,
     username: hasUsername ? form.username.trim() : "",
   };
@@ -631,6 +639,11 @@ export const ConnectionForm = ({
 
   const handleColorSelect = useCallback((color: ConnectionColor | "") => {
     setForm((prev) => ({ ...prev, color }));
+  }, []);
+
+  const handleTrustCertChange = useCallback((checked: boolean) => {
+    setForm((prev) => ({ ...prev, trustServerCertificate: checked }));
+    setTestStatus({ state: "idle" });
   }, []);
 
   const handleEmojiSelect = useCallback((emoji: string) => {
@@ -765,6 +778,22 @@ export const ConnectionForm = ({
         updateField={updateField}
         username={form.username}
       />
+
+      {form.type === "mssql" && (
+        <div className="grid gap-1.5">
+          <Label className="flex items-center gap-2 font-normal">
+            <Checkbox
+              checked={form.trustServerCertificate}
+              onCheckedChange={handleTrustCertChange}
+            />
+            Trust server certificate
+          </Label>
+          <p className="pl-6 text-xs text-muted-foreground">
+            Skip TLS certificate verification. Disable for production servers
+            with a valid certificate.
+          </p>
+        </div>
+      )}
 
       <div className="grid gap-1.5">
         <Label htmlFor="conn-database">{getDatabaseLabel(form.type)}</Label>

--- a/apps/web/src/components/connection-form.tsx
+++ b/apps/web/src/components/connection-form.tsx
@@ -77,7 +77,9 @@ const EMOJI_CATALOG = [
 
 const EMOJI_BY_TYPE: Record<DatabaseType, string> = {
   clickhouse: "📊",
+  duckdb: "🦆",
   mongodb: "🍃",
+  mssql: "🗄️",
   mysql: "🐬",
   postgresql: "🐘",
   redis: "⚡️",
@@ -437,7 +439,9 @@ const DATABASE_OPTIONS: { value: DatabaseType; label: string }[] = [
   { label: "PostgreSQL", value: "postgresql" },
   { label: "MySQL", value: "mysql" },
   { label: "SQLite", value: "sqlite" },
+  { label: "Microsoft SQL Server", value: "mssql" },
   { label: "ClickHouse", value: "clickhouse" },
+  { label: "DuckDB", value: "duckdb" },
   { label: "MongoDB", value: "mongodb" },
   { label: "Redis", value: "redis" },
 ];
@@ -448,16 +452,18 @@ const NEEDS_HOST = new Set<DatabaseType>([
   "clickhouse",
   "mongodb",
   "redis",
+  "mssql",
 ]);
 const NEEDS_USERNAME = new Set<DatabaseType>([
   "postgresql",
   "mysql",
   "clickhouse",
   "mongodb",
+  "mssql",
 ]);
 
 const getDatabaseLabel = (type: DatabaseType): string => {
-  if (type === "sqlite") {
+  if (type === "sqlite" || type === "duckdb") {
     return "File path";
   }
   if (type === "redis") {
@@ -470,6 +476,9 @@ const getDatabaseHint = (type: DatabaseType): string | null => {
   if (type === "redis") {
     return "Redis DBs are numbered 0–15. You can switch DBs inside the workspace after connecting.";
   }
+  if (type === "duckdb") {
+    return "Use :memory: for an in-process database, or an absolute path to a .duckdb file.";
+  }
   return null;
 };
 
@@ -480,12 +489,18 @@ const getUsernamePlaceholder = (type: DatabaseType): string => {
   if (type === "clickhouse") {
     return "default";
   }
+  if (type === "mssql") {
+    return "sa";
+  }
   return "postgres";
 };
 
 const getDatabasePlaceholder = (type: DatabaseType): string => {
   if (type === "sqlite") {
     return "/path/to/database.db";
+  }
+  if (type === "duckdb") {
+    return ":memory: or /path/to/warehouse.duckdb";
   }
   if (type === "redis") {
     return "0";

--- a/apps/web/src/components/icons/database-icons.test.tsx
+++ b/apps/web/src/components/icons/database-icons.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { DatabaseType } from "@/lib/connections";
+
+import { DATABASE_ICON_MAP } from "./database-icons";
+
+const TYPES: DatabaseType[] = [
+  "postgresql",
+  "mysql",
+  "sqlite",
+  "mongodb",
+  "redis",
+  "clickhouse",
+  "duckdb",
+  "mssql",
+];
+
+describe("DATABASE_ICON_MAP", () => {
+  it.each(TYPES)("renders an svg for %s", (type) => {
+    const Icon = DATABASE_ICON_MAP[type];
+    const { container } = render(<Icon data-testid="icon" />);
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/icons/database-icons.test.tsx
+++ b/apps/web/src/components/icons/database-icons.test.tsx
@@ -16,7 +16,7 @@ const TYPES: DatabaseType[] = [
   "mssql",
 ];
 
-describe("DATABASE_ICON_MAP", () => {
+describe("dATABASE_ICON_MAP", () => {
   it.each(TYPES)("renders an svg for %s", (type) => {
     const Icon = DATABASE_ICON_MAP[type];
     const { container } = render(<Icon data-testid="icon" />);

--- a/apps/web/src/components/icons/database-icons.tsx
+++ b/apps/web/src/components/icons/database-icons.tsx
@@ -40,12 +40,26 @@ const RedisIcon = (props: IconProps) => (
   </svg>
 );
 
+const DuckDbIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+    <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm-1.408 6.62c2.962 0 5.363 2.401 5.363 5.363 0 2.963-2.401 5.364-5.363 5.364-2.962 0-5.363-2.401-5.363-5.364 0-2.962 2.401-5.363 5.363-5.363zm6.759 4.02h3.487a1.343 1.343 0 1 1 0 2.686h-3.487a1.343 1.343 0 1 1 0-2.686z" />
+  </svg>
+);
+
+const MssqlIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+    <path d="M12 2C6.48 2 2 3.79 2 6v12c0 2.21 4.48 4 10 4s10-1.79 10-4V6c0-2.21-4.48-4-10-4zm0 2c4.97 0 8 1.35 8 2s-3.03 2-8 2-8-1.35-8-2 3.03-2 8-2zm0 4c3.48 0 6.27-.78 8-1.84V10c0 .65-3.03 2-8 2s-8-1.35-8-2V6.16C5.73 7.22 8.52 8 12 8zm0 4c3.48 0 6.27-.78 8-1.84V14c0 .65-3.03 2-8 2s-8-1.35-8-2v-3.84C5.73 11.22 8.52 12 12 12zm0 4c3.48 0 6.27-.78 8-1.84V18c0 .65-3.03 2-8 2s-8-1.35-8-2v-3.84C5.73 15.22 8.52 16 12 16z" />
+  </svg>
+);
+
 export const DATABASE_ICON_MAP: Record<
   DatabaseType,
   ComponentType<IconProps>
 > = {
   clickhouse: ClickHouseIcon,
+  duckdb: DuckDbIcon,
   mongodb: MongoDbIcon,
+  mssql: MssqlIcon,
   mysql: MySqlIcon,
   postgresql: PostgreSqlIcon,
   redis: RedisIcon,

--- a/apps/web/src/lib/connections.test.ts
+++ b/apps/web/src/lib/connections.test.ts
@@ -42,6 +42,8 @@ describe("isSqlDatabase predicate", () => {
     expect(isSqlDatabase("mysql")).toBeTruthy();
     expect(isSqlDatabase("sqlite")).toBeTruthy();
     expect(isSqlDatabase("clickhouse")).toBeTruthy();
+    expect(isSqlDatabase("duckdb")).toBeTruthy();
+    expect(isSqlDatabase("mssql")).toBeTruthy();
   });
 
   it("returns false for non-SQL databases", () => {
@@ -57,6 +59,9 @@ describe("default ports", () => {
     expect(DEFAULT_PORTS.redis).toBe(6379);
     expect(DEFAULT_PORTS.mongodb).toBe(27_017);
     expect(DEFAULT_PORTS.clickhouse).toBe(8123);
+    expect(DEFAULT_PORTS.mssql).toBe(1433);
+    expect(DEFAULT_PORTS.duckdb).toBe(0);
+    expect(DEFAULT_PORTS.sqlite).toBe(0);
   });
 });
 

--- a/apps/web/src/lib/connections.test.ts
+++ b/apps/web/src/lib/connections.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { DatabaseConnection } from "@/lib/connections";
+import type { DatabaseConnection, DatabaseType } from "@/lib/connections";
 
 import {
   DEFAULT_PORTS,
@@ -37,31 +37,37 @@ const seed = (connections: DatabaseConnection[]): void => {
 };
 
 describe("isSqlDatabase predicate", () => {
-  it("returns true for SQL databases", () => {
-    expect(isSqlDatabase("postgresql")).toBeTruthy();
-    expect(isSqlDatabase("mysql")).toBeTruthy();
-    expect(isSqlDatabase("sqlite")).toBeTruthy();
-    expect(isSqlDatabase("clickhouse")).toBeTruthy();
-    expect(isSqlDatabase("duckdb")).toBeTruthy();
-    expect(isSqlDatabase("mssql")).toBeTruthy();
+  it.each<DatabaseType>([
+    "postgresql",
+    "mysql",
+    "sqlite",
+    "clickhouse",
+    "duckdb",
+    "mssql",
+  ])("returns true for %s", (type) => {
+    expect(isSqlDatabase(type)).toBeTruthy();
   });
 
-  it("returns false for non-SQL databases", () => {
-    expect(isSqlDatabase("mongodb")).toBeFalsy();
-    expect(isSqlDatabase("redis")).toBeFalsy();
-  });
+  it.each<DatabaseType>(["mongodb", "redis"])(
+    "returns false for %s",
+    (type) => {
+      expect(isSqlDatabase(type)).toBeFalsy();
+    }
+  );
 });
 
 describe("default ports", () => {
-  it("maps each database type to a port", () => {
-    expect(DEFAULT_PORTS.postgresql).toBe(5432);
-    expect(DEFAULT_PORTS.mysql).toBe(3306);
-    expect(DEFAULT_PORTS.redis).toBe(6379);
-    expect(DEFAULT_PORTS.mongodb).toBe(27_017);
-    expect(DEFAULT_PORTS.clickhouse).toBe(8123);
-    expect(DEFAULT_PORTS.mssql).toBe(1433);
-    expect(DEFAULT_PORTS.duckdb).toBe(0);
-    expect(DEFAULT_PORTS.sqlite).toBe(0);
+  it.each<[DatabaseType, number]>([
+    ["postgresql", 5432],
+    ["mysql", 3306],
+    ["redis", 6379],
+    ["mongodb", 27_017],
+    ["clickhouse", 8123],
+    ["mssql", 1433],
+    ["duckdb", 0],
+    ["sqlite", 0],
+  ])("maps %s to port %i", (type, port) => {
+    expect(DEFAULT_PORTS[type]).toBe(port);
   });
 });
 

--- a/apps/web/src/lib/connections.ts
+++ b/apps/web/src/lib/connections.ts
@@ -6,7 +6,9 @@ export type DatabaseType =
   | "sqlite"
   | "mongodb"
   | "redis"
-  | "clickhouse";
+  | "clickhouse"
+  | "duckdb"
+  | "mssql";
 
 export type ConnectionEnvironment = "dev" | "staging" | "prod";
 
@@ -38,7 +40,9 @@ export interface DatabaseConnection {
 
 export const DEFAULT_PORTS: Record<DatabaseType, number> = {
   clickhouse: 8123,
+  duckdb: 0,
   mongodb: 27_017,
+  mssql: 1433,
   mysql: 3306,
   postgresql: 5432,
   redis: 6379,
@@ -49,7 +53,9 @@ export const isSqlDatabase = (type: DatabaseType): boolean =>
   type === "postgresql" ||
   type === "mysql" ||
   type === "sqlite" ||
-  type === "clickhouse";
+  type === "clickhouse" ||
+  type === "duckdb" ||
+  type === "mssql";
 
 const STORAGE_KEY = "oh-my-query-connections";
 

--- a/apps/web/src/lib/connections.ts
+++ b/apps/web/src/lib/connections.ts
@@ -30,6 +30,7 @@ export interface DatabaseConnection {
   username: string;
   password: string;
   authSource?: string;
+  trustServerCertificate?: boolean;
   createdAt: string;
   pinned: boolean;
   lastConnectedAt: string | null;

--- a/apps/web/src/routes/_default/-components/connection-list-item.tsx
+++ b/apps/web/src/routes/_default/-components/connection-list-item.tsx
@@ -59,7 +59,7 @@ const formatRelativeTime = (iso: string | null): string => {
 };
 
 const getIdentifier = (connection: DatabaseConnection): string =>
-  connection.type === "sqlite"
+  connection.type === "sqlite" || connection.type === "duckdb"
     ? connection.database
     : `${connection.host}:${connection.port}/${connection.database}`;
 


### PR DESCRIPTION
## Summary
- Adds **DuckDB** (in-process + file-based, including `:memory:`) via the `duckdb` crate. No host/port — the database field is a file path or `:memory:`.
- Adds **Microsoft SQL Server** via `tiberius` + `bb8-tiberius` with SQL Auth and TLS (server cert trusted by default for dev ergonomics). Default port 1433.
- Closes the **ClickHouse** loop: audit-only on the driver, plus the previously missing form-render smoke test at the frontend level.
- Frontend: new \`DatabaseType\` values (\`duckdb\`, \`mssql\`), default ports, icons, emojis, form fields (host/username hidden for DuckDB, \`:memory:\` hint and file-path label), and connection-list identifier handling for DuckDB. Colocated Vitest tests for the form and icon map.
- Backend: per-engine dispatch extended end-to-end — \`DatabasePool\` enum variants, \`connect_native\` + \`verify_connection\`, version detection (DuckDB \`SELECT version()\`, MSSQL \`@@VERSION\`), schema introspection (\`information_schema\` for DuckDB, \`INFORMATION_SCHEMA\` + \`sys.*\` for MSSQL), and execute wrappers that map driver value types to \`serde_json::Value\`.

## Test plan
- [x] \`bun run test\` — frontend suite green (22 tests added/updated across \`connections\`, \`connection-form\`, \`database-icons\`)
- [x] \`cargo check\` — verify Rust compile on the PR runner (local compile on an Apple M1 exceeded 1h in the sandbox due to libduckdb-sys C++ build; please confirm in CI)
- [ ] DuckDB happy path: connect \`:memory:\`, \`SELECT 42\`, schema tree populates
- [ ] MSSQL happy path via \`mcr.microsoft.com/mssql/server:2022-latest\` Docker: \`sa\` + strong password, \`SELECT @@VERSION\`, schema tree populates
- [ ] ClickHouse smoke via \`docker run -d -p 8123:8123 clickhouse/clickhouse-server\`: \`SELECT 1\` and schema tree