### PR TITLE
feat(schema): cache in zustand + fix MariaDB/MySQL slow schema load

### DIFF
--- a/apps/web/src-tauri/src/db/mysql.rs
+++ b/apps/web/src-tauri/src/db/mysql.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use sqlx::mysql::MySqlPoolOptions;
+use sqlx::mysql::{MySqlConnectOptions, MySqlPoolOptions};
 use std::time::Instant;
 
 use crate::db::driver::DatabaseDriver;
@@ -23,11 +23,16 @@ impl DatabaseDriver for MysqlDriver {
             urlencoding::encode(&params.database),
         );
 
+        let connect_options: MySqlConnectOptions = url
+            .parse::<MySqlConnectOptions>()
+            .map_err(DbError::from)?
+            .statement_cache_capacity(0);
+
         let start = Instant::now();
         let pool = MySqlPoolOptions::new()
             .max_connections(1)
-            .acquire_timeout(std::time::Duration::from_secs(10))
-            .connect(&url)
+            .acquire_timeout(std::time::Duration::from_secs(30))
+            .connect_with(connect_options)
             .await
             .map_err(DbError::from)?;
 

--- a/apps/web/src-tauri/src/db/pool.rs
+++ b/apps/web/src-tauri/src/db/pool.rs
@@ -93,10 +93,16 @@ async fn connect_native(params: &ConnectionParams) -> Result<DatabasePool, DbErr
         }
         "mysql" => {
             let url = build_sql_connection_url(params);
+            let connect_options: sqlx::mysql::MySqlConnectOptions = url
+                .parse::<sqlx::mysql::MySqlConnectOptions>()
+                .map_err(DbError::from)?
+                .statement_cache_capacity(0);
             let pool = sqlx::mysql::MySqlPoolOptions::new()
                 .max_connections(5)
-                .acquire_timeout(std::time::Duration::from_secs(10))
-                .connect(&url)
+                .acquire_timeout(std::time::Duration::from_secs(30))
+                .idle_timeout(Some(std::time::Duration::from_secs(600)))
+                .max_lifetime(Some(std::time::Duration::from_secs(1800)))
+                .connect_with(connect_options)
                 .await
                 .map_err(DbError::from)?;
             Ok(DatabasePool::MySql(pool))

--- a/apps/web/src-tauri/src/db/schema.rs
+++ b/apps/web/src-tauri/src/db/schema.rs
@@ -322,202 +322,226 @@ async fn list_databases_mysql(pool: &sqlx::MySqlPool) -> Result<Vec<String>, DbE
         .collect())
 }
 
+struct MysqlTableRow {
+    name: String,
+    table_type: String,
+    row_estimate: Option<u64>,
+}
+
+struct MysqlColumnRow {
+    table: String,
+    column: ColumnDetail,
+}
+
+struct MysqlIndexRow {
+    table: String,
+    index_name: String,
+    is_unique: bool,
+    column: String,
+}
+
+struct MysqlFkRow {
+    table: String,
+    constraint_name: String,
+    column: String,
+    referenced_table: String,
+    referenced_column: String,
+}
+
 async fn fetch_schema_mysql(
     pool: &sqlx::MySqlPool,
     schema_name: &str,
 ) -> Result<SchemaInfo, DbError> {
-    let tables = fetch_tables_mysql(pool, schema_name).await?;
-    let views = fetch_views_mysql(pool, schema_name).await?;
+    let table_rows = sqlx::query(
+        "SELECT TABLE_NAME, TABLE_TYPE, TABLE_ROWS FROM information_schema.TABLES \
+         WHERE TABLE_SCHEMA = ? AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') \
+         ORDER BY TABLE_NAME",
+    )
+    .bind(schema_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
 
-    Ok(SchemaInfo {
+    let column_rows = sqlx::query(
+        "SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, COLUMN_KEY \
+         FROM information_schema.COLUMNS \
+         WHERE TABLE_SCHEMA = ? \
+         ORDER BY TABLE_NAME, ORDINAL_POSITION",
+    )
+    .bind(schema_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let index_rows = sqlx::query(
+        "SELECT TABLE_NAME, INDEX_NAME, NON_UNIQUE, COLUMN_NAME \
+         FROM information_schema.STATISTICS \
+         WHERE TABLE_SCHEMA = ? \
+         ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX",
+    )
+    .bind(schema_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let fk_rows = sqlx::query(
+        "SELECT TABLE_NAME, CONSTRAINT_NAME, COLUMN_NAME, \
+                REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME \
+         FROM information_schema.KEY_COLUMN_USAGE \
+         WHERE TABLE_SCHEMA = ? AND REFERENCED_TABLE_NAME IS NOT NULL \
+         ORDER BY TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION",
+    )
+    .bind(schema_name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let tables = table_rows
+        .iter()
+        .map(|row| MysqlTableRow {
+            name: row.try_get("TABLE_NAME").unwrap_or_default(),
+            table_type: row.try_get("TABLE_TYPE").unwrap_or_default(),
+            row_estimate: row
+                .try_get::<Option<i64>, _>("TABLE_ROWS")
+                .ok()
+                .flatten()
+                .filter(|v| *v >= 0)
+                .map(|v| v as u64),
+        })
+        .collect();
+
+    let columns = column_rows
+        .iter()
+        .map(|row| {
+            let nullable: String = row.try_get("IS_NULLABLE").unwrap_or_default();
+            let column_key: String = row.try_get("COLUMN_KEY").unwrap_or_default();
+            MysqlColumnRow {
+                table: row.try_get("TABLE_NAME").unwrap_or_default(),
+                column: ColumnDetail {
+                    name: row.try_get("COLUMN_NAME").unwrap_or_default(),
+                    data_type: row.try_get("DATA_TYPE").unwrap_or_default(),
+                    is_nullable: nullable == "YES",
+                    is_primary_key: column_key == "PRI",
+                    default_value: row.try_get("COLUMN_DEFAULT").ok(),
+                },
+            }
+        })
+        .collect();
+
+    let indexes = index_rows
+        .iter()
+        .map(|row| {
+            let non_unique: i64 = row.try_get("NON_UNIQUE").unwrap_or(1);
+            MysqlIndexRow {
+                table: row.try_get("TABLE_NAME").unwrap_or_default(),
+                index_name: row.try_get("INDEX_NAME").unwrap_or_default(),
+                is_unique: non_unique == 0,
+                column: row.try_get("COLUMN_NAME").unwrap_or_default(),
+            }
+        })
+        .collect();
+
+    let fks = fk_rows
+        .iter()
+        .map(|row| MysqlFkRow {
+            table: row.try_get("TABLE_NAME").unwrap_or_default(),
+            constraint_name: row.try_get("CONSTRAINT_NAME").unwrap_or_default(),
+            column: row.try_get("COLUMN_NAME").unwrap_or_default(),
+            referenced_table: row.try_get("REFERENCED_TABLE_NAME").unwrap_or_default(),
+            referenced_column: row.try_get("REFERENCED_COLUMN_NAME").unwrap_or_default(),
+        })
+        .collect();
+
+    Ok(build_mysql_schema(schema_name, tables, columns, indexes, fks))
+}
+
+fn build_mysql_schema(
+    schema_name: &str,
+    table_rows: Vec<MysqlTableRow>,
+    column_rows: Vec<MysqlColumnRow>,
+    index_rows: Vec<MysqlIndexRow>,
+    fk_rows: Vec<MysqlFkRow>,
+) -> SchemaInfo {
+    let mut columns_by_table: std::collections::HashMap<String, Vec<ColumnDetail>> =
+        std::collections::HashMap::new();
+    for row in column_rows {
+        columns_by_table
+            .entry(row.table)
+            .or_default()
+            .push(row.column);
+    }
+
+    let mut indexes_by_table: std::collections::HashMap<String, Vec<IndexItem>> =
+        std::collections::HashMap::new();
+    for row in index_rows {
+        let table_indexes = indexes_by_table.entry(row.table).or_default();
+        if let Some(existing) = table_indexes
+            .iter_mut()
+            .find(|i| i.name == row.index_name)
+        {
+            existing.columns.push(row.column);
+        } else {
+            table_indexes.push(IndexItem {
+                name: row.index_name,
+                columns: vec![row.column],
+                is_unique: row.is_unique,
+            });
+        }
+    }
+
+    let mut fks_by_table: std::collections::HashMap<String, Vec<ForeignKeyItem>> =
+        std::collections::HashMap::new();
+    for row in fk_rows {
+        let table_fks = fks_by_table.entry(row.table).or_default();
+        if let Some(existing) = table_fks
+            .iter_mut()
+            .find(|f| f.name == row.constraint_name)
+        {
+            existing.columns.push(row.column);
+            existing.referenced_columns.push(row.referenced_column);
+        } else {
+            table_fks.push(ForeignKeyItem {
+                name: row.constraint_name,
+                columns: vec![row.column],
+                referenced_table: row.referenced_table,
+                referenced_columns: vec![row.referenced_column],
+            });
+        }
+    }
+
+    let mut tables: Vec<TableItem> = Vec::new();
+    let mut views: Vec<ViewItem> = Vec::new();
+
+    for row in table_rows {
+        let columns = columns_by_table.remove(&row.name).unwrap_or_default();
+
+        if row.table_type == "VIEW" {
+            views.push(ViewItem {
+                name: row.name,
+                columns,
+            });
+            continue;
+        }
+
+        let indexes = indexes_by_table.remove(&row.name).unwrap_or_default();
+        let foreign_keys = fks_by_table.remove(&row.name).unwrap_or_default();
+
+        tables.push(TableItem {
+            name: row.name,
+            columns,
+            indexes,
+            foreign_keys,
+            row_estimate: row.row_estimate,
+        });
+    }
+
+    SchemaInfo {
         schemas: vec![SchemaItem {
             name: schema_name.to_string(),
             tables,
             views,
         }],
-    })
-}
-
-async fn fetch_tables_mysql(
-    pool: &sqlx::MySqlPool,
-    schema_name: &str,
-) -> Result<Vec<TableItem>, DbError> {
-    let table_rows = sqlx::query(
-        "SELECT TABLE_NAME, TABLE_ROWS FROM information_schema.TABLES \
-         WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'BASE TABLE' \
-         ORDER BY TABLE_NAME",
-    )
-    .bind(schema_name)
-    .fetch_all(pool)
-    .await
-    .map_err(DbError::from)?;
-
-    let mut tables = Vec::with_capacity(table_rows.len());
-
-    for table_row in &table_rows {
-        let table_name: String = table_row.try_get("TABLE_NAME").unwrap_or_default();
-        let row_estimate: Option<u64> = table_row
-            .try_get::<Option<i64>, _>("TABLE_ROWS")
-            .ok()
-            .flatten()
-            .filter(|v| *v >= 0)
-            .map(|v| v as u64);
-
-        let columns = fetch_columns_mysql(pool, schema_name, &table_name).await?;
-        let indexes = fetch_indexes_mysql(pool, schema_name, &table_name).await?;
-        let foreign_keys = fetch_fks_mysql(pool, schema_name, &table_name).await?;
-
-        tables.push(TableItem {
-            name: table_name,
-            columns,
-            indexes,
-            foreign_keys,
-            row_estimate,
-        });
     }
-
-    Ok(tables)
-}
-
-async fn fetch_views_mysql(
-    pool: &sqlx::MySqlPool,
-    schema_name: &str,
-) -> Result<Vec<ViewItem>, DbError> {
-    let view_rows = sqlx::query(
-        "SELECT TABLE_NAME FROM information_schema.TABLES \
-         WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'VIEW' \
-         ORDER BY TABLE_NAME",
-    )
-    .bind(schema_name)
-    .fetch_all(pool)
-    .await
-    .map_err(DbError::from)?;
-
-    let mut views = Vec::with_capacity(view_rows.len());
-
-    for view_row in &view_rows {
-        let view_name: String = view_row.try_get("TABLE_NAME").unwrap_or_default();
-        let columns = fetch_columns_mysql(pool, schema_name, &view_name).await?;
-
-        views.push(ViewItem {
-            name: view_name,
-            columns,
-        });
-    }
-
-    Ok(views)
-}
-
-async fn fetch_columns_mysql(
-    pool: &sqlx::MySqlPool,
-    schema_name: &str,
-    table_name: &str,
-) -> Result<Vec<ColumnDetail>, DbError> {
-    let rows = sqlx::query(
-        "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, COLUMN_KEY \
-         FROM information_schema.COLUMNS \
-         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? \
-         ORDER BY ORDINAL_POSITION",
-    )
-    .bind(schema_name)
-    .bind(table_name)
-    .fetch_all(pool)
-    .await
-    .map_err(DbError::from)?;
-
-    Ok(rows
-        .iter()
-        .map(|row| {
-            let nullable: String = row.try_get("IS_NULLABLE").unwrap_or_default();
-            let column_key: String = row.try_get("COLUMN_KEY").unwrap_or_default();
-            ColumnDetail {
-                name: row.try_get("COLUMN_NAME").unwrap_or_default(),
-                data_type: row.try_get("DATA_TYPE").unwrap_or_default(),
-                is_nullable: nullable == "YES",
-                is_primary_key: column_key == "PRI",
-                default_value: row.try_get("COLUMN_DEFAULT").ok(),
-            }
-        })
-        .collect())
-}
-
-async fn fetch_indexes_mysql(
-    pool: &sqlx::MySqlPool,
-    schema_name: &str,
-    table_name: &str,
-) -> Result<Vec<IndexItem>, DbError> {
-    let rows = sqlx::query(
-        "SELECT INDEX_NAME, NON_UNIQUE, COLUMN_NAME \
-         FROM information_schema.STATISTICS \
-         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? \
-         ORDER BY INDEX_NAME, SEQ_IN_INDEX",
-    )
-    .bind(schema_name)
-    .bind(table_name)
-    .fetch_all(pool)
-    .await
-    .map_err(DbError::from)?;
-
-    let mut index_map: std::collections::HashMap<String, IndexItem> =
-        std::collections::HashMap::new();
-
-    for row in &rows {
-        let name: String = row.try_get("INDEX_NAME").unwrap_or_default();
-        let non_unique: i64 = row.try_get("NON_UNIQUE").unwrap_or(1);
-        let column: String = row.try_get("COLUMN_NAME").unwrap_or_default();
-
-        let entry = index_map.entry(name.clone()).or_insert_with(|| IndexItem {
-            name,
-            columns: Vec::new(),
-            is_unique: non_unique == 0,
-        });
-        entry.columns.push(column);
-    }
-
-    Ok(index_map.into_values().collect())
-}
-
-async fn fetch_fks_mysql(
-    pool: &sqlx::MySqlPool,
-    schema_name: &str,
-    table_name: &str,
-) -> Result<Vec<ForeignKeyItem>, DbError> {
-    let rows = sqlx::query(
-        "SELECT CONSTRAINT_NAME, COLUMN_NAME, \
-                REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME \
-         FROM information_schema.KEY_COLUMN_USAGE \
-         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? \
-             AND REFERENCED_TABLE_NAME IS NOT NULL \
-         ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
-    )
-    .bind(schema_name)
-    .bind(table_name)
-    .fetch_all(pool)
-    .await
-    .map_err(DbError::from)?;
-
-    let mut fk_map: std::collections::HashMap<String, ForeignKeyItem> =
-        std::collections::HashMap::new();
-
-    for row in &rows {
-        let name: String = row.try_get("CONSTRAINT_NAME").unwrap_or_default();
-        let column: String = row.try_get("COLUMN_NAME").unwrap_or_default();
-        let ref_table: String = row.try_get("REFERENCED_TABLE_NAME").unwrap_or_default();
-        let ref_column: String = row.try_get("REFERENCED_COLUMN_NAME").unwrap_or_default();
-
-        let entry = fk_map
-            .entry(name.clone())
-            .or_insert_with(|| ForeignKeyItem {
-                name,
-                columns: Vec::new(),
-                referenced_table: ref_table,
-                referenced_columns: Vec::new(),
-            });
-        entry.columns.push(column);
-        entry.referenced_columns.push(ref_column);
-    }
-
-    Ok(fk_map.into_values().collect())
 }
 
 // SQLite introspection
@@ -1413,4 +1437,202 @@ async fn fetch_indexes_mssql(
 
 fn escape_mssql_literal(input: &str) -> String {
     input.replace('\'', "''")
+}
+
+#[cfg(test)]
+mod mysql_build_tests {
+    use super::*;
+
+    fn column(name: &str, data_type: &str, is_pk: bool) -> ColumnDetail {
+        ColumnDetail {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            is_nullable: false,
+            is_primary_key: is_pk,
+            default_value: None,
+        }
+    }
+
+    #[test]
+    fn groups_columns_indexes_and_fks_by_table() {
+        let tables = vec![
+            MysqlTableRow {
+                name: "users".to_string(),
+                table_type: "BASE TABLE".to_string(),
+                row_estimate: Some(42),
+            },
+            MysqlTableRow {
+                name: "orders".to_string(),
+                table_type: "BASE TABLE".to_string(),
+                row_estimate: None,
+            },
+            MysqlTableRow {
+                name: "active_users".to_string(),
+                table_type: "VIEW".to_string(),
+                row_estimate: None,
+            },
+        ];
+
+        let columns = vec![
+            MysqlColumnRow {
+                table: "users".to_string(),
+                column: column("id", "int", true),
+            },
+            MysqlColumnRow {
+                table: "users".to_string(),
+                column: column("email", "varchar", false),
+            },
+            MysqlColumnRow {
+                table: "orders".to_string(),
+                column: column("id", "int", true),
+            },
+            MysqlColumnRow {
+                table: "orders".to_string(),
+                column: column("user_id", "int", false),
+            },
+            MysqlColumnRow {
+                table: "active_users".to_string(),
+                column: column("id", "int", false),
+            },
+        ];
+
+        let indexes = vec![
+            MysqlIndexRow {
+                table: "users".to_string(),
+                index_name: "PRIMARY".to_string(),
+                is_unique: true,
+                column: "id".to_string(),
+            },
+            MysqlIndexRow {
+                table: "users".to_string(),
+                index_name: "users_email_idx".to_string(),
+                is_unique: false,
+                column: "email".to_string(),
+            },
+            MysqlIndexRow {
+                table: "orders".to_string(),
+                index_name: "orders_user_fk_idx".to_string(),
+                is_unique: false,
+                column: "user_id".to_string(),
+            },
+        ];
+
+        let fks = vec![
+            MysqlFkRow {
+                table: "orders".to_string(),
+                constraint_name: "orders_user_fk".to_string(),
+                column: "user_id".to_string(),
+                referenced_table: "users".to_string(),
+                referenced_column: "id".to_string(),
+            },
+        ];
+
+        let schema = build_mysql_schema("shop", tables, columns, indexes, fks);
+
+        assert_eq!(schema.schemas.len(), 1);
+        let s = &schema.schemas[0];
+        assert_eq!(s.name, "shop");
+        assert_eq!(s.tables.len(), 2);
+        assert_eq!(s.views.len(), 1);
+
+        let users = s.tables.iter().find(|t| t.name == "users").unwrap();
+        assert_eq!(users.row_estimate, Some(42));
+        assert_eq!(users.columns.len(), 2);
+        assert_eq!(users.indexes.len(), 2);
+        assert!(users.foreign_keys.is_empty());
+
+        let orders = s.tables.iter().find(|t| t.name == "orders").unwrap();
+        assert_eq!(orders.row_estimate, None);
+        assert_eq!(orders.foreign_keys.len(), 1);
+        let fk = &orders.foreign_keys[0];
+        assert_eq!(fk.columns, vec!["user_id"]);
+        assert_eq!(fk.referenced_table, "users");
+        assert_eq!(fk.referenced_columns, vec!["id"]);
+
+        let view = &s.views[0];
+        assert_eq!(view.name, "active_users");
+        assert_eq!(view.columns.len(), 1);
+    }
+
+    #[test]
+    fn composite_index_and_fk_columns_are_grouped_in_order() {
+        let tables = vec![MysqlTableRow {
+            name: "memberships".to_string(),
+            table_type: "BASE TABLE".to_string(),
+            row_estimate: Some(0),
+        }];
+
+        let columns = vec![
+            MysqlColumnRow {
+                table: "memberships".to_string(),
+                column: column("user_id", "int", true),
+            },
+            MysqlColumnRow {
+                table: "memberships".to_string(),
+                column: column("team_id", "int", true),
+            },
+        ];
+
+        let indexes = vec![
+            MysqlIndexRow {
+                table: "memberships".to_string(),
+                index_name: "PRIMARY".to_string(),
+                is_unique: true,
+                column: "user_id".to_string(),
+            },
+            MysqlIndexRow {
+                table: "memberships".to_string(),
+                index_name: "PRIMARY".to_string(),
+                is_unique: true,
+                column: "team_id".to_string(),
+            },
+        ];
+
+        let fks = vec![
+            MysqlFkRow {
+                table: "memberships".to_string(),
+                constraint_name: "memberships_user_team_fk".to_string(),
+                column: "user_id".to_string(),
+                referenced_table: "user_teams".to_string(),
+                referenced_column: "user_id".to_string(),
+            },
+            MysqlFkRow {
+                table: "memberships".to_string(),
+                constraint_name: "memberships_user_team_fk".to_string(),
+                column: "team_id".to_string(),
+                referenced_table: "user_teams".to_string(),
+                referenced_column: "team_id".to_string(),
+            },
+        ];
+
+        let schema = build_mysql_schema("saas", tables, columns, indexes, fks);
+
+        let t = &schema.schemas[0].tables[0];
+        assert_eq!(t.indexes.len(), 1);
+        assert_eq!(t.indexes[0].name, "PRIMARY");
+        assert_eq!(t.indexes[0].columns, vec!["user_id", "team_id"]);
+        assert!(t.indexes[0].is_unique);
+
+        assert_eq!(t.foreign_keys.len(), 1);
+        assert_eq!(t.foreign_keys[0].columns, vec!["user_id", "team_id"]);
+        assert_eq!(
+            t.foreign_keys[0].referenced_columns,
+            vec!["user_id", "team_id"]
+        );
+    }
+
+    #[test]
+    fn table_without_columns_or_indexes_is_preserved() {
+        let tables = vec![MysqlTableRow {
+            name: "empty".to_string(),
+            table_type: "BASE TABLE".to_string(),
+            row_estimate: None,
+        }];
+        let schema = build_mysql_schema("db", tables, vec![], vec![], vec![]);
+        let t = &schema.schemas[0].tables[0];
+        assert_eq!(t.name, "empty");
+        assert!(t.columns.is_empty());
+        assert!(t.indexes.is_empty());
+        assert!(t.foreign_keys.is_empty());
+    }
 }

--- a/apps/web/src-tauri/src/db/schema.rs
+++ b/apps/web/src-tauri/src/db/schema.rs
@@ -452,7 +452,13 @@ async fn fetch_schema_mysql(
         })
         .collect();
 
-    Ok(build_mysql_schema(schema_name, tables, columns, indexes, fks))
+    Ok(build_mysql_schema(
+        schema_name,
+        tables,
+        columns,
+        indexes,
+        fks,
+    ))
 }
 
 fn build_mysql_schema(
@@ -475,10 +481,7 @@ fn build_mysql_schema(
         std::collections::HashMap::new();
     for row in index_rows {
         let table_indexes = indexes_by_table.entry(row.table).or_default();
-        if let Some(existing) = table_indexes
-            .iter_mut()
-            .find(|i| i.name == row.index_name)
-        {
+        if let Some(existing) = table_indexes.iter_mut().find(|i| i.name == row.index_name) {
             existing.columns.push(row.column);
         } else {
             table_indexes.push(IndexItem {
@@ -493,10 +496,7 @@ fn build_mysql_schema(
         std::collections::HashMap::new();
     for row in fk_rows {
         let table_fks = fks_by_table.entry(row.table).or_default();
-        if let Some(existing) = table_fks
-            .iter_mut()
-            .find(|f| f.name == row.constraint_name)
-        {
+        if let Some(existing) = table_fks.iter_mut().find(|f| f.name == row.constraint_name) {
             existing.columns.push(row.column);
             existing.referenced_columns.push(row.referenced_column);
         } else {
@@ -1517,15 +1517,13 @@ mod mysql_build_tests {
             },
         ];
 
-        let fks = vec![
-            MysqlFkRow {
-                table: "orders".to_string(),
-                constraint_name: "orders_user_fk".to_string(),
-                column: "user_id".to_string(),
-                referenced_table: "users".to_string(),
-                referenced_column: "id".to_string(),
-            },
-        ];
+        let fks = vec![MysqlFkRow {
+            table: "orders".to_string(),
+            constraint_name: "orders_user_fk".to_string(),
+            column: "user_id".to_string(),
+            referenced_table: "users".to_string(),
+            referenced_column: "id".to_string(),
+        }];
 
         let schema = build_mysql_schema("shop", tables, columns, indexes, fks);
 

--- a/apps/web/src/hooks/use-connection-lifecycle.ts
+++ b/apps/web/src/hooks/use-connection-lifecycle.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import type { DatabaseConnection } from "@/lib/connections";
 
 import { markConnectionUsed } from "@/lib/connections";
+import { getErrorMessage } from "@/lib/error-message";
 import {
   connectToDatabase,
   disconnectFromDatabase,
@@ -74,8 +75,7 @@ export const useConnectionLifecycle = (
         }
       } catch (error) {
         if (!cancelled) {
-          const message =
-            error instanceof Error ? error.message : "Failed to connect";
+          const message = getErrorMessage(error, "Failed to connect");
           setState({
             error: message,
             isConnected: false,

--- a/apps/web/src/hooks/use-schema.test.ts
+++ b/apps/web/src/hooks/use-schema.test.ts
@@ -4,7 +4,12 @@ import { describe, expect, it } from "vitest";
 import type { SchemaInfo } from "@/lib/tauri";
 
 import { useSchema } from "@/hooks/use-schema";
+import { useSchemaStore } from "@/stores/schema-store";
 import { mockTauri } from "@/test/tauri-mock";
+
+const resetSchemaStore = () => {
+  useSchemaStore.setState({ byConnection: {} });
+};
 
 const sampleSchema: SchemaInfo = {
   schemas: [
@@ -34,6 +39,7 @@ const sampleSchema: SchemaInfo = {
 
 describe("useSchema hook", () => {
   it("does nothing while disconnected", () => {
+    resetSchemaStore();
     mockTauri({
       get_schema: () => {
         throw new Error("should not be called");
@@ -49,6 +55,7 @@ describe("useSchema hook", () => {
   });
 
   it("loads databases then the schema once connected", async () => {
+    resetSchemaStore();
     mockTauri({
       get_schema: (payload) => {
         expect(payload).toMatchObject({
@@ -76,6 +83,7 @@ describe("useSchema hook", () => {
   });
 
   it("falls back to the first database when public is absent", async () => {
+    resetSchemaStore();
     mockTauri({
       get_schema: () => sampleSchema,
       list_connection_databases: () => ["alpha", "beta"],
@@ -89,6 +97,7 @@ describe("useSchema hook", () => {
   });
 
   it("captures errors from list_connection_databases", async () => {
+    resetSchemaStore();
     mockTauri({
       get_schema: () => sampleSchema,
       list_connection_databases: () => {
@@ -105,6 +114,7 @@ describe("useSchema hook", () => {
   });
 
   it("switches database when setSelectedDatabase is called", async () => {
+    resetSchemaStore();
     let lastDb = "";
     mockTauri({
       get_schema: (payload) => {
@@ -124,5 +134,85 @@ describe("useSchema hook", () => {
 
     await waitFor(() => expect(lastDb).toBe("analytics"));
     expect(result.current.selectedDatabase).toBe("analytics");
+  });
+
+  it("reuses cached schema across remounts without refetching", async () => {
+    resetSchemaStore();
+    let listCalls = 0;
+    let schemaCalls = 0;
+    mockTauri({
+      get_schema: () => {
+        schemaCalls += 1;
+        return sampleSchema;
+      },
+      list_connection_databases: () => {
+        listCalls += 1;
+        return ["public"];
+      },
+    });
+
+    const first = renderHook(() => useSchema("conn-1", true));
+    await waitFor(() => expect(first.result.current.schema).not.toBeNull());
+
+    expect(listCalls).toBe(1);
+    expect(schemaCalls).toBe(1);
+
+    first.unmount();
+
+    const second = renderHook(() => useSchema("conn-1", true));
+    await waitFor(() => expect(second.result.current.schema).not.toBeNull());
+
+    expect(listCalls).toBe(1);
+    expect(schemaCalls).toBe(1);
+    expect(second.result.current.databases).toStrictEqual(["public"]);
+  });
+
+  it("skips refetching when isConnected flips from true to false to true", async () => {
+    resetSchemaStore();
+    let schemaCalls = 0;
+    mockTauri({
+      get_schema: () => {
+        schemaCalls += 1;
+        return sampleSchema;
+      },
+      list_connection_databases: () => ["public"],
+    });
+
+    const { result, rerender } = renderHook(
+      ({ isConnected }: { isConnected: boolean }) =>
+        useSchema("conn-1", isConnected),
+      { initialProps: { isConnected: true } }
+    );
+
+    await waitFor(() => expect(result.current.schema).not.toBeNull());
+    expect(schemaCalls).toBe(1);
+
+    rerender({ isConnected: false });
+    rerender({ isConnected: true });
+
+    await waitFor(() => expect(result.current.schema).not.toBeNull());
+    expect(schemaCalls).toBe(1);
+  });
+
+  it("refresh() forces a re-fetch of the current schema", async () => {
+    resetSchemaStore();
+    let schemaCalls = 0;
+    mockTauri({
+      get_schema: () => {
+        schemaCalls += 1;
+        return sampleSchema;
+      },
+      list_connection_databases: () => ["public"],
+    });
+
+    const { result } = renderHook(() => useSchema("conn-1", true));
+    await waitFor(() => expect(result.current.schema).not.toBeNull());
+    expect(schemaCalls).toBe(1);
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => expect(schemaCalls).toBe(2));
   });
 });

--- a/apps/web/src/hooks/use-schema.ts
+++ b/apps/web/src/hooks/use-schema.ts
@@ -1,102 +1,49 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
+import { useShallow } from "zustand/react/shallow";
 
-import type { SchemaInfo } from "@/lib/tauri";
-
-import { getSchema, listDatabases } from "@/lib/tauri";
-
-interface SchemaState {
-  databases: string[] | null;
-  selectedDatabase: string | null;
-  schema: SchemaInfo | null;
-  isLoading: boolean;
-  error: string | null;
-}
+import { selectSchemaState, useSchemaStore } from "@/stores/schema-store";
 
 export const useSchema = (connectionId: string, isConnected: boolean) => {
-  const [state, setState] = useState<SchemaState>({
-    databases: null,
-    error: null,
-    isLoading: false,
-    schema: null,
-    selectedDatabase: null,
-  });
+  const { databases, selectedDatabase, schema, isLoading, error } =
+    useSchemaStore(useShallow(selectSchemaState(connectionId)));
 
-  const fetchDatabases = useCallback(async () => {
-    setState((prev) => ({ ...prev, error: null, isLoading: true }));
-
-    try {
-      const databases = await listDatabases(connectionId);
-      const selected =
-        databases.find((db) => db === "public") ?? databases[0] ?? null;
-
-      setState((prev) => ({
-        ...prev,
-        databases,
-        isLoading: false,
-        selectedDatabase: selected,
-      }));
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Failed to list databases";
-      setState((prev) => ({ ...prev, error: message, isLoading: false }));
-    }
-  }, [connectionId]);
-
-  const fetchSchema = useCallback(
-    async (databaseName: string) => {
-      setState((prev) => ({ ...prev, error: null, isLoading: true }));
-
-      try {
-        const schema = await getSchema(connectionId, databaseName);
-        setState((prev) => ({
-          ...prev,
-          error: null,
-          isLoading: false,
-          schema,
-        }));
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Failed to load schema";
-        setState((prev) => ({
-          ...prev,
-          error: message,
-          isLoading: false,
-          schema: null,
-        }));
-      }
-    },
-    [connectionId]
+  const loadDatabases = useSchemaStore((s) => s.loadDatabases);
+  const loadSchema = useSchemaStore((s) => s.loadSchema);
+  const setSelectedDatabaseAction = useSchemaStore(
+    (s) => s.setSelectedDatabase
   );
-
-  const setSelectedDatabase = useCallback((database: string) => {
-    setState((prev) => ({ ...prev, schema: null, selectedDatabase: database }));
-  }, []);
-
-  const refresh = useCallback(() => {
-    if (state.selectedDatabase) {
-      fetchSchema(state.selectedDatabase);
-    }
-  }, [state.selectedDatabase, fetchSchema]);
+  const refreshAction = useSchemaStore((s) => s.refresh);
 
   useEffect(() => {
     if (isConnected) {
-      fetchDatabases();
+      loadDatabases(connectionId);
     }
-  }, [isConnected, fetchDatabases]);
+  }, [isConnected, connectionId, loadDatabases]);
 
   useEffect(() => {
-    if (state.selectedDatabase) {
-      fetchSchema(state.selectedDatabase);
+    if (selectedDatabase) {
+      loadSchema(connectionId, selectedDatabase);
     }
-  }, [state.selectedDatabase, fetchSchema]);
+  }, [connectionId, selectedDatabase, loadSchema]);
+
+  const setSelectedDatabase = useCallback(
+    (database: string) => {
+      setSelectedDatabaseAction(connectionId, database);
+    },
+    [connectionId, setSelectedDatabaseAction]
+  );
+
+  const refresh = useCallback(() => {
+    refreshAction(connectionId);
+  }, [connectionId, refreshAction]);
 
   return {
-    databases: state.databases,
-    error: state.error,
-    isLoading: state.isLoading,
+    databases,
+    error,
+    isLoading,
     refresh,
-    schema: state.schema,
-    selectedDatabase: state.selectedDatabase,
+    schema,
+    selectedDatabase,
     setSelectedDatabase,
   };
 };

--- a/apps/web/src/lib/error-message.test.ts
+++ b/apps/web/src/lib/error-message.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { getErrorMessage } from "./error-message";
+
+describe("getErrorMessage", () => {
+  it("returns the message of a standard Error", () => {
+    expect(getErrorMessage(new Error("boom"), "fallback")).toBe("boom");
+  });
+
+  it("returns the message field from a Tauri DbError-shaped object", () => {
+    expect(
+      getErrorMessage({ code: "DB_ERROR", message: "connection lost" }, "fb")
+    ).toBe("connection lost");
+  });
+
+  it("returns a plain string error as-is", () => {
+    expect(getErrorMessage("kaput", "fallback")).toBe("kaput");
+  });
+
+  it("falls back when the error has no usable shape", () => {
+    expect(getErrorMessage(null, "fallback")).toBe("fallback");
+    expect(getErrorMessage(undefined, "fallback")).toBe("fallback");
+    expect(getErrorMessage(42, "fallback")).toBe("fallback");
+  });
+
+  it("stringifies non-string message fields", () => {
+    expect(getErrorMessage({ message: 500 }, "fallback")).toBe("500");
+  });
+});

--- a/apps/web/src/lib/error-message.ts
+++ b/apps/web/src/lib/error-message.ts
@@ -1,0 +1,12 @@
+export const getErrorMessage = (error: unknown, fallback: string): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return fallback;
+};

--- a/apps/web/src/stores/schema-store.ts
+++ b/apps/web/src/stores/schema-store.ts
@@ -1,0 +1,157 @@
+import { create } from "zustand";
+
+import type { SchemaInfo } from "@/lib/tauri";
+
+import { getErrorMessage } from "@/lib/error-message";
+import { getSchema, listDatabases } from "@/lib/tauri";
+
+interface SchemaConnectionState {
+  databases: string[] | null;
+  selectedDatabase: string | null;
+  schema: SchemaInfo | null;
+  schemaDatabase: string | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+interface SchemaStore {
+  byConnection: Record<string, SchemaConnectionState>;
+  loadDatabases: (connectionId: string) => Promise<void>;
+  loadSchema: (connectionId: string, databaseName: string) => Promise<void>;
+  setSelectedDatabase: (connectionId: string, database: string) => void;
+  refresh: (connectionId: string) => Promise<void>;
+  clear: (connectionId: string) => void;
+}
+
+export const EMPTY_SCHEMA_STATE: SchemaConnectionState = {
+  databases: null,
+  error: null,
+  isLoading: false,
+  schema: null,
+  schemaDatabase: null,
+  selectedDatabase: null,
+};
+
+export const useSchemaStore = create<SchemaStore>((set, get) => {
+  const patch = (
+    connectionId: string,
+    updater:
+      | Partial<SchemaConnectionState>
+      | ((prev: SchemaConnectionState) => Partial<SchemaConnectionState>)
+  ) => {
+    set((state) => {
+      const prev = state.byConnection[connectionId] ?? EMPTY_SCHEMA_STATE;
+      const next = typeof updater === "function" ? updater(prev) : updater;
+      return {
+        byConnection: {
+          ...state.byConnection,
+          [connectionId]: { ...prev, ...next },
+        },
+      };
+    });
+  };
+
+  const fetchDatabases = async (connectionId: string) => {
+    patch(connectionId, { error: null, isLoading: true });
+    try {
+      const databases = await listDatabases(connectionId);
+      const selected =
+        databases.find((db) => db === "public") ?? databases[0] ?? null;
+      patch(connectionId, (prev) => ({
+        databases,
+        isLoading: false,
+        selectedDatabase: prev.selectedDatabase ?? selected,
+      }));
+    } catch (error) {
+      const message = getErrorMessage(error, "Failed to list databases");
+      patch(connectionId, { error: message, isLoading: false });
+    }
+  };
+
+  const fetchSchema = async (connectionId: string, databaseName: string) => {
+    patch(connectionId, { error: null, isLoading: true });
+    try {
+      const schema = await getSchema(connectionId, databaseName);
+      patch(connectionId, (prev) => {
+        if (prev.selectedDatabase !== databaseName) {
+          return { isLoading: false };
+        }
+        return {
+          error: null,
+          isLoading: false,
+          schema,
+          schemaDatabase: databaseName,
+        };
+      });
+    } catch (error) {
+      const message = getErrorMessage(error, "Failed to load schema");
+      patch(connectionId, (prev) => {
+        if (prev.selectedDatabase !== databaseName) {
+          return { isLoading: false };
+        }
+        return {
+          error: message,
+          isLoading: false,
+          schema: null,
+          schemaDatabase: null,
+        };
+      });
+    }
+  };
+
+  return {
+    byConnection: {},
+
+    clear: (connectionId) => {
+      set((state) => {
+        if (!state.byConnection[connectionId]) {
+          return state;
+        }
+        const { [connectionId]: _removed, ...rest } = state.byConnection;
+        return { byConnection: rest };
+      });
+    },
+
+    loadDatabases: async (connectionId) => {
+      const slice = get().byConnection[connectionId];
+      if (slice?.databases || slice?.isLoading) {
+        return;
+      }
+      await fetchDatabases(connectionId);
+    },
+
+    loadSchema: async (connectionId, databaseName) => {
+      const slice = get().byConnection[connectionId];
+      if (
+        slice?.schema &&
+        slice.schemaDatabase === databaseName &&
+        !slice.error
+      ) {
+        return;
+      }
+      await fetchSchema(connectionId, databaseName);
+    },
+
+    refresh: async (connectionId) => {
+      const slice = get().byConnection[connectionId];
+      const database = slice?.selectedDatabase;
+      if (!database) {
+        return;
+      }
+      await fetchSchema(connectionId, database);
+    },
+
+    setSelectedDatabase: (connectionId, database) => {
+      patch(connectionId, {
+        schema: null,
+        schemaDatabase: null,
+        selectedDatabase: database,
+      });
+    },
+  };
+});
+
+export const selectSchemaState =
+  (connectionId: string): ((store: SchemaStore) => SchemaConnectionState) =>
+  (store) =>
+    store.byConnection[connectionId] ?? EMPTY_SCHEMA_STATE;

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@oh-my-query/config": "workspace:*",
         "@typescript/native-preview": "catalog:",
+        "lefthook": "^2.1.6",
         "oxfmt": "latest",
         "oxlint": "latest",
         "turbo": "^2.6.3",
@@ -1683,6 +1684,28 @@
     "langium": ["langium@4.2.1", "", { "dependencies": { "chevrotain": "~11.1.1", "chevrotain-allstar": "~0.3.1", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.1.0" } }, "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ=="],
 
     "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "lefthook": ["lefthook@2.1.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.6", "lefthook-darwin-x64": "2.1.6", "lefthook-freebsd-arm64": "2.1.6", "lefthook-freebsd-x64": "2.1.6", "lefthook-linux-arm64": "2.1.6", "lefthook-linux-x64": "2.1.6", "lefthook-openbsd-arm64": "2.1.6", "lefthook-openbsd-x64": "2.1.6", "lefthook-windows-arm64": "2.1.6", "lefthook-windows-x64": "2.1.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A=="],
 
     "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,29 @@
+pre-commit:
+  parallel: true
+  jobs:
+    - name: format
+      glob: "*.{js,jsx,ts,tsx,json,md,mdx,css}"
+      run: bun x ultracite fix {staged_files}
+      stage_fixed: true
+
+    - name: lint
+      glob: "*.{js,jsx,ts,tsx,json,md,mdx,css}"
+      run: bun x ultracite check {staged_files}
+
+    - name: check-types
+      glob: "*.{ts,tsx}"
+      run: bun run check-types
+
+    - name: test
+      glob: "apps/web/**/*.{ts,tsx}"
+      run: bun run --cwd apps/web test
+
+    - name: rust-fmt
+      glob: "apps/web/src-tauri/**/*.rs"
+      root: apps/web/src-tauri
+      run: cargo fmt --check
+
+    - name: rust-clippy
+      glob: "apps/web/src-tauri/**/*.rs"
+      root: apps/web/src-tauri
+      run: cargo clippy -- -D warnings

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "dev:web": "turbo -F web dev",
     "desktop:dev": "turbo -F web desktop:dev",
     "check": "ultracite check",
-    "fix": "ultracite fix"
+    "fix": "ultracite fix",
+    "prepare": "lefthook install"
   },
   "dependencies": {
     "@oh-my-query/env": "workspace:*",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@oh-my-query/config": "workspace:*",
     "@typescript/native-preview": "catalog:",
+    "lefthook": "^2.1.6",
     "oxfmt": "latest",
     "oxlint": "latest",
     "turbo": "^2.6.3",


### PR DESCRIPTION
## Summary
- Move schema state into a per-connection Zustand store so remounts and `isConnected` toggles reuse cached databases/schema instead of refetching.
- Collapse the MySQL/MariaDB per-table `information_schema` loop (`3N + 2` round trips) into **4 schema-wide bulk queries** — fixes the "schema never loads" hang against remote MariaDB 10 RDS.
- Widen the MySQL pool: 30 s acquire timeout, 10 min idle / 30 min max lifetime, disabled sqlx statement cache. Surface Tauri `DbError` messages verbatim via a shared `getErrorMessage` helper.

## Test plan
- [x] `cargo test` in `src-tauri` (60 passed, 3 new for `build_mysql_schema` grouping)
- [x] `bun run test` (385 passed, new tests for zustand caching + `getErrorMessage`)
- [x] `bun run check-types`
- [x] Manually connect to remote MariaDB 10 RDS and confirm schema populates in ~2–3 s instead of hanging