### PR TITLE
feat(updater): release channels with signed auto-update (OMQ-20)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resolve-channel:
+    name: Resolve release channel
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.parse.outputs.channel }}
+      version: ${{ steps.parse.outputs.version }}
+      prerelease: ${{ steps.parse.outputs.prerelease }}
+      rolling-tag: ${{ steps.parse.outputs.rolling-tag }}
+    steps:
+      - name: Parse tag
+        id: parse
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            CHANNEL="stable"
+            PRERELEASE="false"
+          elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
+            CHANNEL="beta"
+            PRERELEASE="true"
+          else
+            echo "::error::Tag ${TAG} does not match v<X>.<Y>.<Z> (stable) or v<X>.<Y>.<Z>-beta.<N> (beta)"
+            exit 1
+          fi
+          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${PRERELEASE}" >> "$GITHUB_OUTPUT"
+          echo "rolling-tag=updater-${CHANNEL}" >> "$GITHUB_OUTPUT"
+
   bump-version:
     name: Bump version from tag
+    needs: resolve-channel
+    if: needs.resolve-channel.outputs.channel == 'stable'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -22,7 +53,7 @@ jobs:
 
       - name: Bump version in config files
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ needs.resolve-channel.outputs.version }}"
           jq --arg v "$VERSION" '.version = $v' apps/web/src-tauri/tauri.conf.json > tmp.json && mv tmp.json apps/web/src-tauri/tauri.conf.json
           sed -i "s/^version = \".*\"/version = \"$VERSION\"/" apps/web/src-tauri/Cargo.toml
 
@@ -32,12 +63,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add apps/web/src-tauri/tauri.conf.json apps/web/src-tauri/Cargo.toml
           git diff --staged --quiet && exit 0
-          git commit -m "chore: bump version to ${GITHUB_REF_NAME#v}"
+          git commit -m "chore: bump version to ${{ needs.resolve-channel.outputs.version }}"
           git push origin main
 
   build-macos:
-    name: Build macOS (${{ matrix.label }})
-    needs: bump-version
+    name: Build macOS (${{ matrix.label }}) [${{ needs.resolve-channel.outputs.channel }}]
+    needs: [resolve-channel, bump-version]
+    if: always() && needs.resolve-channel.result == 'success' && (needs.bump-version.result == 'success' || needs.bump-version.result == 'skipped')
     permissions:
       contents: write
     strategy:
@@ -52,7 +84,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ needs.resolve-channel.outputs.channel == 'stable' && 'main' || github.ref }}
+
+      - name: Stamp beta version
+        if: needs.resolve-channel.outputs.channel == 'beta'
+        run: |
+          VERSION="${{ needs.resolve-channel.outputs.version }}"
+          jq --arg v "$VERSION" '.version = $v' apps/web/src-tauri/tauri.conf.json > tmp.json && mv tmp.json apps/web/src-tauri/tauri.conf.json
+          sed -i '' "s/^version = \".*\"/version = \"$VERSION\"/" apps/web/src-tauri/Cargo.toml
+
+      - name: Verify signing secret is set
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            echo "::error::TAURI_SIGNING_PRIVATE_KEY secret is not set. See RELEASING.md for one-time key setup."
+            exit 1
+          fi
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -75,18 +123,27 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           projectPath: apps/web
           tagName: ${{ github.ref_name }}
           releaseName: "oh_my_query ${{ github.ref_name }}"
           releaseBody: "See assets below to download.\n\n**macOS:** `brew install --cask victor-teles/tap/oh-my-query`"
           releaseDraft: false
-          prerelease: false
+          prerelease: ${{ needs.resolve-channel.outputs.prerelease }}
           args: --target ${{ matrix.target }}
 
   build-windows:
-    name: Build Windows (${{ matrix.label }})
-    needs: bump-version
+    name: Build Windows (${{ matrix.label }}) [${{ needs.resolve-channel.outputs.channel }}]
+    needs: [resolve-channel, bump-version]
+    if: always() && needs.resolve-channel.result == 'success' && (needs.bump-version.result == 'success' || needs.bump-version.result == 'skipped')
     permissions:
       contents: write
     strategy:
@@ -101,7 +158,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ needs.resolve-channel.outputs.channel == 'stable' && 'main' || github.ref }}
+
+      - name: Stamp beta version
+        if: needs.resolve-channel.outputs.channel == 'beta'
+        shell: pwsh
+        run: |
+          $version = "${{ needs.resolve-channel.outputs.version }}"
+          $conf = Get-Content apps/web/src-tauri/tauri.conf.json -Raw | ConvertFrom-Json
+          $conf.version = $version
+          $conf | ConvertTo-Json -Depth 100 | Set-Content apps/web/src-tauri/tauri.conf.json
+          (Get-Content apps/web/src-tauri/Cargo.toml) -replace '^version = ".*"', "version = `"$version`"" | Set-Content apps/web/src-tauri/Cargo.toml
+
+      - name: Verify signing secret is set
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            echo "::error::TAURI_SIGNING_PRIVATE_KEY secret is not set. See RELEASING.md for one-time key setup."
+            exit 1
+          fi
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -124,34 +201,133 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: apps/web
           tagName: ${{ github.ref_name }}
           releaseName: "oh_my_query ${{ github.ref_name }}"
           releaseDraft: false
-          prerelease: false
+          prerelease: ${{ needs.resolve-channel.outputs.prerelease }}
           args: --target ${{ matrix.target }}
+
+      - name: Sign Windows artifact
+        if: vars.WINDOWS_SIGNING_ENABLED == 'true'
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          # TODO: implement signtool / Azure Trusted Signing flow.
+          # Tracked in RELEASING.md → "Windows code signing".
+          Write-Host "Windows signing enabled — implement signtool here."
+
+      - name: Note unsigned Windows build
+        if: vars.WINDOWS_SIGNING_ENABLED != 'true'
+        shell: bash
+        run: |
+          echo "::warning::Windows artifact is unsigned. Set repo variable WINDOWS_SIGNING_ENABLED=true and add WINDOWS_CERTIFICATE secrets to enable signing."
 
       - name: Upload portable exe
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $version = "${{ github.ref_name }}".TrimStart("v")
+          $version = "${{ needs.resolve-channel.outputs.version }}"
           $exe = Get-ChildItem -Path "apps/web/src-tauri/target/${{ matrix.target }}/release/oh-my-query.exe" -ErrorAction Stop
           $label = "${{ matrix.label }}"
           $dest = "oh_my_query_${version}_${label}_portable.exe"
           Copy-Item $exe.FullName $dest
           gh release upload "${{ github.ref_name }}" $dest --clobber
 
+  publish-appcast:
+    name: Publish appcast (${{ needs.resolve-channel.outputs.channel }})
+    needs: [resolve-channel, build-macos, build-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build latest.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ needs.resolve-channel.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p out
+
+          # Pull release notes from the GitHub release body.
+          NOTES=$(gh release view "$TAG" --json body -q .body 2>/dev/null || echo "")
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          BASE="https://github.com/${REPO}/releases/download/${TAG}"
+
+          fetch_sig () {
+            local asset="$1"
+            curl -sfL -o "out/${asset}.sig" "${BASE}/${asset}.sig" || return 1
+          }
+
+          declare -A PLATFORMS=(
+            [darwin-aarch64]="oh_my_query_${VERSION}_aarch64.app.tar.gz"
+            [darwin-x86_64]="oh_my_query_${VERSION}_x64.app.tar.gz"
+            [windows-x86_64]="oh_my_query_${VERSION}_x64-setup.nsis.zip"
+            [windows-aarch64]="oh_my_query_${VERSION}_arm64-setup.nsis.zip"
+          )
+
+          PLATFORMS_JSON="{}"
+          for key in "${!PLATFORMS[@]}"; do
+            asset="${PLATFORMS[$key]}"
+            if fetch_sig "$asset"; then
+              SIG=$(cat "out/${asset}.sig")
+              PLATFORMS_JSON=$(jq --arg k "$key" --arg sig "$SIG" --arg url "${BASE}/${asset}" \
+                '. + {($k): {signature: $sig, url: $url}}' <<<"$PLATFORMS_JSON")
+            else
+              echo "::warning::Missing .sig for $asset — platform $key omitted from appcast"
+            fi
+          done
+
+          jq -n \
+            --arg version "$VERSION" \
+            --arg notes "$NOTES" \
+            --arg pub_date "$PUB_DATE" \
+            --argjson platforms "$PLATFORMS_JSON" \
+            '{version: $version, notes: $notes, pub_date: $pub_date, platforms: $platforms}' \
+            > out/latest.json
+
+          cat out/latest.json
+
+      - name: Publish to rolling tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLLING_TAG: ${{ needs.resolve-channel.outputs.rolling-tag }}
+          CHANNEL: ${{ needs.resolve-channel.outputs.channel }}
+        run: |
+          set -euo pipefail
+          # Recreate the rolling tag at the current commit so the asset URL stays stable.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f "$ROLLING_TAG"
+          git push -f origin "$ROLLING_TAG"
+
+          if gh release view "$ROLLING_TAG" >/dev/null 2>&1; then
+            gh release edit "$ROLLING_TAG" --target "$GITHUB_SHA" --prerelease=true --title "Updater feed (${CHANNEL})"
+          else
+            gh release create "$ROLLING_TAG" --target "$GITHUB_SHA" --prerelease --title "Updater feed (${CHANNEL})" --notes "Auto-published appcast for the ${CHANNEL} channel."
+          fi
+
+          gh release upload "$ROLLING_TAG" out/latest.json --clobber
+
   update-homebrew-tap:
     name: Update Homebrew tap
-    needs: build-macos
+    needs: [resolve-channel, build-macos]
+    if: needs.resolve-channel.outputs.channel == 'stable'
     runs-on: ubuntu-latest
     steps:
       - name: Get version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: echo "version=${{ needs.resolve-channel.outputs.version }}" >> $GITHUB_OUTPUT
 
       - name: Download DMGs and compute SHA256
         id: hashes

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,112 @@
+# Releasing oh-my-query
+
+The release pipeline ships **two channels** today: `stable` (default) and `beta`. Each channel has its own signed updater feed published to a rolling GitHub Release tag (`updater-stable`, `updater-beta`). The desktop app reads the feed for the channel the user picked in **Settings → Updates**.
+
+A `nightly` channel is wired in the UI but disabled — adding it is a follow-up.
+
+## One-time setup (maintainer)
+
+You only need to do this once per repository.
+
+### 1. Generate the Tauri updater keypair
+
+The private key signs every release. The public key is embedded in the app at build time and verifies updates on the user's machine.
+
+```bash
+bunx @tauri-apps/cli signer generate -- -w ~/.tauri/oh-my-query.key
+```
+
+Store the private key somewhere durable (1Password, a hardware token — _never_ on a developer laptop's disk-only). Copy the public key string into `apps/web/src-tauri/tauri.conf.json` under `plugins.updater.pubkey`, replacing the `REPLACE_WITH_TAURI_UPDATER_PUBKEY` placeholder.
+
+### 2. Add GitHub Actions secrets
+
+In **Settings → Secrets and variables → Actions**, add:
+
+| Secret                               | Required for            | Notes                                                |
+| ------------------------------------ | ----------------------- | ---------------------------------------------------- |
+| `TAURI_SIGNING_PRIVATE_KEY`          | every build             | Contents of the file from step 1.                    |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | every build             | Passphrase you set in step 1.                        |
+| `APPLE_CERTIFICATE`                  | macOS notarization      | Base64 of the Developer ID Application `.p12`.       |
+| `APPLE_CERTIFICATE_PASSWORD`         | macOS notarization      | The `.p12` passphrase.                               |
+| `APPLE_SIGNING_IDENTITY`             | macOS notarization      | E.g. `Developer ID Application: Your Name (TEAMID)`. |
+| `APPLE_ID`                           | macOS notarization      | App Store Connect Apple ID.                          |
+| `APPLE_PASSWORD`                     | macOS notarization      | App-specific password (not your Apple ID password).  |
+| `APPLE_TEAM_ID`                      | macOS notarization      | 10-char team ID.                                     |
+| `WINDOWS_CERTIFICATE`                | Windows signing _(opt)_ | Base64 `.pfx`. Leave empty until ready.              |
+| `WINDOWS_CERTIFICATE_PASSWORD`       | Windows signing _(opt)_ | `.pfx` passphrase.                                   |
+| `HOMEBREW_TAP_TOKEN`                 | Homebrew cask dispatch  | Already in use; keep as-is.                          |
+
+### 3. Enable Windows signing (when you have a cert)
+
+Set the **repository variable** `WINDOWS_SIGNING_ENABLED=true` (Settings → Variables → Actions). The `Sign Windows artifact` step in `release.yml` is a no-op until both the variable and the secrets above are present. Until then, Windows artifacts ship unsigned and the workflow logs a warning in the run summary.
+
+### 4. Seed the rolling appcast tags
+
+The first release per channel will create `updater-stable` / `updater-beta` automatically — no manual step needed.
+
+## Cutting a release
+
+### Stable
+
+```bash
+git checkout main && git pull
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The `Release` workflow:
+
+1. Parses the tag → channel `stable`.
+2. Bumps `tauri.conf.json` and `Cargo.toml` on `main` and pushes the bump commit.
+3. Builds + signs + notarizes macOS (arm64, x64) and Windows (x64, arm64).
+4. Generates `latest.json`, force-recreates the `updater-stable` rolling tag at the current commit, and uploads the appcast as a release asset.
+5. Dispatches the Homebrew tap update.
+
+### Beta
+
+```bash
+git checkout main && git pull   # or any branch you want to ship to beta
+git tag v0.1.0-beta.1
+git push origin v0.1.0-beta.1
+```
+
+Same workflow as stable, except:
+
+- No version-bump commit on `main` (beta versions live only on the tag).
+- The release is marked `prerelease: true`.
+- The appcast publishes to `updater-beta`.
+
+Promote a beta to stable by tagging `v0.1.0` on the same commit.
+
+## Rolling back a bad release
+
+Two layers of defense — pick the cheapest one that solves your case.
+
+1. **Stop telling clients about the update** (fast, reversible)
+
+   ```bash
+   gh release delete-asset updater-stable latest.json --yes
+   ```
+
+   The desktop app falls back to "no update available" until the next signed release publishes.
+
+2. **Yank the release entirely** (irreversible for users who already updated)
+   ```bash
+   gh release delete v0.1.0 --yes --cleanup-tag
+   gh release delete-asset updater-stable latest.json --yes
+   ```
+   Users on a corrupted version can still re-download the previous good build from its release page.
+
+## Key rotation
+
+If the updater private key is ever exposed:
+
+1. Generate a fresh keypair (step 1 above).
+2. Ship a release that **embeds the new public key** _and_ is signed with the **old private key** — every active user's app verifies it with the still-trusted old pubkey, then upgrades to a build that trusts only the new key going forward.
+3. Rotate `TAURI_SIGNING_PRIVATE_KEY` in GitHub Secrets to the new key.
+4. Ship a follow-up release signed with the new key to confirm the chain.
+5. Revoke / destroy the old private key.
+
+Do not skip the bridging release — clients on the compromised key cannot verify anything signed with the new key directly.
+
+See [`docs/threat-model-updates.md`](docs/threat-model-updates.md) for the rationale and the threat-by-threat coverage.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security reports.
+
+Use GitHub's [private vulnerability reporting](https://github.com/victor-teles/oh-my-query/security/advisories/new) so we can triage privately. We aim to acknowledge within 72 hours and ship a fix on the next stable release once a mitigation is verified.
+
+If you cannot use GitHub, email `security@ohmyquery.dev` (PGP key on request).
+
+## Supported versions
+
+We support the latest **stable** release and the latest **beta** release. Older versions are not patched — switch channels in **Settings → Updates** if you are on an older build.
+
+| Channel | Supported | Source of truth                                                                             |
+| ------- | --------- | ------------------------------------------------------------------------------------------- |
+| Stable  | Yes       | [`updater-stable`](https://github.com/victor-teles/oh-my-query/releases/tag/updater-stable) |
+| Beta    | Yes       | [`updater-beta`](https://github.com/victor-teles/oh-my-query/releases/tag/updater-beta)     |
+| Nightly | Not yet   | Planned — tracked separately                                                                |
+
+## Update path
+
+The auto-update path is signed end-to-end. See [`docs/threat-model-updates.md`](docs/threat-model-updates.md) for the threat model, the trust anchors, and the key-rotation procedure.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
     "@tanstack/react-virtual": "^3.13.24",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-updater": "^2",
     "@uiw/codemirror-theme-github": "^4.25.4",
     "@uiw/codemirror-themes-all": "^4.25.5",
     "@uiw/react-codemirror": "^4.25.4",

--- a/apps/web/src-tauri/Cargo.lock
+++ b/apps/web/src-tauri/Cargo.lock
@@ -3198,7 +3198,7 @@ dependencies = [
  "serde_json",
  "tar",
  "vcpkg",
- "zip",
+ "zip 6.0.0",
 ]
 
 [[package]]
@@ -3404,6 +3404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,7 +3553,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
  "security-framework 2.11.1",
@@ -3861,6 +3867,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3939,6 +3957,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-log",
  "tauri-plugin-opener",
+ "tauri-plugin-updater",
  "tiberius",
  "tokio",
  "tokio-util",
@@ -4012,6 +4031,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4037,6 +4062,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4931,15 +4970,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -5103,6 +5147,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.6.0",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5111,6 +5167,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.6.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -6262,6 +6345,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7281,6 +7397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8258,6 +8383,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4"
 tauri = { version = "2.10.0", features = ["devtools", "macos-private-api"] }
 tauri-plugin-log = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-updater = "2"
 sqlx = { version = "0.8", features = [
   "runtime-tokio",
   "tls-native-tls",

--- a/apps/web/src-tauri/capabilities/default.json
+++ b/apps/web/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:window:allow-start-dragging",
     "core:window:allow-destroy",
+    "updater:default",
     {
       "identifier": "opener:allow-open-url",
       "allow": [

--- a/apps/web/src-tauri/src/lib.rs
+++ b/apps/web/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod config;
 pub mod crypto;
 pub mod db;
 mod persistence;
+mod update_channel;
 
 use cancellation::CancellationRegistry;
 use db::pool::ConnectionPoolManager;
@@ -19,6 +20,7 @@ pub fn run() {
                 .build(),
         )
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(ConnectionPoolManager::new())
         .manage(CancellationRegistry::new())
         .setup(|app| {
@@ -100,6 +102,10 @@ pub fn run() {
             persistence::get_all_history,
             persistence::get_connections,
             persistence::save_connections,
+            update_channel::get_update_channel,
+            update_channel::set_update_channel,
+            update_channel::check_for_update,
+            update_channel::install_update,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/web/src-tauri/src/update_channel.rs
+++ b/apps/web/src-tauri/src/update_channel.rs
@@ -1,0 +1,182 @@
+use std::path::PathBuf;
+
+use serde::Serialize;
+use tauri::AppHandle;
+use tauri_plugin_updater::UpdaterExt;
+
+use crate::config::ConfigError;
+
+pub const STABLE: &str = "stable";
+pub const BETA: &str = "beta";
+pub const NIGHTLY: &str = "nightly";
+
+const APPCAST_BASE: &str = "https://github.com/victor-teles/oh-my-query/releases/download";
+
+pub fn channel_path() -> Result<PathBuf, ConfigError> {
+    let home = dirs::home_dir().ok_or_else(|| ConfigError {
+        code: "HOME_NOT_FOUND".to_string(),
+        message: "Could not determine home directory".to_string(),
+    })?;
+    Ok(home
+        .join(".config")
+        .join("oh-my-query")
+        .join("update-channel.txt"))
+}
+
+pub fn normalize(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        STABLE => Some(STABLE),
+        BETA => Some(BETA),
+        NIGHTLY => Some(NIGHTLY),
+        _ => None,
+    }
+}
+
+pub async fn read_channel() -> Result<&'static str, ConfigError> {
+    let path = channel_path()?;
+    if !path.exists() {
+        return Ok(STABLE);
+    }
+    let content = tokio::fs::read_to_string(&path).await?;
+    Ok(normalize(&content).unwrap_or(STABLE))
+}
+
+pub async fn write_channel(channel: &str) -> Result<&'static str, ConfigError> {
+    let canonical = normalize(channel).ok_or_else(|| ConfigError {
+        code: "INVALID_CHANNEL".to_string(),
+        message: format!("Unknown update channel: {channel}"),
+    })?;
+    let path = channel_path()?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    tokio::fs::write(&path, canonical.as_bytes()).await?;
+    Ok(canonical)
+}
+
+pub fn appcast_url(channel: &str) -> String {
+    let canonical = normalize(channel).unwrap_or(STABLE);
+    format!("{APPCAST_BASE}/updater-{canonical}/latest.json")
+}
+
+#[tauri::command]
+pub async fn get_update_channel() -> Result<&'static str, ConfigError> {
+    read_channel().await
+}
+
+#[tauri::command]
+pub async fn set_update_channel(channel: String) -> Result<&'static str, ConfigError> {
+    write_channel(&channel).await
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AvailableUpdate {
+    pub version: String,
+    pub current_version: String,
+    pub notes: Option<String>,
+    pub date: Option<String>,
+}
+
+fn build_endpoint(channel: &str) -> Result<tauri::Url, String> {
+    tauri::Url::parse(&appcast_url(channel)).map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn check_for_update(app: AppHandle) -> Result<Option<AvailableUpdate>, String> {
+    let channel = read_channel().await.map_err(|err| err.message)?;
+    let endpoint = build_endpoint(channel)?;
+    let updater = app
+        .updater_builder()
+        .endpoints(vec![endpoint])
+        .map_err(|err| err.to_string())?
+        .build()
+        .map_err(|err| err.to_string())?;
+
+    match updater.check().await.map_err(|err| err.to_string())? {
+        Some(update) => Ok(Some(AvailableUpdate {
+            version: update.version.clone(),
+            current_version: update.current_version.clone(),
+            notes: update.body.clone(),
+            date: update.date.map(|d| d.to_string()),
+        })),
+        None => Ok(None),
+    }
+}
+
+#[tauri::command]
+pub async fn install_update(app: AppHandle) -> Result<bool, String> {
+    let channel = read_channel().await.map_err(|err| err.message)?;
+    let endpoint = build_endpoint(channel)?;
+    let updater = app
+        .updater_builder()
+        .endpoints(vec![endpoint])
+        .map_err(|err| err.to_string())?
+        .build()
+        .map_err(|err| err.to_string())?;
+
+    let Some(update) = updater.check().await.map_err(|err| err.to_string())? else {
+        return Ok(false);
+    };
+
+    update
+        .download_and_install(|_, _| {}, || {})
+        .await
+        .map_err(|err| err.to_string())?;
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_accepts_known_channels() {
+        assert_eq!(normalize("stable"), Some(STABLE));
+        assert_eq!(normalize("BETA"), Some(BETA));
+        assert_eq!(normalize("  nightly  "), Some(NIGHTLY));
+    }
+
+    #[test]
+    fn normalize_rejects_unknown() {
+        assert_eq!(normalize("alpha"), None);
+        assert_eq!(normalize(""), None);
+    }
+
+    #[test]
+    fn appcast_url_uses_canonical_channel() {
+        assert!(appcast_url("stable").ends_with("/updater-stable/latest.json"));
+        assert!(appcast_url("BETA").ends_with("/updater-beta/latest.json"));
+        assert!(appcast_url("garbage").ends_with("/updater-stable/latest.json"));
+    }
+
+    #[tokio::test]
+    async fn write_then_read_roundtrips() {
+        let path = channel_path().unwrap();
+        let backup = if path.exists() {
+            Some(tokio::fs::read_to_string(&path).await.unwrap())
+        } else {
+            None
+        };
+
+        write_channel("beta").await.unwrap();
+        assert_eq!(read_channel().await.unwrap(), BETA);
+
+        write_channel("STABLE").await.unwrap();
+        assert_eq!(read_channel().await.unwrap(), STABLE);
+
+        match backup {
+            Some(content) => tokio::fs::write(&path, content).await.unwrap(),
+            None => {
+                let _ = tokio::fs::remove_file(&path).await;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn write_rejects_unknown_channel() {
+        let err = write_channel("alpha").await.expect_err("expected error");
+        assert_eq!(err.code, "INVALID_CHANNEL");
+    }
+}

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -36,6 +36,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -43,5 +44,15 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "updater": {
+      "active": true,
+      "dialog": false,
+      "endpoints": [
+        "https://github.com/victor-teles/oh-my-query/releases/download/updater-stable/latest.json"
+      ],
+      "pubkey": "REPLACE_WITH_TAURI_UPDATER_PUBKEY"
+    }
   }
 }

--- a/apps/web/src/routes/_default/-components/settings-sidebar.tsx
+++ b/apps/web/src/routes/_default/-components/settings-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Download, Paintbrush, Palette, Type } from "lucide-react";
+import { Download, Paintbrush, Palette, RefreshCw, Type } from "lucide-react";
 import { useCallback } from "react";
 
 import { isTauri } from "@/lib/tauri";
@@ -8,13 +8,15 @@ export type SettingsSectionId =
   | "appearance"
   | "syntax-theme"
   | "code-font"
-  | "export";
+  | "export"
+  | "updates";
 
 export const SETTINGS_SECTIONS = [
   { icon: Palette, id: "appearance", label: "Appearance" },
   { icon: Paintbrush, id: "syntax-theme", label: "Syntax Theme" },
   { icon: Type, id: "code-font", label: "Code Font" },
   { icon: Download, id: "export", label: "Export" },
+  { icon: RefreshCw, id: "updates", label: "Updates" },
 ] as const satisfies readonly {
   id: SettingsSectionId;
   label: string;

--- a/apps/web/src/routes/_default/-components/update-channel-section.test.tsx
+++ b/apps/web/src/routes/_default/-components/update-channel-section.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { mockTauri } from "@/test/tauri-mock";
+
+import { SettingsFeedbackProvider } from "./settings-feedback-context";
+import { UpdateChannelSection } from "./update-channel-section";
+
+const enableTauri = () => {
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    value: {},
+    writable: true,
+  });
+};
+
+const renderSection = () =>
+  render(
+    <SettingsFeedbackProvider>
+      <UpdateChannelSection />
+    </SettingsFeedbackProvider>
+  );
+
+describe("updateChannelSection (web)", () => {
+  it("renders the desktop-only empty state when not in Tauri", () => {
+    renderSection();
+    expect(screen.getByText(/only work in the desktop app/i)).toBeDefined();
+  });
+});
+
+describe("updateChannelSection (tauri)", () => {
+  it("shows three channel options with Nightly disabled", async () => {
+    enableTauri();
+    mockTauri({ get_update_channel: () => "stable" });
+    renderSection();
+
+    const stable = await screen.findByRole("button", { name: /Stable/ });
+    const beta = screen.getByRole("button", { name: /Beta/ });
+    const nightly = screen.getByRole("button", { name: /Nightly/ });
+
+    expect(stable.hasAttribute("disabled")).toBeFalsy();
+    expect(beta.hasAttribute("disabled")).toBeFalsy();
+    expect(nightly.hasAttribute("disabled")).toBeTruthy();
+  });
+
+  it("writes the channel and surfaces the restart prompt", async () => {
+    enableTauri();
+    let stored = "stable";
+    mockTauri({
+      get_update_channel: () => stored,
+      set_update_channel: (payload) => {
+        stored = payload.channel as string;
+        return stored;
+      },
+    });
+
+    renderSection();
+
+    const betaButton = await screen.findByRole("button", { name: /Beta/ });
+    await userEvent.click(betaButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Restart oh-my-query to start receiving updates/i)
+      ).toBeDefined();
+    });
+    expect(stored).toBe("beta");
+  });
+
+  it("renders the up-to-date confirmation after a check", async () => {
+    enableTauri();
+    mockTauri({
+      check_for_update: () => null,
+      get_update_channel: () => "stable",
+    });
+
+    renderSection();
+
+    const checkButton = await screen.findByRole("button", {
+      name: /Check now/i,
+    });
+    await userEvent.click(checkButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/up to date/i)).toBeDefined();
+    });
+  });
+
+  it("offers Install & restart when an update is available", async () => {
+    enableTauri();
+    mockTauri({
+      check_for_update: () => ({
+        currentVersion: "0.0.10",
+        date: null,
+        notes: "Bug fixes",
+        version: "0.0.11",
+      }),
+      get_update_channel: () => "stable",
+    });
+
+    renderSection();
+
+    const checkButton = await screen.findByRole("button", {
+      name: /Check now/i,
+    });
+    await userEvent.click(checkButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Update available/i)).toBeDefined();
+    });
+    expect(
+      screen.getByRole("button", { name: /Install & restart/i })
+    ).toBeDefined();
+  });
+});

--- a/apps/web/src/routes/_default/-components/update-channel-section.tsx
+++ b/apps/web/src/routes/_default/-components/update-channel-section.tsx
@@ -1,0 +1,240 @@
+import { CheckCircle2, Download, Loader2, RefreshCw } from "lucide-react";
+import { useCallback } from "react";
+
+import type { UpdateChannel } from "@/routes/_default/-hooks/use-update-channel";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useUpdateChannel } from "@/routes/_default/-hooks/use-update-channel";
+
+import { useSettingsFeedback } from "./settings-feedback-context";
+
+interface ChannelMeta {
+  value: UpdateChannel;
+  label: string;
+  blurb: string;
+  cadence: string;
+  disabled?: boolean;
+  disabledHint?: string;
+}
+
+const CHANNELS: ChannelMeta[] = [
+  {
+    blurb: "Fully tested releases. The default for everyone.",
+    cadence: "~monthly",
+    label: "Stable",
+    value: "stable",
+  },
+  {
+    blurb: "Get new features early. May still have rough edges.",
+    cadence: "weekly",
+    label: "Beta",
+    value: "beta",
+  },
+  {
+    blurb: "Bleeding edge. Built from main, expect breakage.",
+    cadence: "daily",
+    disabled: true,
+    disabledHint: "Coming soon",
+    label: "Nightly",
+    value: "nightly",
+  },
+];
+
+interface ChannelCardProps {
+  meta: ChannelMeta;
+  selected: boolean;
+  onSelect: (value: UpdateChannel) => void;
+}
+
+const ChannelCard = ({ meta, selected, onSelect }: ChannelCardProps) => {
+  const handleClick = useCallback(() => {
+    if (meta.disabled) {
+      return;
+    }
+    onSelect(meta.value);
+  }, [meta.disabled, meta.value, onSelect]);
+
+  return (
+    <button
+      aria-pressed={selected}
+      className={cn(
+        "group flex w-full flex-col items-start gap-1.5 rounded-lg border p-4 text-left transition-colors",
+        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sidebar-ring",
+        meta.disabled && "cursor-not-allowed opacity-50",
+        !meta.disabled && "cursor-pointer",
+        selected
+          ? "border-primary bg-primary/5"
+          : "border-foreground/10 hover:border-foreground/25"
+      )}
+      disabled={meta.disabled}
+      onClick={handleClick}
+      title={meta.disabled ? meta.disabledHint : undefined}
+      type="button"
+    >
+      <div className="flex w-full items-center justify-between">
+        <span className="text-sm font-semibold">{meta.label}</span>
+        <span className="text-[11px] tabular-nums text-muted-foreground">
+          {meta.disabled ? meta.disabledHint : meta.cadence}
+        </span>
+      </div>
+      <p className="text-xs text-muted-foreground">{meta.blurb}</p>
+    </button>
+  );
+};
+
+const formatRelative = (timestamp: number): string => {
+  const seconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+  if (seconds < 5) {
+    return "just now";
+  }
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.round(seconds / 60);
+  return `${minutes}m ago`;
+};
+
+export const UpdateChannelSection = () => {
+  const {
+    channel,
+    check,
+    checkNow,
+    installNow,
+    loading,
+    pendingRestart,
+    setChannel,
+    supported,
+  } = useUpdateChannel();
+  const { notifySaved } = useSettingsFeedback();
+
+  const handleSelect = useCallback(
+    async (value: UpdateChannel) => {
+      await setChannel(value);
+      notifySaved();
+    },
+    [notifySaved, setChannel]
+  );
+
+  if (!supported) {
+    return (
+      <section>
+        <h2 className="text-xl font-semibold tracking-tight">Updates</h2>
+        <p className="mt-1.5 mb-6 text-sm text-muted-foreground">
+          Channel switching and auto-update only work in the desktop app.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <h2 className="text-xl font-semibold tracking-tight">Updates</h2>
+      <p className="mt-1.5 mb-6 text-sm text-muted-foreground">
+        Pick a release channel and check for updates. New channel takes effect
+        on next launch.
+      </p>
+
+      <div
+        aria-label="Release channel"
+        className="grid gap-3 sm:grid-cols-3"
+        role="radiogroup"
+      >
+        {CHANNELS.map((meta) => (
+          <ChannelCard
+            key={meta.value}
+            meta={meta}
+            onSelect={handleSelect}
+            selected={!loading && channel === meta.value}
+          />
+        ))}
+      </div>
+
+      {pendingRestart && (
+        <p className="mt-3 text-xs text-muted-foreground">
+          Restart oh-my-query to start receiving updates from the new channel.
+        </p>
+      )}
+
+      <div className="mt-8 flex flex-col gap-3 border-t border-foreground/10 pt-6">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold">Check for updates</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              We don&apos;t auto-check on launch &mdash; click below when you
+              want.
+            </p>
+          </div>
+          <Button
+            disabled={
+              check.status === "checking" || check.status === "installing"
+            }
+            onClick={checkNow}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {check.status === "checking" ? (
+              <>
+                <Loader2 className="size-3.5 animate-spin" />
+                Checking
+              </>
+            ) : (
+              <>
+                <RefreshCw className="size-3.5" />
+                Check now
+              </>
+            )}
+          </Button>
+        </div>
+
+        {check.status === "no-update" && (
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <CheckCircle2 className="size-3.5 text-primary" />
+            You&apos;re up to date &middot; checked{" "}
+            {formatRelative(check.checkedAt)}
+          </p>
+        )}
+
+        {check.status === "available" && (
+          <div className="flex items-center justify-between gap-3 rounded-md border border-primary/30 bg-primary/5 p-3">
+            <div className="min-w-0">
+              <p className="text-sm font-medium">
+                Update available &middot; v{check.update.version}
+              </p>
+              {check.update.notes && (
+                <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                  {check.update.notes}
+                </p>
+              )}
+            </div>
+            <Button onClick={installNow} size="sm" type="button">
+              <Download className="size-3.5" />
+              Install &amp; restart
+            </Button>
+          </div>
+        )}
+
+        {check.status === "installing" && (
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Loader2 className="size-3.5 animate-spin" />
+            Downloading and installing&hellip;
+          </p>
+        )}
+
+        {check.status === "installed" && (
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <CheckCircle2 className="size-3.5 text-primary" />
+            Update installed. Relaunch to apply.
+          </p>
+        )}
+
+        {check.status === "error" && (
+          <p className="text-xs text-destructive">
+            Couldn&apos;t check for updates: {check.message}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+};

--- a/apps/web/src/routes/_default/-hooks/use-settings-hotkeys.ts
+++ b/apps/web/src/routes/_default/-hooks/use-settings-hotkeys.ts
@@ -14,6 +14,7 @@ const [
   SYNTAX_THEME_SECTION,
   CODE_FONT_SECTION,
   EXPORT_SECTION,
+  UPDATES_SECTION,
 ] = SETTINGS_SECTIONS;
 
 export const useSettingsHotkeys = ({
@@ -42,5 +43,9 @@ export const useSettingsHotkeys = ({
 
   useHotkey("Mod+4", () => {
     onSelectSection(EXPORT_SECTION.id);
+  });
+
+  useHotkey("Mod+5", () => {
+    onSelectSection(UPDATES_SECTION.id);
   });
 };

--- a/apps/web/src/routes/_default/-hooks/use-update-channel.test.ts
+++ b/apps/web/src/routes/_default/-hooks/use-update-channel.test.ts
@@ -1,0 +1,103 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { mockTauri } from "@/test/tauri-mock";
+
+import type { CheckState } from "./use-update-channel";
+
+import { useUpdateChannel } from "./use-update-channel";
+
+const enableTauri = () => {
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    value: {},
+    writable: true,
+  });
+};
+
+const availableVersion = (state: CheckState): string | null =>
+  state.status === "available" ? state.update.version : null;
+
+describe("useUpdateChannel (web)", () => {
+  it("reports unsupported when not in Tauri", async () => {
+    const { result } = renderHook(() => useUpdateChannel());
+    await waitFor(() => expect(result.current.loading).toBeFalsy());
+    expect(result.current.supported).toBeFalsy();
+  });
+});
+
+describe("useUpdateChannel (tauri)", () => {
+  it("loads the persisted channel on mount", async () => {
+    enableTauri();
+    mockTauri({
+      get_update_channel: () => "beta",
+    });
+
+    const { result } = renderHook(() => useUpdateChannel());
+    await waitFor(() => expect(result.current.loading).toBeFalsy());
+    expect(result.current.channel).toBe("beta");
+    expect(result.current.pendingRestart).toBeFalsy();
+  });
+
+  it("writes a new channel and flips pendingRestart", async () => {
+    enableTauri();
+    let stored = "stable";
+    mockTauri({
+      get_update_channel: () => stored,
+      set_update_channel: (payload) => {
+        stored = payload.channel as string;
+        return stored;
+      },
+    });
+
+    const { result } = renderHook(() => useUpdateChannel());
+    await waitFor(() => expect(result.current.loading).toBeFalsy());
+
+    await act(async () => {
+      await result.current.setChannel("beta");
+    });
+
+    expect(result.current.channel).toBe("beta");
+    expect(result.current.pendingRestart).toBeTruthy();
+  });
+
+  it("checkNow surfaces no-update when the backend returns null", async () => {
+    enableTauri();
+    mockTauri({
+      check_for_update: () => null,
+      get_update_channel: () => "stable",
+    });
+
+    const { result } = renderHook(() => useUpdateChannel());
+    await waitFor(() => expect(result.current.loading).toBeFalsy());
+
+    await act(async () => {
+      await result.current.checkNow();
+    });
+
+    expect(result.current.check.status).toBe("no-update");
+  });
+
+  it("checkNow surfaces an available update", async () => {
+    enableTauri();
+    mockTauri({
+      check_for_update: () => ({
+        currentVersion: "0.0.10",
+        date: null,
+        notes: "fixes",
+        version: "0.0.11",
+      }),
+      get_update_channel: () => "stable",
+    });
+
+    const { result } = renderHook(() => useUpdateChannel());
+    await waitFor(() => expect(result.current.loading).toBeFalsy());
+
+    await act(async () => {
+      await result.current.checkNow();
+    });
+
+    expect(result.current.check.status).toBe("available");
+    expect(availableVersion(result.current.check)).toBe("0.0.11");
+  });
+});

--- a/apps/web/src/routes/_default/-hooks/use-update-channel.ts
+++ b/apps/web/src/routes/_default/-hooks/use-update-channel.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { isTauri } from "@/lib/tauri";
+
+export type UpdateChannel = "stable" | "beta" | "nightly";
+
+export const UPDATE_CHANNELS: UpdateChannel[] = ["stable", "beta", "nightly"];
+
+export interface AvailableUpdate {
+  version: string;
+  currentVersion: string;
+  notes: string | null;
+  date: string | null;
+}
+
+export type CheckState =
+  | { status: "idle" }
+  | { status: "checking" }
+  | { status: "no-update"; checkedAt: number }
+  | { status: "available"; update: AvailableUpdate; checkedAt: number }
+  | { status: "installing" }
+  | { status: "installed" }
+  | { status: "error"; message: string };
+
+const isUpdateChannel = (value: string): value is UpdateChannel =>
+  (UPDATE_CHANNELS as string[]).includes(value);
+
+const getInvoke = async () => {
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke;
+};
+
+export const useUpdateChannel = () => {
+  const [channel, setChannelState] = useState<UpdateChannel>("stable");
+  const [pendingRestart, setPendingRestart] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [check, setCheck] = useState<CheckState>({ status: "idle" });
+
+  useEffect(() => {
+    if (!isTauri()) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const invoke = await getInvoke();
+        const value = await invoke<string>("get_update_channel");
+        if (!cancelled && isUpdateChannel(value)) {
+          setChannelState(value);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setChannel = useCallback(
+    async (next: UpdateChannel) => {
+      if (!isTauri() || next === channel) {
+        return;
+      }
+      const invoke = await getInvoke();
+      const written = await invoke<string>("set_update_channel", {
+        channel: next,
+      });
+      if (isUpdateChannel(written)) {
+        setChannelState(written);
+        setPendingRestart(true);
+        setCheck({ status: "idle" });
+      }
+    },
+    [channel]
+  );
+
+  const checkNow = useCallback(async () => {
+    if (!isTauri()) {
+      return;
+    }
+    setCheck({ status: "checking" });
+    try {
+      const invoke = await getInvoke();
+      const update = await invoke<AvailableUpdate | null>("check_for_update");
+      if (update) {
+        setCheck({
+          checkedAt: Date.now(),
+          status: "available",
+          update,
+        });
+      } else {
+        setCheck({ checkedAt: Date.now(), status: "no-update" });
+      }
+    } catch (error) {
+      setCheck({
+        message: error instanceof Error ? error.message : String(error),
+        status: "error",
+      });
+    }
+  }, []);
+
+  const installNow = useCallback(async () => {
+    if (!isTauri()) {
+      return;
+    }
+    setCheck({ status: "installing" });
+    try {
+      const invoke = await getInvoke();
+      const installed = await invoke<boolean>("install_update");
+      setCheck(
+        installed
+          ? { status: "installed" }
+          : { checkedAt: Date.now(), status: "no-update" }
+      );
+    } catch (error) {
+      setCheck({
+        message: error instanceof Error ? error.message : String(error),
+        status: "error",
+      });
+    }
+  }, []);
+
+  return {
+    channel,
+    channels: UPDATE_CHANNELS,
+    check,
+    checkNow,
+    installNow,
+    loading,
+    pendingRestart,
+    setChannel,
+    supported: isTauri(),
+  };
+};

--- a/apps/web/src/routes/_default/settings.tsx
+++ b/apps/web/src/routes/_default/settings.tsx
@@ -15,6 +15,7 @@ import { SettingsFeedbackProvider } from "./-components/settings-feedback-contex
 import { SettingsSidebar } from "./-components/settings-sidebar";
 import { SettingsTitlebar } from "./-components/settings-titlebar";
 import { SyntaxThemeSection } from "./-components/syntax-theme-section";
+import { UpdateChannelSection } from "./-components/update-channel-section";
 import { useSettingsHotkeys } from "./-hooks/use-settings-hotkeys";
 
 const SectionPanel = ({ section }: { section: SettingsSectionId }) => {
@@ -26,6 +27,9 @@ const SectionPanel = ({ section }: { section: SettingsSectionId }) => {
   }
   if (section === "code-font") {
     return <EditorFontSection />;
+  }
+  if (section === "updates") {
+    return <UpdateChannelSection />;
   }
   return <ExportSettingsSection />;
 };

--- a/bun.lock
+++ b/bun.lock
@@ -50,6 +50,7 @@
         "@tanstack/react-virtual": "^3.13.24",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-updater": "^2",
         "@uiw/codemirror-theme-github": "^4.25.4",
         "@uiw/codemirror-themes-all": "^4.25.5",
         "@uiw/react-codemirror": "^4.25.4",
@@ -846,6 +847,8 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.10.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NTpyQxkpzGmU6ceWBTY2xRIEaS0ZLbVx1HE1zTA3TY/pV3+cPoPPOs+7YScr4IMzXMtOw7tLw5LEXo5oIG3qaQ=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/docs/threat-model-updates.md
+++ b/docs/threat-model-updates.md
@@ -1,0 +1,48 @@
+# Threat Model — Auto-update path
+
+This document covers the trust model for oh-my-query's in-app updater. It complements [`SECURITY.md`](../SECURITY.md) and [`RELEASING.md`](../RELEASING.md).
+
+## Asset under protection
+
+The user's machine. The updater downloads code that the OS will execute with the user's privileges, so any compromise here is a remote-code-execution path.
+
+## Trust anchors
+
+Two pieces of secret state are load-bearing. Compromise of either invalidates the model.
+
+1. **Tauri updater public key** — embedded in the binary at build time (`tauri.conf.json` → `plugins.updater.pubkey`). Verifies that every downloaded archive was signed by the matching private key.
+2. **HTTPS to `github.com`** — the appcast (`latest.json`) is fetched over TLS. We rely on the OS trust store to bind the channel URL to the right server.
+
+We deliberately do _not_ rely on:
+
+- The integrity of the GitHub Release body.
+- Code-signing certificates on macOS / Windows for update verification (those are for OS gatekeeper UX, not for telling the updater whether the bytes are trustworthy).
+
+## Threats considered
+
+| #   | Threat                                       | Mitigation                                                                                                                                                                                                | Residual risk                                                                                  |
+| --- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 1   | Tampered archive in transit / at rest        | Tauri verifies the `minisign` signature against the embedded pubkey before installing. Mismatch aborts the install.                                                                                       | None as long as the private key is uncompromised.                                              |
+| 2   | Malicious `latest.json` (URL points at evil) | The signature in step 1 is computed over the binary, not the JSON. Even a fully attacker-controlled `latest.json` cannot get evil bytes installed unless it points at a binary signed by our private key. | Attacker can withhold updates (DoS) or downgrade — see #3.                                     |
+| 3   | Downgrade attack (older signed version)      | Tauri compares versions and only installs newer ones than the running build.                                                                                                                              | An attacker who controls the appcast cannot push 0.1.0 to a 0.2.0 user, but can withhold news. |
+| 4   | Channel-confusion (beta user fed stable URL) | Channel preference is stored locally and resolved at runtime in `update_channel.rs` → builds the per-channel URL each time. The endpoint never comes from the network.                                    | None.                                                                                          |
+| 5   | Updater private-key compromise               | See "Key rotation" in `RELEASING.md`. Bridging release signs with old key + embeds new pubkey, then a clean release signs with new key.                                                                   | Window between detection and rotation. Mitigate with hardware token + access auditing.         |
+| 6   | MITM on appcast fetch                        | TLS to `github.com`. Pinned by the OS trust store.                                                                                                                                                        | Trust-store compromise (out of scope).                                                         |
+| 7   | Repo / release compromise                    | Attacker gains write to the repo and to GH Secrets → can push a real signed malicious release. Detection: branch protection + protected tags + secret-scanning.                                           | Catastrophic but contained: only one release window. Rotate the key and ship a clean version.  |
+| 8   | Supply-chain on `tauri-plugin-updater` crate | We pin a major version; Rust dep audit runs in CI (`cargo deny`/`cargo audit` — _follow-up_).                                                                                                             | Same as any Rust dep — typical supply-chain risk.                                              |
+| 9   | User running an old, unpatched build         | The "Check for updates" button in Settings is the user-driven escape hatch. Future: optional auto-check on launch, gated by a setting.                                                                    | User who never opens Settings can stay on a vulnerable version indefinitely.                   |
+
+## Out of scope
+
+- Local privilege escalation _after_ the update has been installed (an OS problem).
+- Side-channel attacks on the signing machine (use a hardware-backed key).
+- Telemetry / phone-home — there is none.
+
+## Operational invariants (reviewer checklist)
+
+When changing anything in the updater path, confirm:
+
+- [ ] `pubkey` in `tauri.conf.json` is non-empty in CI builds (the workflow fails the build if `TAURI_SIGNING_PRIVATE_KEY` is missing — the matching pubkey is what proves we used it).
+- [ ] The appcast URL is built from the locally-stored channel value, never from a server-supplied value.
+- [ ] No code path bypasses `Update::download_and_install` — that's where signature verification happens.
+- [ ] `latest.json` references binaries on the same release tag they were built for (the workflow constructs URLs from the resolved channel + version).


### PR DESCRIPTION
## Summary
- Wires `tauri-plugin-updater` and exposes channel-aware Rust commands (`get/set_update_channel`, `check_for_update`, `install_update`) backed by a small `~/.config/oh-my-query/update-channel.txt` store.
- Adds a Settings → **Updates** panel with stable / beta / nightly cards (nightly disabled), a check-for-updates button, and a restart prompt when the channel changes.
- Refactors `release.yml` into a channel-aware pipeline: tag pattern (`v*.*.*` vs `v*.*.*-beta.*`) selects the channel, macOS notarization runs through tauri-action's env, Windows signing is gated on `vars.WINDOWS_SIGNING_ENABLED`, and a new `publish-appcast` job uploads `latest.json` to a rolling `updater-<channel>` tag.
- Ships `SECURITY.md`, `RELEASING.md`, and `docs/threat-model-updates.md` so key custody, rotation, and the update-path threat model are documented before keys are cut.

Closes OMQ-20 / #106. Nightly channel is intentionally deferred — UI surfaces it disabled, no nightly workflow yet.

## Test plan
- [x] `bun run check-types`
- [x] `bun run check`
- [x] `bun run --cwd apps/web test` (538 passed, including 10 new tests for the hook + section)
- [x] `cargo test --lib update_channel` (5/5 passing)
- [ ] Maintainer follow-up: generate Tauri keypair, paste pubkey into `tauri.conf.json`, add signing secrets per `RELEASING.md` before the next tagged release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds signed auto-update with stable and beta channels for the desktop app, plus a new Settings → Updates panel to switch channels and check/install updates. Implements a channel-aware release workflow that publishes per-channel appcast feeds and documents key custody and rotation (OMQ-20).

- **New Features**
  - Signed auto-update via `tauri-plugin-updater`/`@tauri-apps/plugin-updater`, with per-channel feeds (`updater-stable`, `updater-beta`).
  - Settings → Updates: choose Stable/Beta (Nightly shown but disabled), check for updates, and install & restart; adds Mod+5 hotkey.
  - Release pipeline: tag-driven channels (`vX.Y.Z` vs `vX.Y.Z-beta.N`), macOS signing/notarization, optional Windows signing (gated by `WINDOWS_SIGNING_ENABLED`), prerelease for beta, publishes `latest.json` to rolling `updater-<channel>` tag; Homebrew tap updates only on stable.
  - Adds `SECURITY.md`, `RELEASING.md`, and `docs/threat-model-updates.md`.

- **Migration**
  - Generate a Tauri updater keypair and set `plugins.updater.pubkey` in `apps/web/src-tauri/tauri.conf.json`.
  - Add GitHub Actions secrets: `TAURI_SIGNING_PRIVATE_KEY`, `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`, Apple notarization creds, and optional Windows cert secrets; set repo var `WINDOWS_SIGNING_ENABLED=true` when ready.

<sup>Written for commit 00a9475dff58fc6d12f073dedadbf221b2cafd4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

