### PR TITLE
style(ui): thin native scrollbars globally

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -205,7 +205,7 @@
   }
   * {
     scrollbar-width: thin;
-    scrollbar-color: gray transparent;
+    scrollbar-color: var(--muted-foreground) transparent;
   }
   img,
   svg {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -203,6 +203,10 @@
     -webkit-tap-highlight-color: transparent;
     overscroll-behavior: none;
   }
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: gray transparent;
+  }
   img,
   svg {
     -webkit-user-drag: none;


### PR DESCRIPTION
## Summary
- Adds a global `scrollbar-width: thin` + `scrollbar-color: gray transparent` rule in `apps/web/src/index.css` so plain `overflow-auto` containers render with a slim, unobtrusive scrollbar instead of the chunky OS default.
- The custom `<ScrollArea>` overlay (Base UI) and `.no-scrollbar` utility are unaffected — only native scrollbars pick up the new treatment.

## Test plan
- [ ] Resize the home/connections list and confirm the native scrollbar is thin with a grey thumb on a transparent track.
- [ ] Open a long results table and confirm the scrollbar is thin.
- [ ] Confirm the schema sidebar `<ScrollArea>` still uses its custom thumb (`bg-border`) and the ⌘K palette has no scrollbar.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies global thin native scrollbars using `scrollbar-width: thin` and `scrollbar-color: var(--muted-foreground) transparent` so default overflow containers use a slimmer, less obtrusive native scrollbar. Custom `ScrollArea` overlays and the `.no-scrollbar` utility are unaffected.

<sup>Written for commit 7353b2089f81dfef51d5a5a7e250dd67136a1b77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

