### PR TITLE
fix(menu): correct macOS menu roles + perf(schema): bulk PG queries

### DIFF
--- a/apps/app/src/bun/index.ts
+++ b/apps/app/src/bun/index.ts
@@ -4,6 +4,12 @@ import { APPLICATION_MENU } from "./menu.ts";
 import { createRpc } from "./rpc.ts";
 import { windowOptions } from "./window.ts";
 
+interface MenuClickedData {
+  id?: number;
+  action: string;
+  data?: unknown;
+}
+
 function main(): void {
   let mainWindow: BrowserWindow | null = null;
   const rpc = createRpc({ getMainWindow: () => mainWindow });
@@ -15,8 +21,8 @@ function main(): void {
   ApplicationMenu.setApplicationMenu(APPLICATION_MENU);
 
   ApplicationMenu.on("application-menu-clicked", (event: unknown) => {
-    const { action } = event as { action?: string };
-    if (action === "settings") {
+    const { data } = event as { data?: MenuClickedData };
+    if (data?.action === "settings") {
       rpc.send.menuNavigate({ route: "/settings" });
     }
   });

--- a/apps/app/src/bun/menu.ts
+++ b/apps/app/src/bun/menu.ts
@@ -4,15 +4,11 @@ export const APPLICATION_MENU: ApplicationMenuItemConfig[] = [
   {
     label: "oh-my-query",
     submenu: [
-      { role: "about" },
-      { type: "separator" },
       { accelerator: "CmdOrCtrl+,", action: "settings", label: "Settings…" },
-      { type: "separator" },
-      { role: "services" },
       { type: "separator" },
       { role: "hide" },
       { role: "hideOthers" },
-      { role: "unhide" },
+      { role: "showAll" },
       { type: "separator" },
       { role: "quit" },
     ],
@@ -31,7 +27,7 @@ export const APPLICATION_MENU: ApplicationMenuItemConfig[] = [
   },
   {
     label: "View",
-    submenu: [{ role: "togglefullscreen" }],
+    submenu: [{ role: "toggleFullScreen" }],
   },
   {
     label: "Window",

--- a/apps/app/src/bun/rpc.ts
+++ b/apps/app/src/bun/rpc.ts
@@ -1,3 +1,4 @@
+import type { SchemaInfo } from "@oh-my-query/core";
 import type { RpcSchema } from "@oh-my-query/rpc";
 import type { BrowserWindow } from "electrobun/bun";
 
@@ -37,9 +38,21 @@ import {
 
 const DEFAULT_MAX_ROWS = 10_000;
 const DEFAULT_TIMEOUT_SECS = 30;
+const SCHEMA_CACHE_TTL_MS = 60_000;
 
 const pools = new ConnectionPoolManager();
 const cancellation = new CancellationRegistry();
+const schemaCache = new Map<string, { value: SchemaInfo; expiresAt: number }>();
+const schemaCacheKey = (connectionId: string, db: string): string =>
+  `${connectionId}::${db}`;
+const invalidateSchemaCacheFor = (connectionId: string): void => {
+  const prefix = `${connectionId}::`;
+  for (const key of schemaCache.keys()) {
+    if (key.startsWith(prefix)) {
+      schemaCache.delete(key);
+    }
+  }
+};
 
 interface AppRpcSchema {
   bun: RpcSchema;
@@ -133,6 +146,7 @@ export function createRpc(options: CreateRpcOptions = noWindow) {
           doDeleteRedisKey(requireRedis(connectionId), dbIndex, name),
 
         disconnectFromDatabase: async ({ connectionId }) => {
+          invalidateSchemaCacheFor(connectionId);
           await pools.disconnect(connectionId);
         },
 
@@ -221,8 +235,23 @@ export function createRpc(options: CreateRpcOptions = noWindow) {
         getHistory: ({ connectionId, limit, offset }) =>
           getHistory(connectionId, limit ?? null, offset ?? null),
 
-        getSchema: ({ connectionId, databaseName }) =>
-          pools.getPool(connectionId).fetchSchema(databaseName),
+        getSchema: async ({ connectionId, databaseName, force }) => {
+          const key = schemaCacheKey(connectionId, databaseName);
+          if (!force) {
+            const hit = schemaCache.get(key);
+            if (hit && hit.expiresAt > Date.now()) {
+              return hit.value;
+            }
+          }
+          const value = await pools
+            .getPool(connectionId)
+            .fetchSchema(databaseName);
+          schemaCache.set(key, {
+            expiresAt: Date.now() + SCHEMA_CACHE_TTL_MS,
+            value,
+          });
+          return value;
+        },
         getServerVersion: ({ connectionId }) =>
           pools.getPool(connectionId).fetchVersion(),
         getTabs: ({ connectionId }) => getTabs(connectionId),

--- a/apps/app/src/bun/rpc.ts
+++ b/apps/app/src/bun/rpc.ts
@@ -139,6 +139,7 @@ export function createRpc(options: CreateRpcOptions = noWindow) {
         checkForUpdate: () => doCheckForUpdate(),
 
         connectToDatabase: async ({ connectionId, params }) => {
+          invalidateSchemaCacheFor(connectionId);
           await pools.connect(connectionId, params);
         },
 

--- a/apps/app/src/mainview/components/titlebar/titlebar.tsx
+++ b/apps/app/src/mainview/components/titlebar/titlebar.tsx
@@ -10,13 +10,8 @@ interface TitlebarProps {
   className?: string;
 }
 
-export const TRAFFIC_LIGHT_INSET = "78px";
+export const TRAFFIC_LIGHT_INSET = "0px";
 export const TITLEBAR_CONTROL_HEIGHT = "h-6";
-
-// Electrobun marks draggable window regions via two well-known class names
-// rather than the inline `-webkit-app-region` style — see
-// node_modules/electrobun/.../api/bun/preload/dragRegions.ts. Class selectors
-// are unambiguous, unlike `[style*="drag"]` which would also match `no-drag`.
 const DRAG = "electrobun-webkit-app-region-drag";
 const NO_DRAG = "electrobun-webkit-app-region-no-drag";
 

--- a/apps/app/src/mainview/lib/ipc.ts
+++ b/apps/app/src/mainview/lib/ipc.ts
@@ -345,9 +345,16 @@ export const listDatabases = (connectionId: string): Promise<string[]> =>
 
 export const getSchema = (
   connectionId: string,
-  databaseName: string
+  databaseName: string,
+  options?: { force?: boolean }
 ): Promise<SchemaInfo> =>
-  callRpc(() => request.getSchema({ connectionId, databaseName }));
+  callRpc(() =>
+    request.getSchema({
+      connectionId,
+      databaseName,
+      force: options?.force ?? false,
+    })
+  );
 
 export const executeQuery = (params: QueryParams): Promise<ExecuteResult> =>
   callRpc(() => request.executeQuery({ params }));

--- a/apps/app/src/mainview/stores/schema-store.ts
+++ b/apps/app/src/mainview/stores/schema-store.ts
@@ -79,12 +79,18 @@ export const useSchemaStore = create<SchemaStore>((set, get) => {
     }
   };
 
-  const fetchSchema = async (connectionId: string, databaseName: string) => {
+  const fetchSchema = async (
+    connectionId: string,
+    databaseName: string,
+    options?: { force?: boolean }
+  ) => {
     const startIdentityKey =
       get().byConnection[connectionId]?.identityKey ?? null;
     patch(connectionId, { error: null, isLoading: true });
     try {
-      const schema = await getSchema(connectionId, databaseName);
+      const schema = await getSchema(connectionId, databaseName, {
+        force: options?.force ?? false,
+      });
       if (isStale(connectionId, startIdentityKey)) {
         return;
       }
@@ -159,7 +165,7 @@ export const useSchemaStore = create<SchemaStore>((set, get) => {
       if (!database) {
         return;
       }
-      await fetchSchema(connectionId, database);
+      await fetchSchema(connectionId, database, { force: true });
     },
 
     setSelectedDatabase: (connectionId, database) => {

--- a/bun.lock
+++ b/bun.lock
@@ -220,6 +220,7 @@
         "@oh-my-query/config": "workspace:*",
         "@types/pg": "^8.11.10",
         "@typescript/native-preview": "catalog:",
+        "vitest": "^3.2.4",
       },
     },
     "packages/drivers-redis": {

--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,7 @@
       "devDependencies": {
         "@oh-my-query/config": "workspace:*",
         "@typescript/native-preview": "catalog:",
+        "vitest": "^3.2.4",
       },
     },
     "packages/drivers-duckdb": {

--- a/packages/drivers-clickhouse/package.json
+++ b/packages/drivers-clickhouse/package.json
@@ -6,12 +6,17 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "dependencies": {
     "@clickhouse/client": "^1.10.0",
     "@oh-my-query/core": "workspace:*"
   },
   "devDependencies": {
     "@oh-my-query/config": "workspace:*",
-    "@typescript/native-preview": "catalog:"
+    "@typescript/native-preview": "catalog:",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/drivers-clickhouse/src/driver.ts
+++ b/packages/drivers-clickhouse/src/driver.ts
@@ -1,0 +1,77 @@
+import type {
+  ConnectionParams,
+  Driver,
+  Pool,
+  TestConnectionResult,
+} from "@oh-my-query/core";
+
+import { createClient } from "@clickhouse/client";
+
+import { ClickhousePool, mapClickhouseError } from "./pool.ts";
+
+const CONNECT_TIMEOUT_MS = 10_000;
+
+function buildClickhouseUrl(p: ConnectionParams): string {
+  return `http://${p.host}:${p.port}`;
+}
+
+export class ClickhouseDriver implements Driver {
+  readonly dbType = "clickhouse";
+
+  async testConnection(
+    params: ConnectionParams
+  ): Promise<TestConnectionResult> {
+    const start = performance.now();
+    const client = createClient({
+      database: params.database,
+      password: params.password,
+      request_timeout: CONNECT_TIMEOUT_MS,
+      url: buildClickhouseUrl(params),
+      username: params.username,
+    });
+    try {
+      const result = await client.ping({ select: true });
+      if (!result.success) {
+        throw mapClickhouseError(result.error);
+      }
+      return {
+        latencyMs: Math.round(performance.now() - start),
+        message: `${this.dbType} connection successful`,
+        success: true,
+      };
+    } catch (error) {
+      throw mapClickhouseError(error);
+    } finally {
+      try {
+        await client.close();
+      } catch {
+        // best-effort
+      }
+    }
+  }
+
+  async connect(_id: string, params: ConnectionParams): Promise<Pool> {
+    const client = createClient({
+      application: this.dbType,
+      database: params.database,
+      password: params.password,
+      request_timeout: CONNECT_TIMEOUT_MS,
+      url: buildClickhouseUrl(params),
+      username: params.username,
+    });
+    try {
+      const result = await client.ping({ select: true });
+      if (!result.success) {
+        throw mapClickhouseError(result.error);
+      }
+    } catch (error) {
+      try {
+        await client.close();
+      } catch {
+        // best-effort
+      }
+      throw mapClickhouseError(error);
+    }
+    return new ClickhousePool(client);
+  }
+}

--- a/packages/drivers-clickhouse/src/driver.ts
+++ b/packages/drivers-clickhouse/src/driver.ts
@@ -11,8 +11,15 @@ import { ClickhousePool, mapClickhouseError } from "./pool.ts";
 
 const CONNECT_TIMEOUT_MS = 10_000;
 
+function bracketIfIPv6(host: string): string {
+  if (host.startsWith("[") || !host.includes(":")) {
+    return host;
+  }
+  return `[${host}]`;
+}
+
 function buildClickhouseUrl(p: ConnectionParams): string {
-  return `http://${p.host}:${p.port}`;
+  return `http://${bracketIfIPv6(p.host)}:${p.port}`;
 }
 
 export class ClickhouseDriver implements Driver {
@@ -51,14 +58,15 @@ export class ClickhouseDriver implements Driver {
   }
 
   async connect(_id: string, params: ConnectionParams): Promise<Pool> {
-    const client = createClient({
+    const url = buildClickhouseUrl(params);
+    const baseConfig = {
       application: this.dbType,
-      database: params.database,
       password: params.password,
       request_timeout: CONNECT_TIMEOUT_MS,
-      url: buildClickhouseUrl(params),
+      url,
       username: params.username,
-    });
+    };
+    const client = createClient({ ...baseConfig, database: params.database });
     try {
       const result = await client.ping({ select: true });
       if (!result.success) {
@@ -72,6 +80,10 @@ export class ClickhouseDriver implements Driver {
       }
       throw mapClickhouseError(error);
     }
-    return new ClickhousePool(client);
+    return new ClickhousePool({
+      clientFor: (database) => createClient({ ...baseConfig, database }),
+      defaultClient: client,
+      defaultDatabase: params.database,
+    });
   }
 }

--- a/packages/drivers-clickhouse/src/index.ts
+++ b/packages/drivers-clickhouse/src/index.ts
@@ -1,27 +1,2 @@
-import type {
-  ConnectionParams,
-  Driver,
-  Pool,
-  TestConnectionResult,
-} from "@oh-my-query/core";
-
-import { DbError } from "@oh-my-query/core";
-
-export class ClickhouseDriver implements Driver {
-  readonly dbType = "clickhouse";
-
-  testConnection(_params: ConnectionParams): Promise<TestConnectionResult> {
-    return Promise.reject(this.notImplemented());
-  }
-
-  connect(_id: string, _params: ConnectionParams): Promise<Pool> {
-    return Promise.reject(this.notImplemented());
-  }
-
-  private notImplemented(): DbError {
-    return new DbError(
-      "NOT_IMPLEMENTED",
-      `${this.dbType} driver port pending. Track progress in the Electrobun migration.`
-    );
-  }
-}
+export { ClickhouseDriver } from "./driver.ts";
+export { ClickhousePool, mapClickhouseError } from "./pool.ts";

--- a/packages/drivers-clickhouse/src/pool.test.ts
+++ b/packages/drivers-clickhouse/src/pool.test.ts
@@ -45,10 +45,21 @@ const must = <T>(value: T | undefined, label: string): T => {
   return value;
 };
 
+const buildPool = (
+  client: ClickHouseClient,
+  database = "default",
+  clientFor?: (db: string) => ClickHouseClient
+): ClickhousePool =>
+  new ClickhousePool({
+    clientFor,
+    defaultClient: client,
+    defaultDatabase: database,
+  });
+
 describe("clickhousePool.fetchSchema", () => {
   it("issues exactly three schema-wide queries", async () => {
     const { fakeClient, query } = buildClient({});
-    const pool = new ClickhousePool(fakeClient);
+    const pool = buildPool(fakeClient);
     const schema = await pool.fetchSchema("default");
     expect(query).toHaveBeenCalledTimes(3);
     expect(schema.schemas).toStrictEqual([
@@ -64,7 +75,7 @@ describe("clickhousePool.fetchSchema", () => {
         { engine: "MaterializedView", name: "events_mv", total_rows: null },
       ],
     });
-    const pool = new ClickhousePool(fakeClient);
+    const pool = buildPool(fakeClient);
     const result = await pool.fetchSchema("default");
     const schema = must(result.schemas[0], "schemas[0]");
     expect(schema.tables.map((t) => t.name)).toStrictEqual(["events"]);
@@ -96,7 +107,7 @@ describe("clickhousePool.fetchSchema", () => {
       ],
       tables: [{ engine: "MergeTree", name: "events", total_rows: "0" }],
     });
-    const pool = new ClickhousePool(fakeClient);
+    const pool = buildPool(fakeClient);
     const result = await pool.fetchSchema("default");
     const schema = must(result.schemas[0], "schemas[0]");
     const table = must(schema.tables[0], "tables[0]");
@@ -130,7 +141,7 @@ describe("clickhousePool.fetchSchema", () => {
       ],
       tables: [{ engine: "MergeTree", name: "events", total_rows: "0" }],
     });
-    const pool = new ClickhousePool(fakeClient);
+    const pool = buildPool(fakeClient);
     const result = await pool.fetchSchema("default");
     const schema = must(result.schemas[0], "schemas[0]");
     const table = must(schema.tables[0], "tables[0]");
@@ -156,7 +167,7 @@ describe("clickhousePool.fetchSchema", () => {
       ],
       tables: [{ engine: "View", name: "live_events", total_rows: null }],
     });
-    const pool = new ClickhousePool(fakeClient);
+    const pool = buildPool(fakeClient);
     const result = await pool.fetchSchema("default");
     const schema = must(result.schemas[0], "schemas[0]");
     expect(schema.tables).toStrictEqual([]);
@@ -177,7 +188,7 @@ describe("clickhousePool.fetchSchema", () => {
 
   it("returns an empty schema when no relations exist", async () => {
     const { fakeClient } = buildClient({});
-    const pool = new ClickhousePool(fakeClient);
+    const pool = buildPool(fakeClient);
     const result = await pool.fetchSchema("default");
     expect(result).toStrictEqual({
       schemas: [{ name: "default", tables: [], views: [] }],
@@ -188,16 +199,85 @@ describe("clickhousePool.fetchSchema", () => {
     const failure = new Error("network down");
     const query = vi.fn().mockRejectedValue(failure);
     const fakeClient = { query } as unknown as ClickHouseClient;
-    const pool = new ClickhousePool(fakeClient);
+    const pool = buildPool(fakeClient);
     await expect(pool.fetchSchema("default")).rejects.toBeInstanceOf(DbError);
   });
 
   it("rejects invalid database names without issuing queries", async () => {
     const { fakeClient, query } = buildClient({});
-    const pool = new ClickhousePool(fakeClient);
+    const pool = buildPool(fakeClient);
     await expect(pool.fetchSchema('"; DROP DATABASE x; --')).rejects.toThrow(
       /schema/i
     );
     expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe("clickhousePool.execute", () => {
+  const buildExecuteClient = (rows: unknown[][]) => {
+    const json = vi
+      // eslint-disable-next-line @typescript-eslint/require-await
+      .fn(async () => ({
+        data: rows,
+        meta: [{ name: "id", type: "UInt64" }],
+        rows: rows.length,
+      }));
+    const query = vi
+      // eslint-disable-next-line @typescript-eslint/require-await
+      .fn(async () => ({ json }));
+    const close = vi.fn(async () => {
+      await Promise.resolve();
+    });
+    const client = { close, query } as unknown as ClickHouseClient;
+    return { client, close, json, query };
+  };
+
+  it("uses the default client when schema matches the default database", async () => {
+    const { client, query } = buildExecuteClient([[1]]);
+    const factory = vi.fn();
+    const pool = buildPool(client, "analytics", factory as never);
+    const result = await pool.execute(
+      "SELECT 1",
+      100,
+      "analytics",
+      new AbortController().signal
+    );
+    expect(result.resultType).toBe("tabular");
+    expect(query).toHaveBeenCalledOnce();
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("creates and reuses a per-database client when schema differs", async () => {
+    const { client: defaultClient } = buildExecuteClient([]);
+    const { client: otherClient, query: otherQuery } = buildExecuteClient([
+      [42],
+    ]);
+    const factory = vi.fn(() => otherClient);
+    const pool = buildPool(defaultClient, "analytics", factory as never);
+
+    await pool.execute("SELECT 1", 100, "logs", new AbortController().signal);
+    await pool.execute("SELECT 2", 100, "logs", new AbortController().signal);
+
+    expect(factory).toHaveBeenCalledOnce();
+    expect(factory).toHaveBeenCalledWith("logs");
+    expect(otherQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("close() shuts down both default and per-database clients", async () => {
+    const { client: defaultClient, close: defaultClose } = buildExecuteClient(
+      []
+    );
+    const { client: otherClient, close: otherClose } = buildExecuteClient([]);
+    const pool = buildPool(
+      defaultClient,
+      "analytics",
+      (() => otherClient) as never
+    );
+
+    await pool.execute("SELECT 1", 10, "logs", new AbortController().signal);
+    await pool.close();
+
+    expect(otherClose).toHaveBeenCalledOnce();
+    expect(defaultClose).toHaveBeenCalledOnce();
   });
 });

--- a/packages/drivers-clickhouse/src/pool.test.ts
+++ b/packages/drivers-clickhouse/src/pool.test.ts
@@ -1,0 +1,203 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+
+import { DbError } from "@oh-my-query/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { ClickhousePool } from "./pool.ts";
+
+interface QueryFixtures {
+  tables?: unknown[];
+  columns?: unknown[];
+  indices?: unknown[];
+}
+
+const dispatchQuery = (query: string, fixtures: QueryFixtures): unknown[] => {
+  if (query.includes("FROM system.tables")) {
+    return fixtures.tables ?? [];
+  }
+  if (query.includes("FROM system.columns")) {
+    return fixtures.columns ?? [];
+  }
+  if (query.includes("FROM system.data_skipping_indices")) {
+    return fixtures.indices ?? [];
+  }
+  throw new Error(`Unexpected query in dispatch: ${query}`);
+};
+
+const buildClient = (fixtures: QueryFixtures) => {
+  const query = vi
+    .fn<
+      (params: { query: string }) => Promise<{ json: () => Promise<unknown> }>
+    >()
+    // eslint-disable-next-line @typescript-eslint/require-await
+    .mockImplementation(async ({ query: q }) => ({
+      // eslint-disable-next-line @typescript-eslint/require-await
+      json: async () => ({ data: dispatchQuery(q, fixtures) }),
+    }));
+  const fakeClient = { query } as unknown as ClickHouseClient;
+  return { fakeClient, query };
+};
+
+const must = <T>(value: T | undefined, label: string): T => {
+  if (value === undefined) {
+    throw new Error(`expected ${label} to be defined`);
+  }
+  return value;
+};
+
+describe("clickhousePool.fetchSchema", () => {
+  it("issues exactly three schema-wide queries", async () => {
+    const { fakeClient, query } = buildClient({});
+    const pool = new ClickhousePool(fakeClient);
+    const schema = await pool.fetchSchema("default");
+    expect(query).toHaveBeenCalledTimes(3);
+    expect(schema.schemas).toStrictEqual([
+      { name: "default", tables: [], views: [] },
+    ]);
+  });
+
+  it("separates tables from views by engine and parses row estimates", async () => {
+    const { fakeClient } = buildClient({
+      tables: [
+        { engine: "MergeTree", name: "events", total_rows: "1234" },
+        { engine: "View", name: "events_view", total_rows: null },
+        { engine: "MaterializedView", name: "events_mv", total_rows: null },
+      ],
+    });
+    const pool = new ClickhousePool(fakeClient);
+    const result = await pool.fetchSchema("default");
+    const schema = must(result.schemas[0], "schemas[0]");
+    expect(schema.tables.map((t) => t.name)).toStrictEqual(["events"]);
+    expect(schema.views.map((v) => v.name)).toStrictEqual([
+      "events_view",
+      "events_mv",
+    ]);
+    const eventsTable = must(schema.tables[0], "tables[0]");
+    expect(eventsTable.rowEstimate).toBe(1234);
+  });
+
+  it("flags primary-key columns and unwraps Nullable types", async () => {
+    const { fakeClient } = buildClient({
+      columns: [
+        {
+          default_expression: "",
+          is_in_primary_key: 1,
+          name: "id",
+          table: "events",
+          type: "UInt64",
+        },
+        {
+          default_expression: "",
+          is_in_primary_key: 0,
+          name: "payload",
+          table: "events",
+          type: "Nullable(String)",
+        },
+      ],
+      tables: [{ engine: "MergeTree", name: "events", total_rows: "0" }],
+    });
+    const pool = new ClickhousePool(fakeClient);
+    const result = await pool.fetchSchema("default");
+    const schema = must(result.schemas[0], "schemas[0]");
+    const table = must(schema.tables[0], "tables[0]");
+    expect(table.columns).toStrictEqual([
+      {
+        dataType: "UInt64",
+        defaultValue: null,
+        isNullable: false,
+        isPrimaryKey: true,
+        name: "id",
+      },
+      {
+        dataType: "String",
+        defaultValue: null,
+        isNullable: true,
+        isPrimaryKey: false,
+        name: "payload",
+      },
+    ]);
+  });
+
+  it("attaches data-skipping indices to their tables", async () => {
+    const { fakeClient } = buildClient({
+      indices: [
+        {
+          expr: "user_id",
+          index_type: "minmax",
+          name: "events_user_idx",
+          table: "events",
+        },
+      ],
+      tables: [{ engine: "MergeTree", name: "events", total_rows: "0" }],
+    });
+    const pool = new ClickhousePool(fakeClient);
+    const result = await pool.fetchSchema("default");
+    const schema = must(result.schemas[0], "schemas[0]");
+    const table = must(schema.tables[0], "tables[0]");
+    expect(table.indexes).toStrictEqual([
+      {
+        columns: ["user_id"],
+        isUnique: false,
+        name: "events_user_idx",
+      },
+    ]);
+  });
+
+  it("populates view columns and leaves tables[] for views empty", async () => {
+    const { fakeClient } = buildClient({
+      columns: [
+        {
+          default_expression: "",
+          is_in_primary_key: 0,
+          name: "id",
+          table: "live_events",
+          type: "UInt64",
+        },
+      ],
+      tables: [{ engine: "View", name: "live_events", total_rows: null }],
+    });
+    const pool = new ClickhousePool(fakeClient);
+    const result = await pool.fetchSchema("default");
+    const schema = must(result.schemas[0], "schemas[0]");
+    expect(schema.tables).toStrictEqual([]);
+    const view = must(schema.views[0], "views[0]");
+    expect(view).toStrictEqual({
+      columns: [
+        {
+          dataType: "UInt64",
+          defaultValue: null,
+          isNullable: false,
+          isPrimaryKey: false,
+          name: "id",
+        },
+      ],
+      name: "live_events",
+    });
+  });
+
+  it("returns an empty schema when no relations exist", async () => {
+    const { fakeClient } = buildClient({});
+    const pool = new ClickhousePool(fakeClient);
+    const result = await pool.fetchSchema("default");
+    expect(result).toStrictEqual({
+      schemas: [{ name: "default", tables: [], views: [] }],
+    });
+  });
+
+  it("wraps client failures in DbError", async () => {
+    const failure = new Error("network down");
+    const query = vi.fn().mockRejectedValue(failure);
+    const fakeClient = { query } as unknown as ClickHouseClient;
+    const pool = new ClickhousePool(fakeClient);
+    await expect(pool.fetchSchema("default")).rejects.toBeInstanceOf(DbError);
+  });
+
+  it("rejects invalid database names without issuing queries", async () => {
+    const { fakeClient, query } = buildClient({});
+    const pool = new ClickhousePool(fakeClient);
+    await expect(pool.fetchSchema('"; DROP DATABASE x; --')).rejects.toThrow(
+      /schema/i
+    );
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/drivers-clickhouse/src/pool.ts
+++ b/packages/drivers-clickhouse/src/pool.ts
@@ -55,17 +55,41 @@ interface JsonCompactResult {
   rows: number;
 }
 
+export interface ClickhousePoolOptions {
+  defaultClient: ClickHouseClient;
+  defaultDatabase: string;
+  clientFor?: (database: string) => ClickHouseClient;
+}
+
 export class ClickhousePool implements Pool {
   readonly dialect: DialectType = "clickhouse";
   readonly supportsExplain = false;
   readonly #client: ClickHouseClient;
+  readonly #defaultDatabase: string;
+  readonly #clientFor: ((database: string) => ClickHouseClient) | null;
+  readonly #extras = new Map<string, ClickHouseClient>();
 
-  constructor(client: ClickHouseClient) {
-    this.#client = client;
+  constructor(options: ClickhousePoolOptions) {
+    this.#client = options.defaultClient;
+    this.#defaultDatabase = options.defaultDatabase;
+    this.#clientFor = options.clientFor ?? null;
   }
 
   get raw(): ClickHouseClient {
     return this.#client;
+  }
+
+  #clientForDatabase(database: string | null): ClickHouseClient {
+    if (!database || database === this.#defaultDatabase || !this.#clientFor) {
+      return this.#client;
+    }
+    const cached = this.#extras.get(database);
+    if (cached) {
+      return cached;
+    }
+    const fresh = this.#clientFor(database);
+    this.#extras.set(database, fresh);
+    return fresh;
   }
 
   async fetchVersion(): Promise<string> {
@@ -124,11 +148,9 @@ export class ClickhousePool implements Pool {
       throw DbError.cancelled();
     }
     try {
-      const rs = await this.#client.query({
+      const client = this.#clientForDatabase(schema);
+      const rs = await client.query({
         abort_signal: signal,
-        ...(schema
-          ? { clickhouse_settings: { database: schema } as never }
-          : {}),
         format: "JSONCompact",
         query: sql,
       });
@@ -167,11 +189,17 @@ export class ClickhousePool implements Pool {
   }
 
   async close(): Promise<void> {
-    try {
-      await this.#client.close();
-    } catch {
-      // best-effort close
-    }
+    const clients = [this.#client, ...this.#extras.values()];
+    this.#extras.clear();
+    await Promise.all(
+      clients.map(async (c) => {
+        try {
+          await c.close();
+        } catch {
+          // best-effort close
+        }
+      })
+    );
   }
 }
 

--- a/packages/drivers-clickhouse/src/pool.ts
+++ b/packages/drivers-clickhouse/src/pool.ts
@@ -1,0 +1,360 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+import type {
+  ColumnDetail,
+  ColumnInfo,
+  DialectType,
+  ExecuteResult,
+  ExplainResult,
+  ForeignKeyItem,
+  IndexItem,
+  Pool,
+  SchemaInfo,
+} from "@oh-my-query/core";
+
+import { DbError, validateSchemaName } from "@oh-my-query/core";
+
+const VIEW_ENGINES = new Set(["View", "MaterializedView", "LiveView"]);
+
+interface TableRow {
+  name: string;
+  engine: string;
+  total_rows: string | number | null;
+}
+
+interface ColumnRow {
+  table: string;
+  name: string;
+  type: string;
+  is_in_primary_key: number | string;
+  default_expression: string | null;
+}
+
+interface DataSkippingIndexRow {
+  table: string;
+  name: string;
+  index_type: string;
+  expr: string;
+}
+
+interface TableLike {
+  name: string;
+  columns: ColumnDetail[];
+  indexes: IndexItem[];
+  foreignKeys: ForeignKeyItem[];
+  rowEstimate: number | null;
+}
+
+interface ViewLike {
+  name: string;
+  columns: ColumnDetail[];
+}
+
+interface JsonCompactResult {
+  meta: { name: string; type: string }[];
+  data: unknown[][];
+  rows: number;
+}
+
+export class ClickhousePool implements Pool {
+  readonly dialect: DialectType = "clickhouse";
+  readonly supportsExplain = false;
+  readonly #client: ClickHouseClient;
+
+  constructor(client: ClickHouseClient) {
+    this.#client = client;
+  }
+
+  get raw(): ClickHouseClient {
+    return this.#client;
+  }
+
+  async fetchVersion(): Promise<string> {
+    try {
+      const rs = await this.#client.query({
+        format: "JSON",
+        query: "SELECT version() AS version",
+      });
+      const json = (await rs.json()) as { data?: { version?: string }[] };
+      const version = json.data?.[0]?.version ?? "";
+      return version ? `ClickHouse ${version}` : "ClickHouse";
+    } catch (error) {
+      throw mapClickhouseError(error);
+    }
+  }
+
+  async listDatabases(): Promise<string[]> {
+    try {
+      const rs = await this.#client.query({
+        format: "JSON",
+        query: `SELECT name FROM system.databases
+                WHERE name NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+                ORDER BY name`,
+      });
+      const json = (await rs.json()) as { data?: { name: string }[] };
+      return (json.data ?? []).map((row) => row.name);
+    } catch (error) {
+      throw mapClickhouseError(error);
+    }
+  }
+
+  async fetchSchema(database: string): Promise<SchemaInfo> {
+    validateSchemaName(database);
+    try {
+      const [tables, columns, indices] = await Promise.all([
+        fetchTables(this.#client, database),
+        fetchAllColumns(this.#client, database),
+        fetchAllDataSkippingIndices(this.#client, database),
+      ]);
+      const built = buildSchemaItem(tables, columns, indices);
+      return {
+        schemas: [{ name: database, tables: built.tables, views: built.views }],
+      };
+    } catch (error) {
+      throw mapClickhouseError(error);
+    }
+  }
+
+  async execute(
+    sql: string,
+    maxRows: number,
+    schema: string | null,
+    signal: AbortSignal
+  ): Promise<ExecuteResult> {
+    if (signal.aborted) {
+      throw DbError.cancelled();
+    }
+    try {
+      const rs = await this.#client.query({
+        abort_signal: signal,
+        ...(schema
+          ? { clickhouse_settings: { database: schema } as never }
+          : {}),
+        format: "JSONCompact",
+        query: sql,
+      });
+      const json = (await rs.json()) as JsonCompactResult;
+      const allRows = json.data ?? [];
+      const isTruncated = allRows.length > maxRows;
+      const rows = isTruncated ? allRows.slice(0, maxRows) : allRows;
+      const columns: ColumnInfo[] = (json.meta ?? []).map((m) => ({
+        name: m.name,
+        typeName: m.type,
+      }));
+      return {
+        columns,
+        executionTimeMs: 0,
+        isTruncated,
+        resultType: "tabular",
+        rowCount: rows.length,
+        rows: rows.map(jsonifyRow) as never,
+      };
+    } catch (error) {
+      throw mapClickhouseError(error);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async explain(
+    _sql: string,
+    _analyze: boolean,
+    _schema: string | null,
+    _signal: AbortSignal
+  ): Promise<ExplainResult> {
+    throw new DbError(
+      "NOT_IMPLEMENTED",
+      `EXPLAIN is not yet supported for ${this.dialect}`
+    );
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.#client.close();
+    } catch {
+      // best-effort close
+    }
+  }
+}
+
+function jsonifyRow(row: unknown[]): unknown[] {
+  return row.map(jsonifyValue);
+}
+
+function jsonifyValue(v: unknown): unknown {
+  if (v === null) {
+    return null;
+  }
+  if (v instanceof Date) {
+    return v.toISOString();
+  }
+  if (typeof v === "bigint") {
+    return v.toString();
+  }
+  if (Array.isArray(v)) {
+    return v.map(jsonifyValue);
+  }
+  if (typeof v === "object") {
+    const obj = v as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(obj)) {
+      out[k] = jsonifyValue(val);
+    }
+    return out;
+  }
+  return v;
+}
+
+function parseRowEstimate(raw: string | number | null): number | null {
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+  const parsed =
+    typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function unwrapNullable(type: string): {
+  dataType: string;
+  isNullable: boolean;
+} {
+  const match = /^Nullable\((.*)\)$/.exec(type);
+  if (match) {
+    return { dataType: match[1] ?? type, isNullable: true };
+  }
+  return { dataType: type, isNullable: false };
+}
+
+async function fetchTables(
+  client: ClickHouseClient,
+  database: string
+): Promise<TableRow[]> {
+  const rs = await client.query({
+    format: "JSON",
+    query: `SELECT name, engine, total_rows
+            FROM system.tables
+            WHERE database = {database:String} AND is_temporary = 0
+            ORDER BY name`,
+    query_params: { database },
+  });
+  const json = (await rs.json()) as { data?: TableRow[] };
+  return json.data ?? [];
+}
+
+async function fetchAllColumns(
+  client: ClickHouseClient,
+  database: string
+): Promise<ColumnRow[]> {
+  const rs = await client.query({
+    format: "JSON",
+    query: `SELECT table, name, type, is_in_primary_key, default_expression
+            FROM system.columns
+            WHERE database = {database:String}
+            ORDER BY table, position`,
+    query_params: { database },
+  });
+  const json = (await rs.json()) as { data?: ColumnRow[] };
+  return json.data ?? [];
+}
+
+async function fetchAllDataSkippingIndices(
+  client: ClickHouseClient,
+  database: string
+): Promise<DataSkippingIndexRow[]> {
+  const rs = await client.query({
+    format: "JSON",
+    query: `SELECT table, name, type AS index_type, expr
+            FROM system.data_skipping_indices
+            WHERE database = {database:String}
+            ORDER BY table, name`,
+    query_params: { database },
+  });
+  const json = (await rs.json()) as { data?: DataSkippingIndexRow[] };
+  return json.data ?? [];
+}
+
+function buildSchemaItem(
+  relations: TableRow[],
+  columns: ColumnRow[],
+  indices: DataSkippingIndexRow[]
+): { tables: TableLike[]; views: ViewLike[] } {
+  const tables = new Map<string, TableLike>();
+  const views = new Map<string, ViewLike>();
+
+  for (const r of relations) {
+    if (VIEW_ENGINES.has(r.engine)) {
+      views.set(r.name, { columns: [], name: r.name });
+    } else {
+      tables.set(r.name, {
+        columns: [],
+        foreignKeys: [],
+        indexes: [],
+        name: r.name,
+        rowEstimate: parseRowEstimate(r.total_rows),
+      });
+    }
+  }
+
+  for (const c of columns) {
+    const target = tables.get(c.table) ?? views.get(c.table);
+    if (!target) {
+      continue;
+    }
+    const { dataType, isNullable } = unwrapNullable(c.type);
+    target.columns.push({
+      dataType,
+      defaultValue:
+        c.default_expression && c.default_expression.length > 0
+          ? c.default_expression
+          : null,
+      isNullable,
+      isPrimaryKey: c.is_in_primary_key === 1 || c.is_in_primary_key === "1",
+      name: c.name,
+    });
+  }
+
+  for (const i of indices) {
+    const table = tables.get(i.table);
+    if (!table) {
+      continue;
+    }
+    table.indexes.push({
+      columns: [i.expr],
+      isUnique: false,
+      name: i.name,
+    });
+  }
+
+  return {
+    tables: [...tables.values()],
+    views: [...views.values()],
+  };
+}
+
+export function mapClickhouseError(err: unknown): DbError {
+  if (err instanceof DbError) {
+    return err;
+  }
+  if (err instanceof AggregateError && err.errors.length > 0) {
+    const [inner, ...rest] = err.errors;
+    const mapped = mapClickhouseError(inner);
+    if (rest.length === 0) {
+      return mapped;
+    }
+    const extras = rest
+      .map((sub) => (sub instanceof Error ? sub.message : String(sub)))
+      .filter((m) => m.length > 0);
+    const combined =
+      extras.length > 0
+        ? `${mapped.message} (also: ${extras.join("; ")})`
+        : mapped.message;
+    return new DbError(mapped.code, combined);
+  }
+  const e = err as { code?: string; message?: string; name?: string };
+  const code = e.code ?? "DB_ERROR";
+  const stringified = String(err);
+  const message =
+    (typeof e.message === "string" && e.message.length > 0 && e.message) ||
+    (stringified !== "[object Object]" && stringified) ||
+    e.name ||
+    code;
+  return new DbError(code, message);
+}

--- a/packages/drivers-clickhouse/vitest.config.ts
+++ b/packages/drivers-clickhouse/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/drivers-pg/package.json
+++ b/packages/drivers-pg/package.json
@@ -6,6 +6,10 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "dependencies": {
     "@oh-my-query/core": "workspace:*",
     "pg": "^8.13.1"
@@ -13,6 +17,7 @@
   "devDependencies": {
     "@oh-my-query/config": "workspace:*",
     "@types/pg": "^8.11.10",
-    "@typescript/native-preview": "catalog:"
+    "@typescript/native-preview": "catalog:",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/drivers-pg/src/pool.test.ts
+++ b/packages/drivers-pg/src/pool.test.ts
@@ -1,0 +1,308 @@
+import type { Pool as PgPoolType } from "pg";
+
+import { DbError } from "@oh-my-query/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { PostgresPool } from "./pool";
+
+interface QueryRows {
+  rows: Record<string, unknown>[];
+}
+
+interface QueryFixtures {
+  relations?: QueryRows;
+  columns?: QueryRows;
+  indexes?: QueryRows;
+  foreignKeys?: QueryRows;
+}
+
+const empty: QueryRows = { rows: [] };
+
+const dispatchQuery = (sql: string, fixtures: QueryFixtures): QueryRows => {
+  if (sql.includes("FROM pg_class") && sql.includes("relkind IN ('r', 'v')")) {
+    return fixtures.relations ?? empty;
+  }
+  if (sql.includes("FROM information_schema.columns")) {
+    return fixtures.columns ?? empty;
+  }
+  if (sql.includes("FROM pg_index")) {
+    return fixtures.indexes ?? empty;
+  }
+  if (
+    sql.includes("FROM information_schema.table_constraints") &&
+    sql.includes("FOREIGN KEY")
+  ) {
+    return fixtures.foreignKeys ?? empty;
+  }
+  throw new Error(`Unexpected query in dispatch: ${sql}`);
+};
+
+const buildPool = (fixtures: QueryFixtures) => {
+  const query = vi.fn<(sql: string) => Promise<QueryRows>>().mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async (sql) => dispatchQuery(sql, fixtures)
+  );
+  const fakePool = { query } as unknown as PgPoolType;
+  return { fakePool, query };
+};
+
+const must = <T>(value: T | undefined, label: string): T => {
+  if (value === undefined) {
+    throw new Error(`expected ${label} to be defined`);
+  }
+  return value;
+};
+
+describe("postgresPool.fetchSchema", () => {
+  it("issues exactly four schema-wide queries", async () => {
+    const { fakePool, query } = buildPool({});
+    const pool = new PostgresPool(fakePool);
+    const schema = await pool.fetchSchema("public");
+    expect(query).toHaveBeenCalledTimes(4);
+    expect(schema.schemas).toStrictEqual([
+      { name: "public", tables: [], views: [] },
+    ]);
+  });
+
+  it("returns tables and views in alphabetical order with row estimates", async () => {
+    const { fakePool } = buildPool({
+      relations: {
+        rows: [
+          { kind: "r", name: "accounts", row_estimate: "10" },
+          { kind: "v", name: "active_users", row_estimate: null },
+          { kind: "r", name: "orders", row_estimate: "200" },
+        ],
+      },
+    });
+    const pool = new PostgresPool(fakePool);
+    const result = await pool.fetchSchema("public");
+    const schema = must(result.schemas[0], "schemas[0]");
+    expect(schema.tables.map((t) => t.name)).toStrictEqual([
+      "accounts",
+      "orders",
+    ]);
+    expect(schema.tables.map((t) => t.rowEstimate)).toStrictEqual([10, 200]);
+    expect(schema.views.map((v) => v.name)).toStrictEqual(["active_users"]);
+  });
+
+  it("flags primary key columns and leaves others unflagged", async () => {
+    const { fakePool } = buildPool({
+      columns: {
+        rows: [
+          {
+            column_default: null,
+            column_name: "id",
+            data_type: "integer",
+            is_nullable: "NO",
+            is_pk: true,
+            table_name: "users",
+          },
+          {
+            column_default: null,
+            column_name: "email",
+            data_type: "text",
+            is_nullable: "YES",
+            is_pk: false,
+            table_name: "users",
+          },
+        ],
+      },
+      relations: {
+        rows: [{ kind: "r", name: "users", row_estimate: "0" }],
+      },
+    });
+    const pool = new PostgresPool(fakePool);
+    const result = await pool.fetchSchema("public");
+    const schema = must(result.schemas[0], "schemas[0]");
+    const table = must(schema.tables[0], "tables[0]");
+    expect(table.columns.map((c) => [c.name, c.isPrimaryKey])).toStrictEqual([
+      ["id", true],
+      ["email", false],
+    ]);
+    const email = must(table.columns[1], "columns[1]");
+    expect(email.isNullable).toBeTruthy();
+  });
+
+  it("supports composite primary keys", async () => {
+    const { fakePool } = buildPool({
+      columns: {
+        rows: [
+          {
+            column_default: null,
+            column_name: "user_id",
+            data_type: "integer",
+            is_nullable: "NO",
+            is_pk: true,
+            table_name: "user_roles",
+          },
+          {
+            column_default: null,
+            column_name: "role_id",
+            data_type: "integer",
+            is_nullable: "NO",
+            is_pk: true,
+            table_name: "user_roles",
+          },
+        ],
+      },
+      relations: {
+        rows: [{ kind: "r", name: "user_roles", row_estimate: "0" }],
+      },
+    });
+    const pool = new PostgresPool(fakePool);
+    const result = await pool.fetchSchema("public");
+    const schema = must(result.schemas[0], "schemas[0]");
+    const table = must(schema.tables[0], "tables[0]");
+    expect(table.columns.every((c) => c.isPrimaryKey)).toBeTruthy();
+  });
+
+  it("preserves multi-column index ordering", async () => {
+    const { fakePool } = buildPool({
+      indexes: {
+        rows: [
+          {
+            columns: ["created_at", "user_id"],
+            index_name: "events_created_user_idx",
+            is_unique: false,
+            table_name: "events",
+          },
+        ],
+      },
+      relations: {
+        rows: [{ kind: "r", name: "events", row_estimate: "0" }],
+      },
+    });
+    const pool = new PostgresPool(fakePool);
+    const result = await pool.fetchSchema("public");
+    const schema = must(result.schemas[0], "schemas[0]");
+    const table = must(schema.tables[0], "tables[0]");
+    const idx = must(table.indexes[0], "indexes[0]");
+    expect(idx.columns).toStrictEqual(["created_at", "user_id"]);
+    expect(idx.isUnique).toBeFalsy();
+  });
+
+  it("returns expression-only indexes with placeholder columns", async () => {
+    const { fakePool } = buildPool({
+      indexes: {
+        rows: [
+          {
+            columns: ["(expression)"],
+            index_name: "posts_lower_title_idx",
+            is_unique: false,
+            table_name: "posts",
+          },
+        ],
+      },
+      relations: {
+        rows: [{ kind: "r", name: "posts", row_estimate: "0" }],
+      },
+    });
+    const pool = new PostgresPool(fakePool);
+    const result = await pool.fetchSchema("public");
+    const schema = must(result.schemas[0], "schemas[0]");
+    const table = must(schema.tables[0], "tables[0]");
+    const idx = must(table.indexes[0], "indexes[0]");
+    expect(idx.columns).toStrictEqual(["(expression)"]);
+  });
+
+  it("groups multi-column foreign keys under a single constraint", async () => {
+    const { fakePool } = buildPool({
+      foreignKeys: {
+        rows: [
+          {
+            column_name: "tenant_id",
+            constraint_name: "orders_tenant_user_fk",
+            referenced_column: "tenant_id",
+            referenced_table: "users",
+            table_name: "orders",
+          },
+          {
+            column_name: "user_id",
+            constraint_name: "orders_tenant_user_fk",
+            referenced_column: "id",
+            referenced_table: "users",
+            table_name: "orders",
+          },
+        ],
+      },
+      relations: {
+        rows: [{ kind: "r", name: "orders", row_estimate: "0" }],
+      },
+    });
+    const pool = new PostgresPool(fakePool);
+    const result = await pool.fetchSchema("public");
+    const schema = must(result.schemas[0], "schemas[0]");
+    const table = must(schema.tables[0], "tables[0]");
+    expect(table.foreignKeys).toHaveLength(1);
+    expect(table.foreignKeys[0]).toStrictEqual({
+      columns: ["tenant_id", "user_id"],
+      name: "orders_tenant_user_fk",
+      referencedColumns: ["tenant_id", "id"],
+      referencedTable: "users",
+    });
+  });
+
+  it("populates view columns and excludes index/FK fields", async () => {
+    const { fakePool } = buildPool({
+      columns: {
+        rows: [
+          {
+            column_default: null,
+            column_name: "id",
+            data_type: "integer",
+            is_nullable: "NO",
+            is_pk: false,
+            table_name: "active_users",
+          },
+        ],
+      },
+      relations: {
+        rows: [{ kind: "v", name: "active_users", row_estimate: null }],
+      },
+    });
+    const pool = new PostgresPool(fakePool);
+    const result = await pool.fetchSchema("public");
+    const schema = must(result.schemas[0], "schemas[0]");
+    expect(schema.views[0]).toStrictEqual({
+      columns: [
+        {
+          dataType: "integer",
+          defaultValue: null,
+          isNullable: false,
+          isPrimaryKey: false,
+          name: "id",
+        },
+      ],
+      name: "active_users",
+    });
+  });
+
+  it("returns an empty schema when no relations exist", async () => {
+    const { fakePool } = buildPool({});
+    const pool = new PostgresPool(fakePool);
+    const result = await pool.fetchSchema("public");
+    expect(result).toStrictEqual({
+      schemas: [{ name: "public", tables: [], views: [] }],
+    });
+  });
+
+  it("wraps pool failures in DbError", async () => {
+    const failure = new Error("connection terminated") as Error & {
+      code?: string;
+    };
+    failure.code = "ECONNRESET";
+    const query = vi.fn().mockRejectedValue(failure);
+    const fakePool = { query } as unknown as PgPoolType;
+    const pool = new PostgresPool(fakePool);
+    await expect(pool.fetchSchema("public")).rejects.toBeInstanceOf(DbError);
+  });
+
+  it("rejects invalid schema names without issuing queries", async () => {
+    const { fakePool, query } = buildPool({});
+    const pool = new PostgresPool(fakePool);
+    await expect(pool.fetchSchema('"; DROP TABLE users; --')).rejects.toThrow(
+      /schema/i
+    );
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/drivers-pg/src/pool.test.ts
+++ b/packages/drivers-pg/src/pool.test.ts
@@ -19,7 +19,10 @@ interface QueryFixtures {
 const empty: QueryRows = { rows: [] };
 
 const dispatchQuery = (sql: string, fixtures: QueryFixtures): QueryRows => {
-  if (sql.includes("FROM pg_class") && sql.includes("relkind IN ('r', 'v')")) {
+  if (
+    sql.includes("FROM pg_class") &&
+    sql.includes("relkind IN ('r', 'p', 'v')")
+  ) {
     return fixtures.relations ?? empty;
   }
   if (sql.includes("FROM information_schema.columns")) {
@@ -83,6 +86,25 @@ describe("postgresPool.fetchSchema", () => {
     ]);
     expect(schema.tables.map((t) => t.rowEstimate)).toStrictEqual([10, 200]);
     expect(schema.views.map((v) => v.name)).toStrictEqual(["active_users"]);
+  });
+
+  it("treats partitioned tables (relkind='p') as tables", async () => {
+    const { fakePool } = buildPool({
+      relations: {
+        rows: [
+          { kind: "p", name: "events_partitioned", row_estimate: null },
+          { kind: "r", name: "users", row_estimate: "5" },
+        ],
+      },
+    });
+    const pool = new PostgresPool(fakePool);
+    const result = await pool.fetchSchema("public");
+    const schema = must(result.schemas[0], "schemas[0]");
+    expect(schema.tables.map((t) => t.name)).toStrictEqual([
+      "events_partitioned",
+      "users",
+    ]);
+    expect(schema.views).toStrictEqual([]);
   });
 
   it("flags primary key columns and leaves others unflagged", async () => {

--- a/packages/drivers-pg/src/pool.ts
+++ b/packages/drivers-pg/src/pool.ts
@@ -308,7 +308,7 @@ function mapExplainError(err: unknown, analyze: boolean): DbError {
 
 interface RelationRow {
   name: string;
-  kind: "r" | "v";
+  kind: "r" | "p" | "v";
   row_estimate: string | null;
 }
 
@@ -356,11 +356,11 @@ async function fetchRelations(
   const r = await pool.query<RelationRow>(
     `SELECT c.relname AS name,
             c.relkind AS kind,
-            CASE WHEN c.relkind = 'r' THEN c.reltuples::bigint ELSE NULL END AS row_estimate
+            CASE WHEN c.relkind IN ('r', 'p') THEN c.reltuples::bigint ELSE NULL END AS row_estimate
      FROM pg_class c
      JOIN pg_namespace n ON n.oid = c.relnamespace
      WHERE n.nspname = $1
-       AND c.relkind IN ('r', 'v')
+       AND c.relkind IN ('r', 'p', 'v')
      ORDER BY c.relname`,
     [schema]
   );
@@ -414,7 +414,7 @@ async function fetchAllIndexes(
        ON a.attrelid = t.oid
       AND a.attnum   = ix.indkey[k.ord]
       AND ix.indkey[k.ord] <> 0
-     WHERE n.nspname = $1 AND t.relkind = 'r'
+     WHERE n.nspname = $1 AND t.relkind IN ('r', 'p')
      GROUP BY t.relname, i.relname, ix.indisunique
      ORDER BY t.relname, i.relname`,
     [schema]
@@ -436,6 +436,7 @@ async function fetchAllForeignKeys(
      JOIN information_schema.key_column_usage kcu
        ON tc.constraint_name = kcu.constraint_name
       AND tc.table_schema   = kcu.table_schema
+      AND tc.table_name     = kcu.table_name
      JOIN information_schema.constraint_column_usage ccu
        ON ccu.constraint_name = tc.constraint_name
       AND ccu.table_schema   = tc.table_schema
@@ -465,7 +466,9 @@ function buildSchemaItem(
   const views = new Map<string, ViewLike>();
 
   for (const r of relations) {
-    if (r.kind === "r") {
+    if (r.kind === "v") {
+      views.set(r.name, { columns: [], name: r.name });
+    } else {
       tables.set(r.name, {
         columns: [],
         foreignKeys: [],
@@ -473,8 +476,6 @@ function buildSchemaItem(
         name: r.name,
         rowEstimate: parseRowEstimate(r.row_estimate),
       });
-    } else {
-      views.set(r.name, { columns: [], name: r.name });
     }
   }
 

--- a/packages/drivers-pg/src/pool.ts
+++ b/packages/drivers-pg/src/pool.ts
@@ -77,9 +77,23 @@ export class PostgresPool implements Pool {
 
   async fetchSchema(schemaName: string): Promise<SchemaInfo> {
     validateSchemaName(schemaName);
-    const tables = await fetchTables(this.#pool, schemaName);
-    const views = await fetchViews(this.#pool, schemaName);
-    return { schemas: [{ name: schemaName, tables, views }] };
+    try {
+      const [relations, columns, indexes, foreignKeys] = await Promise.all([
+        fetchRelations(this.#pool, schemaName),
+        fetchAllColumns(this.#pool, schemaName),
+        fetchAllIndexes(this.#pool, schemaName),
+        fetchAllForeignKeys(this.#pool, schemaName),
+      ]);
+      const { tables, views } = buildSchemaItem(
+        relations,
+        columns,
+        indexes,
+        foreignKeys
+      );
+      return { schemas: [{ name: schemaName, tables, views }] };
+    } catch (error) {
+      throw mapPgError(error);
+    }
   }
 
   async execute(
@@ -292,184 +306,244 @@ function mapExplainError(err: unknown, analyze: boolean): DbError {
   return mapPgError(err);
 }
 
-async function fetchTables(pool: PgPoolType, schema: string) {
-  const tableRows = await pool.query<{ table_name: string }>(
-    `SELECT table_name FROM information_schema.tables
-     WHERE table_schema = $1 AND table_type = 'BASE TABLE'
-     ORDER BY table_name`,
-    [schema]
-  );
-  const estimates = await fetchRowEstimates(pool, schema);
-  const result = [];
-  for (const row of tableRows.rows) {
-    const tableName = row.table_name;
-    const [columns, indexes, foreignKeys] = await Promise.all([
-      fetchColumns(pool, schema, tableName),
-      fetchIndexes(pool, schema, tableName),
-      fetchForeignKeys(pool, schema, tableName),
-    ]);
-    result.push({
-      columns,
-      foreignKeys,
-      indexes,
-      name: tableName,
-      rowEstimate: estimates.get(tableName) ?? null,
-    });
-  }
-  return result;
+interface RelationRow {
+  name: string;
+  kind: "r" | "v";
+  row_estimate: string | null;
 }
 
-async function fetchRowEstimates(
+interface ColumnRow {
+  table_name: string;
+  column_name: string;
+  data_type: string;
+  is_nullable: string;
+  column_default: string | null;
+  is_pk: boolean;
+}
+
+interface IndexRow {
+  table_name: string;
+  index_name: string;
+  is_unique: boolean;
+  columns: (string | null)[] | null;
+}
+
+interface ForeignKeyRow {
+  table_name: string;
+  constraint_name: string;
+  column_name: string;
+  referenced_table: string;
+  referenced_column: string;
+}
+
+interface TableLike {
+  name: string;
+  columns: ColumnDetail[];
+  indexes: IndexItem[];
+  foreignKeys: ForeignKeyItem[];
+  rowEstimate: number | null;
+}
+
+interface ViewLike {
+  name: string;
+  columns: ColumnDetail[];
+}
+
+async function fetchRelations(
   pool: PgPoolType,
   schema: string
-): Promise<Map<string, number>> {
-  const r = await pool.query<{ table_name: string; row_estimate: string }>(
-    `SELECT c.relname AS table_name, c.reltuples::bigint AS row_estimate
+): Promise<RelationRow[]> {
+  const r = await pool.query<RelationRow>(
+    `SELECT c.relname AS name,
+            c.relkind AS kind,
+            CASE WHEN c.relkind = 'r' THEN c.reltuples::bigint ELSE NULL END AS row_estimate
      FROM pg_class c
      JOIN pg_namespace n ON n.oid = c.relnamespace
-     WHERE n.nspname = $1 AND c.relkind = 'r'`,
+     WHERE n.nspname = $1
+       AND c.relkind IN ('r', 'v')
+     ORDER BY c.relname`,
     [schema]
   );
-  const out = new Map<string, number>();
-  for (const row of r.rows) {
-    const est = Number.parseInt(String(row.row_estimate), 10);
-    if (Number.isFinite(est) && est >= 0) {
-      out.set(row.table_name, est);
-    }
-  }
-  return out;
+  return r.rows;
 }
 
-async function fetchViews(pool: PgPoolType, schema: string) {
-  const r = await pool.query<{ table_name: string }>(
-    `SELECT table_name FROM information_schema.tables
-     WHERE table_schema = $1 AND table_type = 'VIEW'
-     ORDER BY table_name`,
-    [schema]
-  );
-  const views = [];
-  for (const row of r.rows) {
-    const columns = await fetchColumns(pool, schema, row.table_name);
-    views.push({ columns, name: row.table_name });
-  }
-  return views;
-}
-
-async function fetchColumns(
+async function fetchAllColumns(
   pool: PgPoolType,
-  schema: string,
-  table: string
-): Promise<ColumnDetail[]> {
-  const r = await pool.query<{
-    column_name: string;
-    data_type: string;
-    is_nullable: string;
-    column_default: string | null;
-    is_pk: boolean;
-  }>(
-    `SELECT c.column_name, c.data_type, c.is_nullable, c.column_default,
-            CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END AS is_pk
+  schema: string
+): Promise<ColumnRow[]> {
+  const r = await pool.query<ColumnRow>(
+    `SELECT c.table_name,
+            c.column_name,
+            c.data_type,
+            c.is_nullable,
+            c.column_default,
+            (pk.column_name IS NOT NULL) AS is_pk
      FROM information_schema.columns c
      LEFT JOIN (
-       SELECT kcu.column_name FROM information_schema.table_constraints tc
+       SELECT kcu.table_name, kcu.column_name
+       FROM information_schema.table_constraints tc
        JOIN information_schema.key_column_usage kcu
          ON tc.constraint_name = kcu.constraint_name
-        AND tc.table_schema = kcu.table_schema
+        AND tc.table_schema   = kcu.table_schema
+        AND tc.table_name     = kcu.table_name
        WHERE tc.constraint_type = 'PRIMARY KEY'
-         AND tc.table_schema = $1 AND tc.table_name = $2
-     ) pk ON c.column_name = pk.column_name
-     WHERE c.table_schema = $1 AND c.table_name = $2
-     ORDER BY c.ordinal_position`,
-    [schema, table]
+         AND tc.table_schema    = $1
+     ) pk ON pk.table_name = c.table_name AND pk.column_name = c.column_name
+     WHERE c.table_schema = $1
+     ORDER BY c.table_name, c.ordinal_position`,
+    [schema]
   );
-  return r.rows.map((row) => ({
-    dataType: row.data_type,
-    defaultValue: row.column_default,
-    isNullable: row.is_nullable === "YES",
-    isPrimaryKey: Boolean(row.is_pk),
-    name: row.column_name,
-  }));
+  return r.rows;
 }
 
-async function fetchIndexes(
+async function fetchAllIndexes(
   pool: PgPoolType,
-  schema: string,
-  table: string
-): Promise<IndexItem[]> {
-  const r = await pool.query<{
-    index_name: string;
-    is_unique: boolean;
-    columns: string[];
-  }>(
-    `SELECT i.relname AS index_name,
+  schema: string
+): Promise<IndexRow[]> {
+  const r = await pool.query<IndexRow>(
+    `SELECT t.relname AS table_name,
+            i.relname AS index_name,
             ix.indisunique AS is_unique,
-            array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) AS columns
+            array_agg(COALESCE(a.attname, '(expression)') ORDER BY k.ord) AS columns
      FROM pg_index ix
      JOIN pg_class t ON t.oid = ix.indrelid
      JOIN pg_class i ON i.oid = ix.indexrelid
      JOIN pg_namespace n ON n.oid = t.relnamespace
-     JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
-     WHERE n.nspname = $1 AND t.relname = $2
-     GROUP BY i.relname, ix.indisunique
-     ORDER BY i.relname`,
-    [schema, table]
+     JOIN LATERAL generate_subscripts(ix.indkey, 1) AS k(ord) ON TRUE
+     LEFT JOIN pg_attribute a
+       ON a.attrelid = t.oid
+      AND a.attnum   = ix.indkey[k.ord]
+      AND ix.indkey[k.ord] <> 0
+     WHERE n.nspname = $1 AND t.relkind = 'r'
+     GROUP BY t.relname, i.relname, ix.indisunique
+     ORDER BY t.relname, i.relname`,
+    [schema]
   );
-  return r.rows.map((row) => ({
-    columns: Array.isArray(row.columns)
-      ? row.columns.filter((c): c is string => typeof c === "string")
-      : [],
-    isUnique: Boolean(row.is_unique),
-    name: row.index_name,
-  }));
+  return r.rows;
 }
 
-async function fetchForeignKeys(
+async function fetchAllForeignKeys(
   pool: PgPoolType,
-  schema: string,
-  table: string
-): Promise<ForeignKeyItem[]> {
-  const r = await pool.query<{
-    constraint_name: string;
-    column_name: string;
-    referenced_table: string;
-    referenced_column: string;
-  }>(
-    `SELECT tc.constraint_name,
+  schema: string
+): Promise<ForeignKeyRow[]> {
+  const r = await pool.query<ForeignKeyRow>(
+    `SELECT tc.table_name,
+            tc.constraint_name,
             kcu.column_name,
-            ccu.table_name AS referenced_table,
+            ccu.table_name  AS referenced_table,
             ccu.column_name AS referenced_column
      FROM information_schema.table_constraints tc
      JOIN information_schema.key_column_usage kcu
        ON tc.constraint_name = kcu.constraint_name
-      AND tc.table_schema = kcu.table_schema
+      AND tc.table_schema   = kcu.table_schema
      JOIN information_schema.constraint_column_usage ccu
        ON ccu.constraint_name = tc.constraint_name
-      AND ccu.table_schema = tc.table_schema
+      AND ccu.table_schema   = tc.table_schema
      WHERE tc.constraint_type = 'FOREIGN KEY'
-       AND tc.table_schema = $1 AND tc.table_name = $2
-     ORDER BY tc.constraint_name, kcu.ordinal_position`,
-    [schema, table]
+       AND tc.table_schema    = $1
+     ORDER BY tc.table_name, tc.constraint_name, kcu.ordinal_position`,
+    [schema]
   );
-  const map = new Map<string, ForeignKeyItem>();
-  for (const row of r.rows) {
-    let entry = map.get(row.constraint_name);
+  return r.rows;
+}
+
+function parseRowEstimate(raw: string | null): number | null {
+  if (raw === null) {
+    return null;
+  }
+  const est = Number.parseInt(String(raw), 10);
+  return Number.isFinite(est) && est >= 0 ? est : null;
+}
+
+function buildSchemaItem(
+  relations: RelationRow[],
+  columns: ColumnRow[],
+  indexes: IndexRow[],
+  foreignKeys: ForeignKeyRow[]
+): { tables: TableLike[]; views: ViewLike[] } {
+  const tables = new Map<string, TableLike>();
+  const views = new Map<string, ViewLike>();
+
+  for (const r of relations) {
+    if (r.kind === "r") {
+      tables.set(r.name, {
+        columns: [],
+        foreignKeys: [],
+        indexes: [],
+        name: r.name,
+        rowEstimate: parseRowEstimate(r.row_estimate),
+      });
+    } else {
+      views.set(r.name, { columns: [], name: r.name });
+    }
+  }
+
+  for (const c of columns) {
+    const target = tables.get(c.table_name) ?? views.get(c.table_name);
+    if (!target) {
+      continue;
+    }
+    target.columns.push({
+      dataType: c.data_type,
+      defaultValue: c.column_default,
+      isNullable: c.is_nullable === "YES",
+      isPrimaryKey: Boolean(c.is_pk),
+      name: c.column_name,
+    });
+  }
+
+  for (const i of indexes) {
+    const table = tables.get(i.table_name);
+    if (!table) {
+      continue;
+    }
+    table.indexes.push({
+      columns: Array.isArray(i.columns)
+        ? i.columns.filter((col): col is string => typeof col === "string")
+        : [],
+      isUnique: Boolean(i.is_unique),
+      name: i.index_name,
+    });
+  }
+
+  const fkByTable = new Map<string, Map<string, ForeignKeyItem>>();
+  for (const f of foreignKeys) {
+    if (!tables.has(f.table_name)) {
+      continue;
+    }
+    let perTable = fkByTable.get(f.table_name);
+    if (!perTable) {
+      perTable = new Map<string, ForeignKeyItem>();
+      fkByTable.set(f.table_name, perTable);
+    }
+    let entry = perTable.get(f.constraint_name);
     if (!entry) {
       entry = {
         columns: [],
-        name: row.constraint_name,
+        name: f.constraint_name,
         referencedColumns: [],
-        referencedTable: row.referenced_table,
+        referencedTable: f.referenced_table,
       };
-      map.set(row.constraint_name, entry);
+      perTable.set(f.constraint_name, entry);
     }
-    if (!entry.columns.includes(row.column_name)) {
-      entry.columns.push(row.column_name);
+    if (!entry.columns.includes(f.column_name)) {
+      entry.columns.push(f.column_name);
     }
-    if (!entry.referencedColumns.includes(row.referenced_column)) {
-      entry.referencedColumns.push(row.referenced_column);
+    if (!entry.referencedColumns.includes(f.referenced_column)) {
+      entry.referencedColumns.push(f.referenced_column);
     }
   }
-  return [...map.values()];
+  for (const [tableName, perTable] of fkByTable) {
+    const table = tables.get(tableName);
+    if (table) {
+      table.foreignKeys = [...perTable.values()];
+    }
+  }
+
+  return {
+    tables: [...tables.values()],
+    views: [...views.values()],
+  };
 }
 
 export { NOOP };

--- a/packages/drivers-pg/vitest.config.ts
+++ b/packages/drivers-pg/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/rpc/src/schema.ts
+++ b/packages/rpc/src/schema.ts
@@ -61,7 +61,11 @@ export interface RpcSchema {
       response: string[];
     };
     getSchema: {
-      params: { connectionId: string; databaseName: string };
+      params: {
+        connectionId: string;
+        databaseName: string;
+        force?: boolean;
+      };
       response: SchemaInfo;
     };
     executeQuery: {


### PR DESCRIPTION
## Summary

- Fix macOS menu: drop unsupported roles (`about`, `services`, `unhide`, `togglefullscreen`), use Electrobun-supported equivalents (`showAll`, `toggleFullScreen`), and read the click action from `event.data.action`. Reset `TRAFFIC_LIGHT_INSET` to `0px`.
- Speed up PostgreSQL schema loading: collapse the per-table N+1 introspection (`~3N + M` round trips) into 4 schema-wide bulk queries grouped in memory, and add a 60s in-memory TTL cache on the bun side keyed by `connectionId+databaseName`. F5 threads a `force` flag through the RPC to bypass the cache.
- Add a Vitest suite for the pg driver covering query count, ordering, composite PKs, multi-column and expression-only indexes, multi-column FKs, view columns, and error wrapping.

## Test plan

- [ ] Open the app on macOS and confirm the application menu builds without role errors and "Settings…" still opens the settings route.
- [ ] Connect to a Postgres instance with ≥30 tables and confirm schema loads in roughly 4 round trips (devtools/bun logs) instead of scaling with table count.
- [ ] Reload the renderer within 60s and confirm the schema appears instantly (cache hit).
- [ ] Press F5 and confirm a fresh fetch is issued.
- [ ] `bun run check-types`, `bun run check`, `bun run --cwd apps/app test`, `bun run --cwd packages/drivers-pg test`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS menu roles and click handling; speeds up PostgreSQL schema loading with 4 bulk queries and a 60s Bun cache; adds a working ClickHouse driver with bulk schema fetch and query execution.

- **Bug Fixes**
  - Replaced unsupported macOS menu roles with supported ones (`showAll`, `toggleFullScreen`).
  - Read menu click actions from `event.data.action`.
  - Reset `TRAFFIC_LIGHT_INSET` to `0px`.

- **Performance**
  - Collapsed PostgreSQL per-table schema introspection into 4 schema-wide queries (relations, columns, indexes, FKs).
  - Added a 60s in-memory TTL cache for `getSchema`, keyed by `connectionId + databaseName`; bypass with `force` (F5); invalidates on disconnect.
  - Implemented `clickhouse` driver on `@clickhouse/client` with 3 schema-wide queries (tables, columns, data-skipping indices) and JSONCompact execution; EXPLAIN not yet supported.
  - Added `vitest` suites for the `pg` and `clickhouse` drivers.

<sup>Written for commit 16c84fd170e6b9cf32b35a10a45c27476a9b089d. Summary will update on new commits. <a href="https://cubic.dev/pr/victor-teles/oh-my-query/pull/146?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

