### PR TITLE
Add per-connection run options popover (OMQ-23)

### DIFF
--- a/apps/app/src/mainview/components/connection-form/use-connection-form.ts
+++ b/apps/app/src/mainview/components/connection-form/use-connection-form.ts
@@ -132,6 +132,7 @@ export const useConnectionForm = (
           id: connection.id,
           lastConnectedAt: connection.lastConnectedAt,
           pinned: connection.pinned,
+          runConfig: connection.runConfig,
         };
         await updateConnection(updated);
         onSuccess?.(updated);

--- a/apps/app/src/mainview/components/workspace/run-config-popover.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/run-config-popover.browser.test.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import type { RunConfig } from "@/lib/query-types";
+
+import { DEFAULT_RUN_CONFIG } from "@/lib/query-types";
+
+// oxlint-disable-next-line prefer-const, jest/require-hook
+let runConfig: RunConfig = { ...DEFAULT_RUN_CONFIG };
+const setRunConfig = vi.fn((partial: Partial<RunConfig>) => {
+  runConfig = { ...runConfig, ...partial };
+});
+
+vi.mock(import("@/contexts/connection-context"), () => ({
+  useConnection: () => ({
+    connection: {
+      createdAt: "2026-01-01T00:00:00.000Z",
+      database: "app",
+      host: "localhost",
+      id: "conn-1",
+      lastConnectedAt: null,
+      name: "Local",
+      password: "",
+      pinned: false,
+      port: 5432,
+      type: "postgresql" as const,
+      username: "postgres",
+    },
+    error: null,
+    isConnected: true,
+    isConnecting: false,
+    isReconnecting: false,
+    reconnect: vi.fn(),
+    runConfig,
+    serverVersion: null,
+    setRunConfig,
+  }),
+}));
+
+const { RunConfigPopover } = await import("./run-config-popover");
+
+describe("runConfigPopover", () => {
+  beforeEach(() => {
+    runConfig = { ...DEFAULT_RUN_CONFIG };
+    setRunConfig.mockClear();
+  });
+
+  it("opens the popover and toggles sandbox", async () => {
+    const screen = render(<RunConfigPopover connectionType="postgresql" />);
+    await screen.getByLabelText("Run options").click();
+    const checkbox = screen.getByRole("checkbox");
+    await checkbox.click();
+    expect(setRunConfig).toHaveBeenCalledWith({ sandbox: false });
+  });
+
+  it("hides the schema field for mongodb", async () => {
+    const screen = render(<RunConfigPopover connectionType="mongodb" />);
+    await screen.getByLabelText("Run options").click();
+    expect(screen.getByLabelText("Default schema").query()).toBeNull();
+  });
+
+  it("shows the schema field for postgres", async () => {
+    const screen = render(<RunConfigPopover connectionType="postgresql" />);
+    await screen.getByLabelText("Run options").click();
+    expect(screen.getByLabelText("Default schema").element()).toBeVisible();
+  });
+
+  it("flags an active dot when runConfig deviates from defaults", () => {
+    runConfig = { ...DEFAULT_RUN_CONFIG, timeoutSecs: 30 };
+    const screen = render(<RunConfigPopover connectionType="postgresql" />);
+    const trigger = screen.getByLabelText("Run options").element();
+    const dot = trigger.querySelector("[aria-hidden='true']");
+    expect(dot).not.toBeNull();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/run-config-popover.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/run-config-popover.browser.test.tsx
@@ -46,30 +46,25 @@ describe("runConfigPopover", () => {
   });
 
   it("opens the popover and toggles sandbox", async () => {
-    const screen = render(<RunConfigPopover connectionType="postgresql" />);
+    const screen = render(<RunConfigPopover />);
     await screen.getByLabelText("Run options").click();
     const checkbox = screen.getByRole("checkbox");
     await checkbox.click();
     expect(setRunConfig).toHaveBeenCalledWith({ sandbox: false });
   });
 
-  it("hides the schema field for mongodb", async () => {
-    const screen = render(<RunConfigPopover connectionType="mongodb" />);
-    await screen.getByLabelText("Run options").click();
-    expect(screen.getByLabelText("Default schema").query()).toBeNull();
-  });
-
-  it("shows the schema field for postgres", async () => {
-    const screen = render(<RunConfigPopover connectionType="postgresql" />);
-    await screen.getByLabelText("Run options").click();
-    expect(screen.getByLabelText("Default schema").element()).toBeVisible();
-  });
-
   it("flags an active dot when runConfig deviates from defaults", () => {
-    runConfig = { ...DEFAULT_RUN_CONFIG, timeoutSecs: 30 };
-    const screen = render(<RunConfigPopover connectionType="postgresql" />);
+    runConfig = { ...DEFAULT_RUN_CONFIG, timeoutSecs: 60 };
+    const screen = render(<RunConfigPopover />);
     const trigger = screen.getByLabelText("Run options").element();
-    const dot = trigger.querySelector("[aria-hidden='true']");
+    const dot = trigger.querySelector("span[aria-hidden='true']");
     expect(dot).not.toBeNull();
+  });
+
+  it("does not flag the dot at default values", () => {
+    const screen = render(<RunConfigPopover />);
+    const trigger = screen.getByLabelText("Run options").element();
+    const dot = trigger.querySelector("span[aria-hidden='true']");
+    expect(dot).toBeNull();
   });
 });

--- a/apps/app/src/mainview/components/workspace/run-config-popover.tsx
+++ b/apps/app/src/mainview/components/workspace/run-config-popover.tsx
@@ -1,8 +1,6 @@
 import { Settings2 } from "lucide-react";
 import { useCallback } from "react";
 
-import type { DatabaseType } from "@/lib/connections";
-
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -18,7 +16,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useConnection } from "@/contexts/connection-context";
-import { supportsSchemaOverride } from "@/lib/connections";
+import { DEFAULT_RUN_CONFIG } from "@/lib/query-types";
 
 const parsePositiveInt = (raw: string): number | null => {
   const trimmed = raw.trim();
@@ -32,18 +30,12 @@ const parsePositiveInt = (raw: string): number | null => {
   return parsed;
 };
 
-interface RunConfigPopoverProps {
-  connectionType: DatabaseType;
-}
-
-export const RunConfigPopover = ({ connectionType }: RunConfigPopoverProps) => {
+export const RunConfigPopover = () => {
   const { runConfig, setRunConfig } = useConnection();
-  const showSchema = supportsSchemaOverride(connectionType);
   const isModified =
-    !runConfig.sandbox ||
-    runConfig.maxRows !== 100 ||
-    runConfig.timeoutSecs !== null ||
-    runConfig.schemaOverride !== null;
+    runConfig.sandbox !== DEFAULT_RUN_CONFIG.sandbox ||
+    runConfig.maxRows !== DEFAULT_RUN_CONFIG.maxRows ||
+    runConfig.timeoutSecs !== DEFAULT_RUN_CONFIG.timeoutSecs;
 
   const onSandboxChange = useCallback(
     (checked: boolean) => {
@@ -55,39 +47,30 @@ export const RunConfigPopover = ({ connectionType }: RunConfigPopoverProps) => {
   const onMaxRowsChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = parsePositiveInt(e.target.value);
-      setRunConfig({ maxRows: value ?? 100 });
+      setRunConfig({ maxRows: value ?? DEFAULT_RUN_CONFIG.maxRows });
     },
     [setRunConfig]
   );
 
   const onTimeoutChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      setRunConfig({ timeoutSecs: parsePositiveInt(e.target.value) });
-    },
-    [setRunConfig]
-  );
-
-  const onSchemaChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const trimmed = e.target.value.trim();
-      setRunConfig({ schemaOverride: trimmed.length > 0 ? trimmed : null });
+      const value = parsePositiveInt(e.target.value);
+      setRunConfig({ timeoutSecs: value ?? DEFAULT_RUN_CONFIG.timeoutSecs });
     },
     [setRunConfig]
   );
 
   const onReset = useCallback(() => {
     setRunConfig({
-      maxRows: 100,
-      sandbox: true,
-      schemaOverride: null,
-      timeoutSecs: null,
+      maxRows: DEFAULT_RUN_CONFIG.maxRows,
+      sandbox: DEFAULT_RUN_CONFIG.sandbox,
+      timeoutSecs: DEFAULT_RUN_CONFIG.timeoutSecs,
     });
   }, [setRunConfig]);
 
   const rowCapValue =
     runConfig.maxRows === null ? "" : String(runConfig.maxRows);
-  const timeoutValue =
-    runConfig.timeoutSecs === null ? "" : String(runConfig.timeoutSecs);
+  const timeoutValue = String(runConfig.timeoutSecs);
 
   return (
     <Popover>
@@ -137,19 +120,23 @@ export const RunConfigPopover = ({ connectionType }: RunConfigPopoverProps) => {
           )}
         </div>
 
-        <div className="space-y-1.5">
-          <Label className="flex items-center gap-2 font-normal">
-            <Checkbox
-              checked={runConfig.sandbox}
-              onCheckedChange={onSandboxChange}
-            />
-            Cap rows
-          </Label>
-          {runConfig.sandbox ? (
-            <div className="flex items-center gap-2 pl-6">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <Label
+              className="flex items-center gap-2 font-normal"
+              htmlFor="run-config-max-rows"
+            >
+              <Checkbox
+                checked={runConfig.sandbox}
+                onCheckedChange={onSandboxChange}
+              />
+              Cap rows
+            </Label>
+            <div className="flex items-center gap-1.5">
               <Input
-                aria-label="Row cap"
-                className="h-7 w-24"
+                className="h-7 w-20 text-right"
+                disabled={!runConfig.sandbox}
+                id="run-config-max-rows"
                 inputMode="numeric"
                 min={1}
                 onChange={onMaxRowsChange}
@@ -157,48 +144,39 @@ export const RunConfigPopover = ({ connectionType }: RunConfigPopoverProps) => {
                 type="number"
                 value={rowCapValue}
               />
-              <span className="text-[11px] text-muted-foreground">rows</span>
+              <span className="w-14 text-[11px] text-muted-foreground">
+                rows
+              </span>
             </div>
-          ) : (
-            <p className="pl-6 text-[11px] text-warning">
+          </div>
+
+          <div className="flex items-center justify-between gap-3">
+            <Label className="font-normal" htmlFor="run-config-timeout">
+              Statement timeout
+            </Label>
+            <div className="flex items-center gap-1.5">
+              <Input
+                className="h-7 w-20 text-right"
+                id="run-config-timeout"
+                inputMode="numeric"
+                min={1}
+                onChange={onTimeoutChange}
+                placeholder="30"
+                type="number"
+                value={timeoutValue}
+              />
+              <span className="w-14 text-[11px] text-muted-foreground">
+                seconds
+              </span>
+            </div>
+          </div>
+
+          {!runConfig.sandbox && (
+            <p className="text-[11px] text-warning">
               Queries will run uncapped on this connection.
             </p>
           )}
         </div>
-
-        <div className="space-y-1.5">
-          <Label className="font-normal" htmlFor="run-config-timeout">
-            Statement timeout
-          </Label>
-          <div className="flex items-center gap-2">
-            <Input
-              className="h-7 w-24"
-              id="run-config-timeout"
-              inputMode="numeric"
-              min={1}
-              onChange={onTimeoutChange}
-              placeholder="No limit"
-              type="number"
-              value={timeoutValue}
-            />
-            <span className="text-[11px] text-muted-foreground">seconds</span>
-          </div>
-        </div>
-
-        {showSchema && (
-          <div className="space-y-1.5">
-            <Label className="font-normal" htmlFor="run-config-schema">
-              Default schema
-            </Label>
-            <Input
-              className="h-7"
-              id="run-config-schema"
-              onChange={onSchemaChange}
-              placeholder="Inherit from database"
-              value={runConfig.schemaOverride ?? ""}
-            />
-          </div>
-        )}
       </PopoverContent>
     </Popover>
   );

--- a/apps/app/src/mainview/components/workspace/run-config-popover.tsx
+++ b/apps/app/src/mainview/components/workspace/run-config-popover.tsx
@@ -1,0 +1,205 @@
+import { Settings2 } from "lucide-react";
+import { useCallback } from "react";
+
+import type { DatabaseType } from "@/lib/connections";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useConnection } from "@/contexts/connection-context";
+import { supportsSchemaOverride } from "@/lib/connections";
+
+const parsePositiveInt = (raw: string): number | null => {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+};
+
+interface RunConfigPopoverProps {
+  connectionType: DatabaseType;
+}
+
+export const RunConfigPopover = ({ connectionType }: RunConfigPopoverProps) => {
+  const { runConfig, setRunConfig } = useConnection();
+  const showSchema = supportsSchemaOverride(connectionType);
+  const isModified =
+    !runConfig.sandbox ||
+    runConfig.maxRows !== 100 ||
+    runConfig.timeoutSecs !== null ||
+    runConfig.schemaOverride !== null;
+
+  const onSandboxChange = useCallback(
+    (checked: boolean) => {
+      setRunConfig({ sandbox: checked });
+    },
+    [setRunConfig]
+  );
+
+  const onMaxRowsChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = parsePositiveInt(e.target.value);
+      setRunConfig({ maxRows: value ?? 100 });
+    },
+    [setRunConfig]
+  );
+
+  const onTimeoutChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setRunConfig({ timeoutSecs: parsePositiveInt(e.target.value) });
+    },
+    [setRunConfig]
+  );
+
+  const onSchemaChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const trimmed = e.target.value.trim();
+      setRunConfig({ schemaOverride: trimmed.length > 0 ? trimmed : null });
+    },
+    [setRunConfig]
+  );
+
+  const onReset = useCallback(() => {
+    setRunConfig({
+      maxRows: 100,
+      sandbox: true,
+      schemaOverride: null,
+      timeoutSecs: null,
+    });
+  }, [setRunConfig]);
+
+  const rowCapValue =
+    runConfig.maxRows === null ? "" : String(runConfig.maxRows);
+  const timeoutValue =
+    runConfig.timeoutSecs === null ? "" : String(runConfig.timeoutSecs);
+
+  return (
+    <Popover>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <PopoverTrigger
+              render={
+                <Button
+                  aria-label="Run options"
+                  className="relative"
+                  size="icon-xs"
+                  variant="ghost"
+                >
+                  <Settings2 className="size-3.5" />
+                  {isModified && (
+                    <span
+                      aria-hidden="true"
+                      className="
+                        absolute top-0.5 right-0.5 size-1.5 rounded-full
+                        bg-primary
+                      "
+                    />
+                  )}
+                </Button>
+              }
+            />
+          }
+        />
+        <TooltipContent>Run options</TooltipContent>
+      </Tooltip>
+
+      <PopoverContent align="end" className="w-72 space-y-3 p-3">
+        <div className="flex items-center justify-between">
+          <p className="text-section-label">Run options</p>
+          {isModified && (
+            <button
+              className="
+                text-[11px] text-muted-foreground transition-colors
+                hover:text-foreground
+              "
+              onClick={onReset}
+              type="button"
+            >
+              Reset
+            </button>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label className="flex items-center gap-2 font-normal">
+            <Checkbox
+              checked={runConfig.sandbox}
+              onCheckedChange={onSandboxChange}
+            />
+            Cap rows
+          </Label>
+          {runConfig.sandbox ? (
+            <div className="flex items-center gap-2 pl-6">
+              <Input
+                aria-label="Row cap"
+                className="h-7 w-24"
+                inputMode="numeric"
+                min={1}
+                onChange={onMaxRowsChange}
+                placeholder="100"
+                type="number"
+                value={rowCapValue}
+              />
+              <span className="text-[11px] text-muted-foreground">rows</span>
+            </div>
+          ) : (
+            <p className="pl-6 text-[11px] text-warning">
+              Queries will run uncapped on this connection.
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label className="font-normal" htmlFor="run-config-timeout">
+            Statement timeout
+          </Label>
+          <div className="flex items-center gap-2">
+            <Input
+              className="h-7 w-24"
+              id="run-config-timeout"
+              inputMode="numeric"
+              min={1}
+              onChange={onTimeoutChange}
+              placeholder="No limit"
+              type="number"
+              value={timeoutValue}
+            />
+            <span className="text-[11px] text-muted-foreground">seconds</span>
+          </div>
+        </div>
+
+        {showSchema && (
+          <div className="space-y-1.5">
+            <Label className="font-normal" htmlFor="run-config-schema">
+              Default schema
+            </Label>
+            <Input
+              className="h-7"
+              id="run-config-schema"
+              onChange={onSchemaChange}
+              placeholder="Inherit from database"
+              value={runConfig.schemaOverride ?? ""}
+            />
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/apps/app/src/mainview/components/workspace/workspace-content.tsx
+++ b/apps/app/src/mainview/components/workspace/workspace-content.tsx
@@ -49,6 +49,7 @@ import { QueryErrorDisplay } from "./query-error-display";
 import { QueryStatusBar } from "./query-status-bar";
 import { QueryTabBar } from "./query-tab-bar";
 import { ResultsGrid } from "./results-grid/results-grid";
+import { RunConfigPopover } from "./run-config-popover";
 import { SqlEditor } from "./sql-editor";
 import { SyntaxTreePanel } from "./syntax-tree-panel";
 import { SyntaxTreeToggle } from "./syntax-tree-toggle";
@@ -509,7 +510,7 @@ interface EditorToolbarProps {
   title: string | undefined;
   isSql: boolean;
   sourceDialect: string | null;
-  connectionType: string;
+  connectionType: DatabaseType;
   onDialectChange: (dialect: string) => void;
   isFormatDisabled: boolean;
   onFormat: () => void;
@@ -565,6 +566,7 @@ const EditorToolbar = ({
           )}
         </>
       )}
+      <RunConfigPopover connectionType={connectionType} />
       <ExecuteButton
         isRunning={isRunning}
         disabled={isExecuteDisabled}

--- a/apps/app/src/mainview/components/workspace/workspace-content.tsx
+++ b/apps/app/src/mainview/components/workspace/workspace-content.tsx
@@ -566,7 +566,7 @@ const EditorToolbar = ({
           )}
         </>
       )}
-      <RunConfigPopover connectionType={connectionType} />
+      <RunConfigPopover />
       <ExecuteButton
         isRunning={isRunning}
         disabled={isExecuteDisabled}

--- a/apps/app/src/mainview/components/workspace/workspace-content.tsx
+++ b/apps/app/src/mainview/components/workspace/workspace-content.tsx
@@ -220,7 +220,6 @@ const getResultsPanelProps = (
   executedSql: activeTab?.executedSql ?? null,
   isSql,
   result: activeTab?.result ?? null,
-  runningSql: activeTab?.pendingExecution?.sql ?? null,
   status: activeTab?.status,
 });
 
@@ -471,7 +470,6 @@ const ConnectedWorkspace = ({
 
         <ResizablePanel defaultSize="60%" minSize="20%">
           <EditorToolbar
-            title={activeTab?.title}
             isSql={isSql}
             sourceDialect={activeTab?.sourceDialect ?? null}
             connectionType={connection.type}
@@ -507,7 +505,6 @@ const ConnectedWorkspace = ({
 };
 
 interface EditorToolbarProps {
-  title: string | undefined;
   isSql: boolean;
   sourceDialect: string | null;
   connectionType: DatabaseType;
@@ -526,7 +523,6 @@ interface EditorToolbarProps {
 }
 
 const EditorToolbar = ({
-  title,
   isSql,
   sourceDialect,
   connectionType,
@@ -545,7 +541,6 @@ const EditorToolbar = ({
 }: EditorToolbarProps) => (
   <div className="flex items-center justify-between border-b px-2 py-1">
     <div className="flex items-center gap-2">
-      <span className="text-xs text-muted-foreground">{title}</span>
       {isSql && (
         <DialectSelector
           value={sourceDialect ?? connectionType}
@@ -608,68 +603,57 @@ const SPRING_TRANSITION = {
 } as const;
 const REDUCED_MOTION_TRANSITION = { duration: 0 } as const;
 
-const RunningSqlPreview = ({ sql }: { sql: string }) => (
-  <pre
-    aria-hidden="true"
-    className="
-      max-h-48 max-w-2xl overflow-hidden text-center font-mono text-xs/relaxed
-      wrap-break-word whitespace-pre-wrap text-muted-foreground/60
-    "
-    style={{
-      WebkitMaskImage:
-        "linear-gradient(to bottom, black 55%, transparent 100%)",
-      maskImage: "linear-gradient(to bottom, black 55%, transparent 100%)",
-    }}
-  >
-    {sql.trim()}
-  </pre>
-);
-
-interface RunningStatusBarProps {
+interface RunningQueryViewProps {
   onCancel?: () => void;
 }
 
-const RunningStatusBar = ({ onCancel }: RunningStatusBarProps) => {
+const RunningQueryView = ({ onCancel }: RunningQueryViewProps) => {
   const elapsed = useElapsedMs(true);
   return (
     <div
       aria-live="polite"
       className="
-        relative flex items-center gap-2 overflow-hidden border-t bg-muted/30
-        px-3 py-1.5 text-xs text-muted-foreground
+        flex h-full flex-col items-center justify-center gap-4 px-6 py-8
       "
       role="status"
     >
-      <span
+      <span className="text-sm font-medium text-foreground">Running…</span>
+      <div
         aria-hidden="true"
         className="
-          pointer-events-none absolute inset-y-0 left-0 w-1/3 -translate-x-full
-          bg-linear-to-r from-transparent via-primary/20 to-transparent
-          motion-safe:animate-[query-shimmer_1.8s_ease-in-out_infinite]
+          relative h-px w-24 overflow-hidden rounded-full bg-border/40
           motion-reduce:hidden
         "
-      />
-      <span
-        className="
-          relative inline-flex size-1.5 rounded-full bg-primary
-          motion-safe:animate-pulse
-        "
-      />
-      <span className="relative font-medium text-foreground">Running…</span>
-      <span className="relative tabular-nums">{formatDuration(elapsed)}</span>
-      {onCancel && (
-        <button
+      >
+        <span
           className="
-            relative ml-auto rounded-sm px-2 py-0.5 text-xs
-            text-muted-foreground transition-colors
-            hover:bg-accent hover:text-foreground
+            absolute inset-y-0 left-0 w-1/2 -translate-x-full bg-linear-to-r
+            from-transparent via-primary/70 to-transparent
+            motion-safe:animate-[query-shimmer_1.6s_ease-in-out_infinite]
           "
-          onClick={onCancel}
-          type="button"
-        >
-          Cancel
-        </button>
-      )}
+        />
+      </div>
+      <div
+        className="
+          flex items-center gap-2 text-xs text-muted-foreground
+        "
+      >
+        <span className="tabular-nums">{formatDuration(elapsed)}</span>
+        {onCancel && (
+          <>
+            <span aria-hidden="true">·</span>
+            <button
+              className="
+                rounded-sm transition-colors hover:text-foreground
+              "
+              onClick={onCancel}
+              type="button"
+            >
+              Cancel
+            </button>
+          </>
+        )}
+      </div>
     </div>
   );
 };
@@ -678,7 +662,6 @@ interface ResultsPanelProps {
   status: string | undefined;
   result: ExecuteResult | null;
   executedSql: string | null;
-  runningSql: string | null;
   error: string | null;
   errorCode: string | null;
   isSql: boolean;
@@ -689,7 +672,6 @@ const ResultsPanel = ({
   status,
   result,
   executedSql,
-  runningSql,
   error,
   errorCode,
   isSql,
@@ -745,7 +727,6 @@ const ResultsPanel = ({
     jumpTo,
     onAiFix,
     result,
-    runningSql,
     status,
   });
 
@@ -777,7 +758,6 @@ interface RenderResultsStateArgs {
   jumpTo: ReturnType<typeof useEditorInsert>["jumpTo"];
   onAiFix?: () => void;
   result: ExecuteResult | null;
-  runningSql: string | null;
   status: string | undefined;
 }
 
@@ -793,23 +773,11 @@ const renderResultsState = ({
   jumpTo,
   onAiFix,
   result,
-  runningSql,
   status,
 }: RenderResultsStateArgs): { stateKey: string; content: React.ReactNode } => {
   if (status === "running") {
     return {
-      content: (
-        <div className="flex h-full flex-col">
-          <div
-            className="
-              flex flex-1 items-center justify-center overflow-hidden p-6
-            "
-          >
-            {runningSql && <RunningSqlPreview sql={runningSql} />}
-          </div>
-          <RunningStatusBar onCancel={handleCancel} />
-        </div>
-      ),
+      content: <RunningQueryView onCancel={handleCancel} />,
       stateKey: "running",
     };
   }
@@ -924,7 +892,7 @@ const BottomPanel = ({
     >
       <TabsList variant="segment" className="shrink-0">
         <TabsTrigger value="results">Results</TabsTrigger>
-        {showExplainTab && <TabsTrigger value="explain">EXPLAIN</TabsTrigger>}
+        {showExplainTab && <TabsTrigger value="explain">Explain</TabsTrigger>}
         {isSyntaxTreeOpen && (
           <TabsTrigger value="syntaxTree">Syntax Tree</TabsTrigger>
         )}

--- a/apps/app/src/mainview/contexts/connection-context.tsx
+++ b/apps/app/src/mainview/contexts/connection-context.tsx
@@ -1,10 +1,12 @@
 import type { ReactNode } from "react";
 
-import { createContext, use, useMemo } from "react";
+import { createContext, use, useCallback, useMemo, useState } from "react";
 
 import type { DatabaseConnection } from "@/lib/connections";
+import type { RunConfig } from "@/lib/query-types";
 
 import { useConnectionLifecycle } from "@/hooks/use-connection-lifecycle";
+import { resolveRunConfig, updateConnection } from "@/lib/connections";
 
 interface ConnectionContextValue {
   connection: DatabaseConnection;
@@ -14,6 +16,8 @@ interface ConnectionContextValue {
   error: string | null;
   serverVersion: string | null;
   reconnect: () => void;
+  runConfig: RunConfig;
+  setRunConfig: (partial: Partial<RunConfig>) => void;
 }
 
 const ConnectionContext = createContext<ConnectionContextValue | null>(null);
@@ -25,11 +29,50 @@ export const ConnectionProvider = ({
   connection: DatabaseConnection;
   children: ReactNode;
 }) => {
-  const lifecycle = useConnectionLifecycle(connection);
-  const value = useMemo(
-    () => ({ connection, ...lifecycle }),
-    [connection, lifecycle]
+  const [runConfig, setRunConfigState] = useState<RunConfig>(() =>
+    resolveRunConfig(connection)
   );
+
+  const liveConnection = useMemo<DatabaseConnection>(
+    () => ({ ...connection, runConfig }),
+    [connection, runConfig]
+  );
+
+  const lifecycle = useConnectionLifecycle(liveConnection);
+
+  const persistRunConfig = useCallback(
+    async (next: RunConfig): Promise<void> => {
+      try {
+        await updateConnection({ ...connection, runConfig: next });
+      } catch (error) {
+        console.warn("Couldn't persist runConfig", error);
+      }
+    },
+    [connection]
+  );
+
+  const setRunConfig = useCallback(
+    (partial: Partial<RunConfig>) => {
+      const next = {
+        ...resolveRunConfig({ ...connection, runConfig }),
+        ...partial,
+      };
+      setRunConfigState(next);
+      persistRunConfig(next);
+    },
+    [connection, runConfig, persistRunConfig]
+  );
+
+  const value = useMemo(
+    () => ({
+      connection: liveConnection,
+      runConfig,
+      setRunConfig,
+      ...lifecycle,
+    }),
+    [liveConnection, runConfig, setRunConfig, lifecycle]
+  );
+
   return <ConnectionContext value={value}>{children}</ConnectionContext>;
 };
 

--- a/apps/app/src/mainview/contexts/connection-context.tsx
+++ b/apps/app/src/mainview/contexts/connection-context.tsx
@@ -29,9 +29,15 @@ export const ConnectionProvider = ({
   connection: DatabaseConnection;
   children: ReactNode;
 }) => {
+  const [storedConnectionId, setStoredConnectionId] = useState(connection.id);
   const [runConfig, setRunConfigState] = useState<RunConfig>(() =>
     resolveRunConfig(connection)
   );
+
+  if (storedConnectionId !== connection.id) {
+    setStoredConnectionId(connection.id);
+    setRunConfigState(resolveRunConfig(connection));
+  }
 
   const liveConnection = useMemo<DatabaseConnection>(
     () => ({ ...connection, runConfig }),

--- a/apps/app/src/mainview/hooks/use-query-tabs.ts
+++ b/apps/app/src/mainview/hooks/use-query-tabs.ts
@@ -166,7 +166,9 @@ export const useQueryTabs = (
         );
         continue;
       }
-      execute(tab.id, pending.sql, pending.sourceDialect);
+      execute(tab.id, pending.sql, {
+        sourceDialect: pending.sourceDialect,
+      });
     }
   }, [isRestored, selectedDatabase, execute]);
 
@@ -224,7 +226,7 @@ export const useQueryTabs = (
         tabsRef.current = tabsRef.current.map((t) =>
           t.id === active.id ? replaced : t
         );
-        execute(active.id, sql, active.sourceDialect);
+        execute(active.id, sql, { sourceDialect: active.sourceDialect });
         return;
       }
 
@@ -233,7 +235,7 @@ export const useQueryTabs = (
       setTabs((prev) => [...prev, tab]);
       tabsRef.current = [...tabsRef.current, tab];
       setActiveTabId(tab.id);
-      execute(tab.id, sql, tab.sourceDialect);
+      execute(tab.id, sql, { sourceDialect: tab.sourceDialect });
     },
     [execute]
   );
@@ -309,13 +311,16 @@ export const useQueryTabs = (
   );
 
   const executeTab = useCallback(
-    (tabId: string, sqlOverride?: string, maxRows?: number) => {
+    (tabId: string, sqlOverride?: string, maxRowsOverride?: number) => {
       const tab = tabsRef.current.find((t) => t.id === tabId);
       const sqlToExecute = sqlOverride ?? tab?.sql;
-      if (!sqlToExecute?.trim()) {
+      if (!sqlToExecute?.trim() || !tab) {
         return;
       }
-      execute(tabId, sqlToExecute, tab?.sourceDialect, maxRows);
+      execute(tabId, sqlToExecute, {
+        maxRows: maxRowsOverride,
+        sourceDialect: tab.sourceDialect,
+      });
     },
     [execute]
   );

--- a/apps/app/src/mainview/hooks/use-tab-execution.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-tab-execution.browser.test.tsx
@@ -246,7 +246,6 @@ describe("useTabExecution", () => {
       runConfig: {
         maxRows: 250,
         sandbox: true,
-        schemaOverride: "analytics",
         timeoutSecs: 30,
       },
     };
@@ -275,7 +274,7 @@ describe("useTabExecution", () => {
     const [[payload]] = executeHandler.mock.calls;
     const params = payload.params as Record<string, unknown>;
     expect(params.maxRows).toBe(250);
-    expect(params.schema).toBe("analytics");
+    expect(params.schema).toBe("public");
     expect(params.timeoutSecs).toBe(30);
   });
 

--- a/apps/app/src/mainview/hooks/use-tab-execution.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-tab-execution.browser.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DatabaseConnection } from "@/lib/connections";
 import type { QueryTab } from "@/lib/query-types";
@@ -6,7 +6,7 @@ import type { QueryTab } from "@/lib/query-types";
 import { renderHook, waitFor } from "@/test/render-hook";
 import { mockTauri } from "@/test/tauri-mock";
 
-const fakeConnection: DatabaseConnection = {
+const baseConnection: DatabaseConnection = {
   createdAt: "2024-01-01T00:00:00.000Z",
   database: "app",
   host: "localhost",
@@ -20,22 +20,30 @@ const fakeConnection: DatabaseConnection = {
   username: "postgres",
 };
 
+// oxlint-disable-next-line prefer-const, jest/require-hook
+let activeConnection: DatabaseConnection = baseConnection;
+
 const confirmMock = vi.fn(async (_sql: string) => {
   await Promise.resolve();
   return true;
 });
 
-vi.mock(import("@/contexts/connection-context"), () => ({
-  useConnection: () => ({
-    connection: fakeConnection,
-    error: null,
-    isConnected: true,
-    isConnecting: false,
-    isReconnecting: false,
-    reconnect: vi.fn(),
-    serverVersion: null,
-  }),
-}));
+vi.mock(import("@/contexts/connection-context"), async () => {
+  const { resolveRunConfig } = await import("@/lib/connections");
+  return {
+    useConnection: () => ({
+      connection: activeConnection,
+      error: null,
+      isConnected: true,
+      isConnecting: false,
+      isReconnecting: false,
+      reconnect: vi.fn(),
+      runConfig: resolveRunConfig(activeConnection),
+      serverVersion: null,
+      setRunConfig: vi.fn(),
+    }),
+  };
+});
 
 vi.mock(import("@/contexts/safe-mode-context"), () => ({
   useSafeMode: () => ({
@@ -87,6 +95,10 @@ const flushSave = vi.fn(async () => {
 });
 
 describe("useTabExecution", () => {
+  beforeEach(() => {
+    activeConnection = baseConnection;
+  });
+
   it("runs a successful query and updates the tab result", async () => {
     mockTauri({
       executeQuery: () => ({
@@ -226,6 +238,109 @@ describe("useTabExecution", () => {
       connectionType: "postgresql",
       environment: undefined,
     });
+  });
+
+  it("forwards connection runConfig to executeQuery", async () => {
+    activeConnection = {
+      ...baseConnection,
+      runConfig: {
+        maxRows: 250,
+        sandbox: true,
+        schemaOverride: "analytics",
+        timeoutSecs: 30,
+      },
+    };
+    const executeHandler = vi.fn((_payload: Record<string, unknown>) => ({
+      columns: [],
+      executionTimeMs: 0,
+      isTruncated: false,
+      resultType: "tabular" as const,
+      rowCount: 0,
+      rows: [],
+    }));
+    mockTauri({ executeQuery: executeHandler });
+
+    const { setTabs } = makeSetTabs([makeTab()]);
+    const { result } = renderHook(() =>
+      useTabExecution({
+        connectionId: "conn-1",
+        flushSave,
+        selectedDatabase: "public",
+        setTabs,
+      })
+    );
+
+    await result.current.execute("tab-1", "SELECT 1");
+
+    const [[payload]] = executeHandler.mock.calls;
+    const params = payload.params as Record<string, unknown>;
+    expect(params.maxRows).toBe(250);
+    expect(params.schema).toBe("analytics");
+    expect(params.timeoutSecs).toBe(30);
+  });
+
+  it("passes null maxRows when connection sandbox is off", async () => {
+    activeConnection = {
+      ...baseConnection,
+      runConfig: { sandbox: false },
+    };
+    const executeHandler = vi.fn((_payload: Record<string, unknown>) => ({
+      columns: [],
+      executionTimeMs: 0,
+      isTruncated: false,
+      resultType: "tabular" as const,
+      rowCount: 0,
+      rows: [],
+    }));
+    mockTauri({ executeQuery: executeHandler });
+
+    const { setTabs } = makeSetTabs([makeTab()]);
+    const { result } = renderHook(() =>
+      useTabExecution({
+        connectionId: "conn-1",
+        flushSave,
+        selectedDatabase: "public",
+        setTabs,
+      })
+    );
+
+    await result.current.execute("tab-1", "SELECT 1");
+
+    const [[payload]] = executeHandler.mock.calls;
+    const params = payload.params as Record<string, unknown>;
+    expect(params.maxRows).toBeNull();
+  });
+
+  it("respects per-call maxRows override", async () => {
+    activeConnection = {
+      ...baseConnection,
+      runConfig: { maxRows: 100, sandbox: true },
+    };
+    const executeHandler = vi.fn((_payload: Record<string, unknown>) => ({
+      columns: [],
+      executionTimeMs: 0,
+      isTruncated: false,
+      resultType: "tabular" as const,
+      rowCount: 0,
+      rows: [],
+    }));
+    mockTauri({ executeQuery: executeHandler });
+
+    const { setTabs } = makeSetTabs([makeTab()]);
+    const { result } = renderHook(() =>
+      useTabExecution({
+        connectionId: "conn-1",
+        flushSave,
+        selectedDatabase: "public",
+        setTabs,
+      })
+    );
+
+    await result.current.execute("tab-1", "SELECT 1", { maxRows: 5000 });
+
+    const [[payload]] = executeHandler.mock.calls;
+    const params = payload.params as Record<string, unknown>;
+    expect(params.maxRows).toBe(5000);
   });
 
   it("forwards cancel() to cancel_query", async () => {

--- a/apps/app/src/mainview/hooks/use-tab-execution.ts
+++ b/apps/app/src/mainview/hooks/use-tab-execution.ts
@@ -67,7 +67,7 @@ export const useTabExecution = ({
       const maxRows =
         options?.maxRows === undefined ? sandboxedMaxRows : options.maxRows;
       const { timeoutSecs } = runConfig;
-      const schema = runConfig.schemaOverride ?? selectedDatabase ?? undefined;
+      const schema = selectedDatabase ?? undefined;
 
       const confirmed = await requestConfirmation(sql, {
         connectionName: connection.name,

--- a/apps/app/src/mainview/hooks/use-tab-execution.ts
+++ b/apps/app/src/mainview/hooks/use-tab-execution.ts
@@ -4,6 +4,7 @@ import type { QueryTab } from "@/lib/query-types";
 
 import { useConnection } from "@/contexts/connection-context";
 import { useSafeMode } from "@/contexts/safe-mode-context";
+import { resolveRunConfig } from "@/lib/connections";
 import { appendHistory, HISTORY_UPDATED_EVENT } from "@/lib/persistence";
 import { cancelQuery, executeQuery } from "@/lib/tauri";
 
@@ -43,6 +44,11 @@ interface UseTabExecutionParams {
   flushSave: () => Promise<void>;
 }
 
+export interface ExecuteOptions {
+  sourceDialect?: string | null;
+  maxRows?: number | null;
+}
+
 export const useTabExecution = ({
   connectionId,
   selectedDatabase,
@@ -54,12 +60,15 @@ export const useTabExecution = ({
   const { connection } = useConnection();
 
   const execute = useCallback(
-    async (
-      tabId: string,
-      sql: string,
-      sourceDialect?: string | null,
-      maxRows?: number
-    ) => {
+    async (tabId: string, sql: string, options?: ExecuteOptions) => {
+      const sourceDialect = options?.sourceDialect ?? null;
+      const runConfig = resolveRunConfig(connection);
+      const sandboxedMaxRows = runConfig.sandbox ? runConfig.maxRows : null;
+      const maxRows =
+        options?.maxRows === undefined ? sandboxedMaxRows : options.maxRows;
+      const { timeoutSecs } = runConfig;
+      const schema = runConfig.schemaOverride ?? selectedDatabase ?? undefined;
+
       const confirmed = await requestConfirmation(sql, {
         connectionName: connection.name,
         connectionType: connection.type,
@@ -81,7 +90,7 @@ export const useTabExecution = ({
                 executedSql: null,
                 pendingExecution: {
                   database: selectedDatabase,
-                  sourceDialect: sourceDialect ?? null,
+                  sourceDialect,
                   sql,
                   startedAt,
                 },
@@ -104,11 +113,12 @@ export const useTabExecution = ({
       try {
         const result = await executeQuery({
           connectionId,
-          maxRows,
+          maxRows: maxRows ?? null,
           queryId,
-          schema: selectedDatabase ?? undefined,
+          schema,
           sourceDialect: sourceDialect ?? undefined,
           sql,
+          timeoutSecs: timeoutSecs ?? null,
         });
         ({ executionTimeMs } = result);
         success = true;
@@ -176,9 +186,7 @@ export const useTabExecution = ({
       }
     },
     [
-      connection.environment,
-      connection.name,
-      connection.type,
+      connection,
       connectionId,
       selectedDatabase,
       setTabs,

--- a/apps/app/src/mainview/hooks/use-tab-execution.ts
+++ b/apps/app/src/mainview/hooks/use-tab-execution.ts
@@ -118,7 +118,7 @@ export const useTabExecution = ({
           schema,
           sourceDialect: sourceDialect ?? undefined,
           sql,
-          timeoutSecs: timeoutSecs ?? null,
+          timeoutSecs,
         });
         ({ executionTimeMs } = result);
         success = true;

--- a/apps/app/src/mainview/hooks/use-tab-explain.ts
+++ b/apps/app/src/mainview/hooks/use-tab-explain.ts
@@ -2,6 +2,8 @@ import { useCallback } from "react";
 
 import type { QueryTab } from "@/lib/query-types";
 
+import { useConnection } from "@/contexts/connection-context";
+import { resolveRunConfig } from "@/lib/connections";
 import { cancelQuery, explainQuery } from "@/lib/tauri";
 
 const isCancellationError = (error: unknown): boolean => {
@@ -42,6 +44,8 @@ export const useTabExplain = ({
   selectedDatabase,
   setTabs,
 }: UseTabExplainParams) => {
+  const { connection } = useConnection();
+
   const explain = useCallback(
     async (
       tabId: string,
@@ -49,6 +53,10 @@ export const useTabExplain = ({
       sourceDialect: string | null,
       analyze: boolean
     ) => {
+      const runConfig = resolveRunConfig(connection);
+      const schema = runConfig.schemaOverride ?? selectedDatabase ?? undefined;
+      const { timeoutSecs } = runConfig;
+
       const queryId = crypto.randomUUID();
       setTabs((prev) =>
         prev.map((t) =>
@@ -69,9 +77,10 @@ export const useTabExplain = ({
           analyze,
           connectionId,
           queryId,
-          schema: selectedDatabase ?? undefined,
+          schema,
           sourceDialect: sourceDialect ?? undefined,
           sql,
+          timeoutSecs,
         });
         setTabs((prev) =>
           prev.map((t) =>
@@ -105,7 +114,7 @@ export const useTabExplain = ({
         );
       }
     },
-    [connectionId, selectedDatabase, setTabs]
+    [connection, connectionId, selectedDatabase, setTabs]
   );
 
   const cancel = useCallback(async (queryId: string) => {

--- a/apps/app/src/mainview/hooks/use-tab-explain.ts
+++ b/apps/app/src/mainview/hooks/use-tab-explain.ts
@@ -54,7 +54,7 @@ export const useTabExplain = ({
       analyze: boolean
     ) => {
       const runConfig = resolveRunConfig(connection);
-      const schema = runConfig.schemaOverride ?? selectedDatabase ?? undefined;
+      const schema = selectedDatabase ?? undefined;
       const { timeoutSecs } = runConfig;
 
       const queryId = crypto.randomUUID();

--- a/apps/app/src/mainview/lib/connections.ts
+++ b/apps/app/src/mainview/lib/connections.ts
@@ -1,9 +1,11 @@
 import type { DatabaseConnection as IpcDatabaseConnection } from "@/lib/ipc";
+import type { RunConfig } from "@/lib/query-types";
 
 import {
   getConnections as ipcGetConnections,
   saveConnections as ipcSaveConnections,
 } from "@/lib/ipc";
+import { DEFAULT_RUN_CONFIG } from "@/lib/query-types";
 
 export type DatabaseType =
   | "postgresql"
@@ -34,6 +36,7 @@ export interface DatabaseConnection extends Omit<
   environment?: ConnectionEnvironment;
   piiRedaction?: boolean;
   customPiiPatterns?: string[];
+  runConfig?: Partial<RunConfig>;
 }
 
 export const DEFAULT_PORTS: Record<DatabaseType, number> = {
@@ -118,6 +121,16 @@ export const markConnectionUsed = async (id: string): Promise<void> => {
   );
   await writeConnections(connections);
 };
+
+export const resolveRunConfig = (
+  connection: DatabaseConnection
+): RunConfig => ({
+  ...DEFAULT_RUN_CONFIG,
+  ...connection.runConfig,
+});
+
+export const supportsSchemaOverride = (type: DatabaseType): boolean =>
+  type !== "mongodb" && type !== "redis";
 
 export const isPiiRedactionEnabled = (
   connection: DatabaseConnection

--- a/apps/app/src/mainview/lib/connections.ts
+++ b/apps/app/src/mainview/lib/connections.ts
@@ -122,15 +122,13 @@ export const markConnectionUsed = async (id: string): Promise<void> => {
   await writeConnections(connections);
 };
 
-export const resolveRunConfig = (
-  connection: DatabaseConnection
-): RunConfig => ({
-  ...DEFAULT_RUN_CONFIG,
-  ...connection.runConfig,
-});
-
-export const supportsSchemaOverride = (type: DatabaseType): boolean =>
-  type !== "mongodb" && type !== "redis";
+export const resolveRunConfig = (connection: DatabaseConnection): RunConfig => {
+  const merged = { ...DEFAULT_RUN_CONFIG, ...connection.runConfig };
+  return {
+    ...merged,
+    timeoutSecs: merged.timeoutSecs ?? DEFAULT_RUN_CONFIG.timeoutSecs,
+  };
+};
 
 export const isPiiRedactionEnabled = (
   connection: DatabaseConnection

--- a/apps/app/src/mainview/lib/query-types.ts
+++ b/apps/app/src/mainview/lib/query-types.ts
@@ -9,13 +9,11 @@ export interface RunConfig {
   sandbox: boolean;
   maxRows: number | null;
   timeoutSecs: number;
-  schemaOverride: string | null;
 }
 
 export const DEFAULT_RUN_CONFIG: RunConfig = {
   maxRows: 100,
   sandbox: true,
-  schemaOverride: null,
   timeoutSecs: 30,
 };
 

--- a/apps/app/src/mainview/lib/query-types.ts
+++ b/apps/app/src/mainview/lib/query-types.ts
@@ -8,7 +8,7 @@ export type ExplainDensity = "comfortable" | "compact";
 export interface RunConfig {
   sandbox: boolean;
   maxRows: number | null;
-  timeoutSecs: number | null;
+  timeoutSecs: number;
   schemaOverride: string | null;
 }
 
@@ -16,7 +16,7 @@ export const DEFAULT_RUN_CONFIG: RunConfig = {
   maxRows: 100,
   sandbox: true,
   schemaOverride: null,
-  timeoutSecs: null,
+  timeoutSecs: 30,
 };
 
 export interface QueryTab {

--- a/apps/app/src/mainview/lib/query-types.ts
+++ b/apps/app/src/mainview/lib/query-types.ts
@@ -5,6 +5,20 @@ export type TabStatus = "idle" | "running" | "success" | "error";
 
 export type ExplainDensity = "comfortable" | "compact";
 
+export interface RunConfig {
+  sandbox: boolean;
+  maxRows: number | null;
+  timeoutSecs: number | null;
+  schemaOverride: string | null;
+}
+
+export const DEFAULT_RUN_CONFIG: RunConfig = {
+  maxRows: 100,
+  sandbox: true,
+  schemaOverride: null,
+  timeoutSecs: null,
+};
+
 export interface QueryTab {
   id: string;
   title: string;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -31,6 +31,7 @@ export type {
   DatabaseConnection,
   HistoryEntry,
   HistoryFilters,
+  PersistedRunConfig,
   PersistedTab,
   TabState,
 } from "./persistence.ts";

--- a/packages/core/src/persistence.ts
+++ b/packages/core/src/persistence.ts
@@ -13,6 +13,13 @@ import {
 const MAX_HISTORY_ENTRIES = 10_000;
 const DEFAULT_ALL_HISTORY_LIMIT = 500;
 
+export interface PersistedRunConfig {
+  sandbox?: boolean;
+  maxRows?: number | null;
+  timeoutSecs?: number | null;
+  schemaOverride?: string | null;
+}
+
 export interface PersistedTab {
   id: string;
   title: string;
@@ -67,6 +74,7 @@ export interface DatabaseConnection {
   environment?: string;
   piiRedaction?: boolean;
   customPiiPatterns?: string[];
+  runConfig?: PersistedRunConfig;
 }
 
 const fileLocks = new Map<string, Promise<unknown>>();

--- a/packages/core/src/persistence.ts
+++ b/packages/core/src/persistence.ts
@@ -17,7 +17,6 @@ export interface PersistedRunConfig {
   sandbox?: boolean;
   maxRows?: number | null;
   timeoutSecs?: number | null;
-  schemaOverride?: string | null;
 }
 
 export interface PersistedTab {


### PR DESCRIPTION
## Summary

- Adds a settings-icon popover next to the Execute button in the editor toolbar. Click it to set: row-cap toggle + cap value, statement timeout, default schema (Postgres `search_path`, MySQL/MSSQL active database; the schema row is hidden for Mongo and Redis).
- Settings live on `DatabaseConnection.runConfig` and persist on every change via `setRunConfig` in the connection context. One setting per connection — applies across every tab.
- A small amber dot on the trigger flags a non-default config so you can tell at a glance.
- `useTabExecution` and `useTabExplain` resolve the merged config from `useConnection()` and forward `maxRows` / `timeoutSecs` / `schema` to RPC. RPC contract unchanged.

Closes [OMQ-23](https://linear.app/oh-my-query/issue/OMQ-23) / #109.

## Test plan

- [x] `bun run check-types`
- [x] `bun run check`
- [x] `bun run --cwd apps/app test` (140 files, 918 tests)
- [ ] Smoke in `desktop:dev`: open the run-options popover from the editor toolbar → toggle the row cap, set a custom value, set a timeout, set a schema override; confirm the trigger gets an amber dot when non-default; quit + relaunch → config restored on the same connection; switch to a Mongo connection → schema field hidden; open a second tab on the same connection → the cap applies there too.