### PR TITLE
Fix Redis connect probe; refine query tab bar (max width, drag-to-reorder)

### DIFF
--- a/apps/app/src/mainview/components/workspace/query-tab-bar.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/query-tab-bar.browser.test.tsx
@@ -35,6 +35,7 @@ const renderBar = (
       activeTabId={overrides.activeTabId ?? "t1"}
       onAddTab={overrides.onAddTab ?? vi.fn()}
       onCloseTab={overrides.onCloseTab ?? vi.fn()}
+      onReorderTabs={overrides.onReorderTabs ?? vi.fn()}
       onSelectTab={overrides.onSelectTab ?? vi.fn()}
       tabs={
         overrides.tabs ?? [
@@ -99,6 +100,7 @@ describe("query-tab-bar", () => {
           activeTabId="t1"
           onAddTab={vi.fn()}
           onCloseTab={vi.fn()}
+          onReorderTabs={vi.fn()}
           onSelectTab={vi.fn()}
           tabs={[tab({ status })]}
         />

--- a/apps/app/src/mainview/components/workspace/query-tab-bar.tsx
+++ b/apps/app/src/mainview/components/workspace/query-tab-bar.tsx
@@ -1,5 +1,6 @@
 import { Plus, X } from "lucide-react";
-import { useCallback } from "react";
+import { Reorder, useReducedMotion } from "motion/react";
+import { useCallback, useMemo } from "react";
 
 import type { QueryTab, TabStatus } from "@/lib/query-types";
 
@@ -25,12 +26,24 @@ const statusDotClass: Partial<Record<TabStatus, string>> = {
   success: "bg-foreground/40",
 };
 
+const REORDER_SPRING = {
+  damping: 38,
+  stiffness: 700,
+  type: "spring",
+} as const;
+
+const DRAG_LIFT = {
+  scale: 1.02,
+  transition: { damping: 30, stiffness: 600, type: "spring" },
+} as const;
+
 interface QueryTabBarProps {
   tabs: QueryTab[];
   activeTabId: string;
   onSelectTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => void;
   onAddTab: () => void;
+  onReorderTabs: (orderedIds: string[]) => void;
 }
 
 interface TabCloseButtonProps {
@@ -48,6 +61,13 @@ const TabCloseButton = ({ tabTitle, tabId, onClose }: TabCloseButtonProps) => {
     [onClose, tabId]
   );
 
+  // Stop the native pointerdown from reaching motion's drag listener on the
+  // parent Reorder.Item — without this, clicking close starts a drag.
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    e.stopPropagation();
+    e.nativeEvent.stopImmediatePropagation();
+  }, []);
+
   return (
     <button
       aria-label={`Close ${tabTitle}`}
@@ -59,6 +79,7 @@ const TabCloseButton = ({ tabTitle, tabId, onClose }: TabCloseButtonProps) => {
         focus-visible:outline-none
       "
       onClick={handleClick}
+      onPointerDown={handlePointerDown}
       title={`Close ${tabTitle} (⌘W)`}
       type="button"
     >
@@ -73,7 +94,11 @@ export const QueryTabBar = ({
   onSelectTab,
   onCloseTab,
   onAddTab,
+  onReorderTabs,
 }: QueryTabBarProps) => {
+  const reduceMotion = useReducedMotion();
+  const tabIds = useMemo(() => tabs.map((t) => t.id), [tabs]);
+
   const handleValueChange = useCallback(
     (value: unknown) => {
       onSelectTab(value as string);
@@ -88,38 +113,70 @@ export const QueryTabBar = ({
       className="gap-0"
     >
       <div className="flex items-center border-b">
-        <TabsList variant="segment" className="flex-1">
-          {tabs.map((tab) => (
-            <TabsTrigger
-              key={tab.id}
-              value={tab.id}
-              className="group/tab"
-              aria-description={statusDescription[tab.status] || undefined}
-            >
-              {statusDotClass[tab.status] ? (
-                <span className={`
+        <div
+          className="
+            min-w-0 flex-1 overflow-x-auto
+            [scrollbar-width:none]
+            [&::-webkit-scrollbar]:hidden
+          "
+        >
+          <TabsList
+            variant="segment"
+            render={
+              <Reorder.Group
+                as="div"
+                axis="x"
+                values={tabIds}
+                onReorder={onReorderTabs}
+              />
+            }
+          >
+            {tabs.map((tab) => (
+              <TabsTrigger
+                key={tab.id}
+                value={tab.id}
+                className="
+                  group/tab max-w-[14rem]
+                  min-w-[7rem] !flex-none
+                  cursor-grab active:cursor-grabbing
+                "
+                aria-description={statusDescription[tab.status] || undefined}
+                render={
+                  <Reorder.Item
+                    as="button"
+                    value={tab.id}
+                    dragElastic={0.08}
+                    dragMomentum={false}
+                    transition={reduceMotion ? { duration: 0 } : REORDER_SPRING}
+                    whileDrag={reduceMotion ? undefined : DRAG_LIFT}
+                  />
+                }
+              >
+                {statusDotClass[tab.status] ? (
+                  <span className={`
                     inline-block size-1.5 shrink-0 rounded-full
                     ${statusDotClass[tab.status]}
                   `} />
-              ) : (
-                isTabDirty(tab) && (
-                  <span
-                    className="
+                ) : (
+                  isTabDirty(tab) && (
+                    <span
+                      className="
                       inline-block size-1.5 shrink-0 rounded-full
                       bg-foreground/25
                     "
-                  />
-                )
-              )}
-              <span className="max-w-30 truncate">{tab.title}</span>
-              <TabCloseButton
-                tabTitle={tab.title}
-                tabId={tab.id}
-                onClose={onCloseTab}
-              />
-            </TabsTrigger>
-          ))}
-        </TabsList>
+                    />
+                  )
+                )}
+                <span className="max-w-30 truncate">{tab.title}</span>
+                <TabCloseButton
+                  tabTitle={tab.title}
+                  tabId={tab.id}
+                  onClose={onCloseTab}
+                />
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </div>
         <Tooltip>
           <TooltipTrigger
             render={

--- a/apps/app/src/mainview/components/workspace/redis/keys-panel.tsx
+++ b/apps/app/src/mainview/components/workspace/redis/keys-panel.tsx
@@ -5,6 +5,7 @@ import type { RedisKey } from "@/lib/tauri";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useConnection } from "@/contexts/connection-context";
 import { useEditorInsert } from "@/contexts/editor-insert-context";
 import {
   redisInspectCommand,
@@ -61,6 +62,7 @@ export const KeysPanel = ({
   isActiveTab,
 }: KeysPanelProps) => {
   const { openQueryAndRun } = useEditorInsert();
+  const { isConnected } = useConnection();
 
   const {
     dbInfo,
@@ -78,7 +80,7 @@ export const KeysPanel = ({
   } = useRedisKeyspace({
     connectionId: connection.id,
     dbIndex,
-    isConnected: true,
+    isConnected,
   });
 
   const [activeRowId, setActiveRowId] = useState<string | null>(null);

--- a/apps/app/src/mainview/components/workspace/workspace-content.tsx
+++ b/apps/app/src/mainview/components/workspace/workspace-content.tsx
@@ -240,6 +240,7 @@ const ConnectedWorkspace = ({
     closeTab,
     explainTab,
     reopenTab,
+    reorderTabs,
     setActiveTabId,
     updateTabDialect,
     updateTabSql,
@@ -443,6 +444,7 @@ const ConnectedWorkspace = ({
         onSelectTab={setActiveTabId}
         onCloseTab={closeTab}
         onAddTab={addTab}
+        onReorderTabs={reorderTabs}
       />
 
       <ResizablePanelGroup className="min-h-0 flex-1" orientation="vertical">

--- a/apps/app/src/mainview/contexts/query-tabs-context.tsx
+++ b/apps/app/src/mainview/contexts/query-tabs-context.tsx
@@ -13,6 +13,7 @@ interface QueryTabsContextValue {
   addTabWithSqlAndRun: (sql: string) => void;
   closeTab: (tabId: string) => void;
   reopenTab: () => void;
+  reorderTabs: (orderedIds: string[]) => void;
   setActiveTabId: (id: string) => void;
   updateTabDialect: (tabId: string, dialect: string | null) => void;
   updateTabSql: (tabId: string, sql: string) => void;

--- a/apps/app/src/mainview/hooks/use-query-tabs.ts
+++ b/apps/app/src/mainview/hooks/use-query-tabs.ts
@@ -301,6 +301,24 @@ export const useQueryTabs = (
     setTabs((prev) => prev.map((t) => (t.id === tabId ? { ...t, sql } : t)));
   }, []);
 
+  const reorderTabs = useCallback((orderedIds: string[]) => {
+    setTabs((prev) => {
+      if (orderedIds.length !== prev.length) {
+        return prev;
+      }
+      const byId = new Map(prev.map((t) => [t.id, t]));
+      const next: QueryTab[] = [];
+      for (const id of orderedIds) {
+        const tab = byId.get(id);
+        if (!tab) {
+          return prev;
+        }
+        next.push(tab);
+      }
+      return next;
+    });
+  }, []);
+
   const updateTabDialect = useCallback(
     (tabId: string, dialect: string | null) => {
       setTabs((prev) =>
@@ -404,6 +422,7 @@ export const useQueryTabs = (
     onCancelClose,
     onConfirmClose,
     reopenTab,
+    reorderTabs,
     setActiveTabId,
     setExplainAnalyze,
     setExplainDensity,

--- a/packages/drivers-redis/src/driver.test.ts
+++ b/packages/drivers-redis/src/driver.test.ts
@@ -30,6 +30,7 @@ const params = (overrides: Partial<ConnectionParams> = {}): ConnectionParams =>
   }) as ConnectionParams;
 
 interface FakeClient {
+  connect: ReturnType<typeof vi.fn>;
   ping: ReturnType<typeof vi.fn>;
   quit: ReturnType<typeof vi.fn>;
   disconnect: ReturnType<typeof vi.fn>;
@@ -43,6 +44,9 @@ const defaultPing = async () => {
 const buildFakeClient = (
   pingImpl: () => Promise<unknown> = defaultPing
 ): FakeClient => ({
+  connect: vi.fn(async () => {
+    await Promise.resolve();
+  }),
   disconnect: vi.fn(),
   ping: vi.fn(pingImpl),
   quit: vi.fn(async () => {
@@ -136,7 +140,25 @@ describe("redisDriver.testConnection", () => {
     expect(result.success).toBeTruthy();
     expect(result.latencyMs).toBeGreaterThanOrEqual(0);
     expect(result.message.toLowerCase()).toContain("redis");
+    expect(fake.connect).toHaveBeenCalledOnce();
     expect(fake.ping).toHaveBeenCalledOnce();
+  });
+
+  it("rejects with DbError and tears down the client when connect fails", async () => {
+    const fake = buildFakeClient();
+    fake.connect.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    RedisMock.mockImplementation(stubReturn(fake));
+
+    let caught: unknown;
+    try {
+      await new RedisDriver().testConnection(params());
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(DbError);
+    expect((caught as DbError).message).toBe("ECONNREFUSED");
+    expect(fake.ping).not.toHaveBeenCalled();
+    expect(fake.quit).toHaveBeenCalledWith();
   });
 
   it("quits the client after a successful probe", async () => {
@@ -198,8 +220,26 @@ describe("redisDriver.connect", () => {
 
     const pool = await new RedisDriver().connect("conn-1", params());
     expect(pool).toBeInstanceOf(RedisPool);
+    expect(fake.connect).toHaveBeenCalledOnce();
     expect(fake.ping).toHaveBeenCalledOnce();
     expect(fake.quit).not.toHaveBeenCalled();
+  });
+
+  it("rejects with DbError and tears down the client when connect fails", async () => {
+    const fake = buildFakeClient();
+    fake.connect.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    RedisMock.mockImplementation(stubReturn(fake));
+
+    let caught: unknown;
+    try {
+      await new RedisDriver().connect("conn-1", params());
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(DbError);
+    expect((caught as DbError).message).toBe("ECONNREFUSED");
+    expect(fake.ping).not.toHaveBeenCalled();
+    expect(fake.quit).toHaveBeenCalledWith();
   });
 
   it("rejects with DbError and tears down the client when the probe fails", async () => {

--- a/packages/drivers-redis/src/driver.ts
+++ b/packages/drivers-redis/src/driver.ts
@@ -7,19 +7,9 @@ import type {
 
 import Redis from "ioredis";
 
-import { mapRedisError, RedisPool } from "./pool";
+import { mapRedisError, parseDbIndex, RedisPool } from "./pool";
 
-export function parseDbIndex(database: string | undefined): number {
-  const trimmed = database?.trim();
-  if (!trimmed) {
-    return 0;
-  }
-  const parsed = Number.parseInt(trimmed, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return 0;
-  }
-  return parsed;
-}
+export { parseDbIndex } from "./pool.ts";
 
 function createClient(params: ConnectionParams, connectionName: string): Redis {
   const db = parseDbIndex(params.database);

--- a/packages/drivers-redis/src/driver.ts
+++ b/packages/drivers-redis/src/driver.ts
@@ -65,6 +65,7 @@ export class RedisDriver implements Driver {
     const start = performance.now();
     const client = openClient(params, this.dbType);
     try {
+      await client.connect();
       await client.ping();
       return {
         latencyMs: Math.round(performance.now() - start),
@@ -81,6 +82,7 @@ export class RedisDriver implements Driver {
   async connect(_id: string, params: ConnectionParams): Promise<Pool> {
     const client = openClient(params, this.dbType);
     try {
+      await client.connect();
       await client.ping();
     } catch (error) {
       await safeQuit(client);

--- a/packages/drivers-redis/src/pool.test.ts
+++ b/packages/drivers-redis/src/pool.test.ts
@@ -7,6 +7,7 @@ import {
   deleteRedisKey,
   isRedisPool,
   mapRedisError,
+  parseRedisCommands,
   redisDbInfo,
   RedisPool,
   scanRedisKeys,
@@ -66,6 +67,7 @@ interface FakeClient {
   dbsize: ReturnType<typeof vi.fn>;
   scan: ReturnType<typeof vi.fn>;
   del: ReturnType<typeof vi.fn>;
+  call: ReturnType<typeof vi.fn>;
   pipeline: ReturnType<typeof vi.fn>;
   pendingPipelines: FakePipeline[];
 }
@@ -73,6 +75,7 @@ interface FakeClient {
 const buildFakeClient = (): FakeClient => {
   const pendingPipelines: FakePipeline[] = [];
   return {
+    call: vi.fn(),
     config: vi.fn(),
     dbsize: vi.fn(),
     del: vi.fn(),
@@ -210,23 +213,270 @@ describe("redisPool > fetchSchema", () => {
   });
 });
 
-describe("redisPool > execute / explain", () => {
-  it("execute rejects with UNSUPPORTED", async () => {
-    const { pool } = buildPool();
-    const err = await pool
-      .execute("KEYS *", 100, null, new AbortController().signal)
-      .catch((error: unknown) => error);
-    expect(err).toBeInstanceOf(DbError);
-    expect((err as DbError).code).toBe("UNSUPPORTED");
+describe("redisPool > execute", () => {
+  it("runs a single command via client.call and returns one document", async () => {
+    const { client, pool } = buildPool();
+    client.call.mockResolvedValueOnce("hello");
+    const result = await pool.execute(
+      "GET greeting",
+      100,
+      null,
+      new AbortController().signal
+    );
+    expect(client.call).toHaveBeenCalledWith("GET", "greeting");
+    expect(result).toStrictEqual({
+      count: 1,
+      documents: [{ command: "GET greeting", reply: "hello" }],
+      executionTimeMs: 0,
+      isTruncated: false,
+      resultType: "documents",
+    });
   });
 
-  it("explain rejects with UNSUPPORTED", async () => {
+  it("runs multi-line input as separate commands in order", async () => {
+    const { client, pool } = buildPool();
+    client.call
+      .mockResolvedValueOnce("OK")
+      .mockResolvedValueOnce("1")
+      .mockResolvedValueOnce(2);
+    const result = await pool.execute(
+      "SET a 1\nGET a\nINCR counter",
+      100,
+      null,
+      new AbortController().signal
+    );
+    expect(client.call.mock.calls).toStrictEqual([
+      ["SET", "a", "1"],
+      ["GET", "a"],
+      ["INCR", "counter"],
+    ]);
+    expect(result).toStrictEqual({
+      count: 3,
+      documents: [
+        { command: "SET a 1", reply: "OK" },
+        { command: "GET a", reply: "1" },
+        { command: "INCR counter", reply: 2 },
+      ],
+      executionTimeMs: 0,
+      isTruncated: false,
+      resultType: "documents",
+    });
+  });
+
+  it("preserves quoted args containing whitespace", async () => {
+    const { client, pool } = buildPool();
+    client.call.mockResolvedValueOnce("OK");
+    await pool.execute(
+      'SET "user:1" "John Doe"',
+      100,
+      null,
+      new AbortController().signal
+    );
+    expect(client.call).toHaveBeenCalledWith("SET", "user:1", "John Doe");
+  });
+
+  it("supports escape sequences inside double quotes", async () => {
+    const { client, pool } = buildPool();
+    client.call.mockResolvedValueOnce("OK");
+    await pool.execute(
+      'SET key "line1\\nline2"',
+      100,
+      null,
+      new AbortController().signal
+    );
+    expect(client.call).toHaveBeenCalledWith("SET", "key", "line1\nline2");
+  });
+
+  it("ignores blank lines and # / // comment lines", async () => {
+    const { client, pool } = buildPool();
+    client.call.mockResolvedValueOnce("hello");
+    await pool.execute(
+      "# header\n\n// note\nGET greeting",
+      100,
+      null,
+      new AbortController().signal
+    );
+    expect(client.call).toHaveBeenCalledOnce();
+    expect(client.call).toHaveBeenCalledWith("GET", "greeting");
+  });
+
+  it("rejects empty / comment-only input with INVALID_COMMAND", async () => {
+    const { pool } = buildPool();
+    const err = await pool
+      .execute(
+        "  \n# only a comment\n",
+        100,
+        null,
+        new AbortController().signal
+      )
+      .catch((error: unknown) => error);
+    expect(err).toBeInstanceOf(DbError);
+    expect((err as DbError).code).toBe("INVALID_COMMAND");
+  });
+
+  it("decodes Buffer replies to UTF-8 strings", async () => {
+    const { client, pool } = buildPool();
+    client.call.mockResolvedValueOnce(Buffer.from("héllo", "utf8"));
+    const result = await pool.execute(
+      "GET k",
+      100,
+      null,
+      new AbortController().signal
+    );
+    expect(result).toStrictEqual({
+      count: 1,
+      documents: [{ command: "GET k", reply: "héllo" }],
+      executionTimeMs: 0,
+      isTruncated: false,
+      resultType: "documents",
+    });
+  });
+
+  it("decodes nested Buffer replies inside arrays", async () => {
+    const { client, pool } = buildPool();
+    client.call.mockResolvedValueOnce([
+      Buffer.from("a", "utf8"),
+      Buffer.from("b", "utf8"),
+    ]);
+    const result = await pool.execute(
+      "LRANGE list 0 -1",
+      100,
+      null,
+      new AbortController().signal
+    );
+    expect(result).toStrictEqual({
+      count: 1,
+      documents: [{ command: "LRANGE list 0 -1", reply: ["a", "b"] }],
+      executionTimeMs: 0,
+      isTruncated: false,
+      resultType: "documents",
+    });
+  });
+
+  it("calls SELECT once when schema differs from defaultDb", async () => {
+    const { client, pool } = buildPool();
+    client.call.mockResolvedValueOnce("OK").mockResolvedValueOnce("OK");
+    await pool.execute(
+      "SET a 1\nSET b 2",
+      100,
+      "3",
+      new AbortController().signal
+    );
+    expect(client.select).toHaveBeenCalledWith(3);
+    expect(client.select).toHaveBeenCalledOnce();
+  });
+
+  it("does not call SELECT when schema matches defaultDb", async () => {
+    const { client, pool } = buildPool();
+    client.call.mockResolvedValueOnce("OK");
+    await pool.execute("SET a 1", 100, "0", new AbortController().signal);
+    expect(client.select).not.toHaveBeenCalled();
+  });
+
+  it("does not call SELECT when schema is null", async () => {
+    const { client, pool } = buildPool();
+    client.call.mockResolvedValueOnce("OK");
+    await pool.execute("SET a 1", 100, null, new AbortController().signal);
+    expect(client.select).not.toHaveBeenCalled();
+  });
+
+  it("truncates to maxRows commands when more are provided", async () => {
+    const { client, pool } = buildPool();
+    client.call.mockResolvedValue("OK");
+    const result = await pool.execute(
+      "SET a 1\nSET b 2\nSET c 3",
+      1,
+      null,
+      new AbortController().signal
+    );
+    expect(client.call).toHaveBeenCalledOnce();
+    expect(result).toStrictEqual({
+      count: 1,
+      documents: [{ command: "SET a 1", reply: "OK" }],
+      executionTimeMs: 0,
+      isTruncated: true,
+      resultType: "documents",
+    });
+  });
+
+  it("wraps native errors from client.call in DbError", async () => {
+    const { client, pool } = buildPool();
+    client.call.mockRejectedValueOnce(
+      new Error("ERR wrong number of arguments for 'set' command")
+    );
+    const err = await pool
+      .execute("SET k", 100, null, new AbortController().signal)
+      .catch((error: unknown) => error);
+    expect(err).toBeInstanceOf(DbError);
+    expect((err as DbError).message).toBe(
+      "ERR wrong number of arguments for 'set' command"
+    );
+  });
+
+  it("aborts before issuing the next command when signal fires mid-batch", async () => {
+    const { client, pool } = buildPool();
+    const controller = new AbortController();
+    client.call.mockImplementationOnce(async () => {
+      await Promise.resolve();
+      controller.abort();
+      return "OK";
+    });
+    const err = await pool
+      .execute("SET a 1\nSET b 2", 100, null, controller.signal)
+      .catch((error: unknown) => error);
+    expect(err).toBeInstanceOf(DbError);
+    expect((err as DbError).code).toBe("QUERY_CANCELLED");
+    expect(client.call).toHaveBeenCalledOnce();
+  });
+
+  it("rejects with POOL_CLOSED when pool is closed", async () => {
+    const { pool } = buildPool();
+    await pool.close();
+    const err = await pool
+      .execute("GET x", 100, null, new AbortController().signal)
+      .catch((error: unknown) => error);
+    expect(err).toBeInstanceOf(DbError);
+    expect((err as DbError).code).toBe("POOL_CLOSED");
+  });
+});
+
+describe("redisPool > explain", () => {
+  it("rejects with UNSUPPORTED", async () => {
     const { pool } = buildPool();
     const err = await pool
       .explain("KEYS *", false, null, new AbortController().signal)
       .catch((error: unknown) => error);
     expect(err).toBeInstanceOf(DbError);
     expect((err as DbError).code).toBe("UNSUPPORTED");
+  });
+});
+
+describe("parseRedisCommands", () => {
+  it("splits on newlines and tokenizes by whitespace", () => {
+    expect(parseRedisCommands("GET a\nSET b 1")).toStrictEqual([
+      { args: ["a"], name: "GET", raw: "GET a" },
+      { args: ["b", "1"], name: "SET", raw: "SET b 1" },
+    ]);
+  });
+
+  it("treats a double-quoted string as one token", () => {
+    expect(parseRedisCommands('SET "user 1" hello')).toStrictEqual([
+      { args: ["user 1", "hello"], name: "SET", raw: 'SET "user 1" hello' },
+    ]);
+  });
+
+  it("treats a single-quoted string as one token without escapes", () => {
+    expect(parseRedisCommands("SET 'a\\nb' v")).toStrictEqual([
+      { args: ["a\\nb", "v"], name: "SET", raw: "SET 'a\\nb' v" },
+    ]);
+  });
+
+  it("throws INVALID_COMMAND on unterminated quotes", () => {
+    expect(() => parseRedisCommands('GET "missing')).toThrow(DbError);
+  });
+
+  it("throws INVALID_COMMAND when input has no commands", () => {
+    expect(() => parseRedisCommands("\n# only\n")).toThrow(DbError);
   });
 });
 

--- a/packages/drivers-redis/src/pool.ts
+++ b/packages/drivers-redis/src/pool.ts
@@ -1,4 +1,5 @@
 import type {
+  DocumentResult,
   ExecuteResult,
   ExplainResult,
   Pool,
@@ -83,6 +84,137 @@ export function mapRedisError(err: unknown): DbError {
 
 const POOL_CLOSED = new DbError("POOL_CLOSED", "Redis pool is closed");
 
+export function parseDbIndex(database: string | undefined | null): number {
+  const trimmed = database?.trim();
+  if (!trimmed) {
+    return 0;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0;
+  }
+  return parsed;
+}
+
+export interface RedisCommand {
+  name: string;
+  args: string[];
+  raw: string;
+}
+
+const ESCAPE_MAP: Record<string, string> = {
+  '"': '"',
+  "'": "'",
+  "\\": "\\",
+  n: "\n",
+  r: "\r",
+  t: "\t",
+};
+
+function tokenizeLine(line: string, lineNumber: number): string[] {
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < line.length) {
+    const ch = line[i] ?? "";
+    if (ch === " " || ch === "\t") {
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      let value = "";
+      i += 1;
+      while (i < line.length) {
+        const c = line[i] ?? "";
+        if (c === "\\" && quote === '"') {
+          const next = line[i + 1];
+          if (next !== undefined && next in ESCAPE_MAP) {
+            value += ESCAPE_MAP[next];
+            i += 2;
+            continue;
+          }
+        }
+        if (c === quote) {
+          i += 1;
+          tokens.push(value);
+          break;
+        }
+        value += c;
+        i += 1;
+        if (i >= line.length) {
+          throw new DbError(
+            "INVALID_COMMAND",
+            `Unterminated ${quote === '"' ? "double" : "single"}-quoted string on line ${lineNumber}`
+          );
+        }
+      }
+      continue;
+    }
+    let value = "";
+    while (i < line.length) {
+      const c = line[i] ?? "";
+      if (c === " " || c === "\t") {
+        break;
+      }
+      value += c;
+      i += 1;
+    }
+    tokens.push(value);
+  }
+  return tokens;
+}
+
+export function parseRedisCommands(input: string): RedisCommand[] {
+  const commands: RedisCommand[] = [];
+  const lines = input.split(/\r?\n/);
+  for (let idx = 0; idx < lines.length; idx += 1) {
+    const raw = lines[idx] ?? "";
+    const trimmed = raw.trim();
+    if (
+      trimmed.length === 0 ||
+      trimmed.startsWith("#") ||
+      trimmed.startsWith("//")
+    ) {
+      continue;
+    }
+    const tokens = tokenizeLine(raw, idx + 1);
+    const [name, ...args] = tokens;
+    if (!name) {
+      continue;
+    }
+    commands.push({ args, name, raw: trimmed });
+  }
+  if (commands.length === 0) {
+    throw new DbError("INVALID_COMMAND", "No Redis command to run");
+  }
+  return commands;
+}
+
+function decodeReply(reply: unknown): unknown {
+  if (reply === null || reply === undefined) {
+    return null;
+  }
+  if (typeof reply === "string" || typeof reply === "number") {
+    return reply;
+  }
+  if (Buffer.isBuffer(reply)) {
+    return reply.toString("utf8");
+  }
+  if (Array.isArray(reply)) {
+    return reply.map(decodeReply);
+  }
+  if (typeof reply === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(
+      reply as Record<string, unknown>
+    )) {
+      out[key] = decodeReply(value);
+    }
+    return out;
+  }
+  return String(reply);
+}
+
 export class RedisPool implements Pool {
   readonly dialect = null;
   readonly supportsExplain = false;
@@ -141,15 +273,44 @@ export class RedisPool implements Pool {
     });
   }
 
-  execute(
-    _sql: string,
-    _maxRows: number,
-    _schema: string | null,
-    _signal: AbortSignal
+  async execute(
+    sql: string,
+    maxRows: number,
+    schema: string | null,
+    signal: AbortSignal
   ): Promise<ExecuteResult> {
-    return Promise.reject(
-      new DbError("UNSUPPORTED", `${this.kind} does not support SQL execution`)
-    );
+    const client = this.#requireClient();
+    const commands = parseRedisCommands(sql);
+    const targetDb = parseDbIndex(schema);
+    const limit = Math.max(1, maxRows);
+    const isTruncated = commands.length > limit;
+    const toRun = isTruncated ? commands.slice(0, limit) : commands;
+    const documents: unknown[] = [];
+    try {
+      if (schema && targetDb !== this.#defaultDb) {
+        await client.select(targetDb);
+      }
+      for (const command of toRun) {
+        if (signal.aborted) {
+          throw new DbError("QUERY_CANCELLED", "Query cancelled");
+        }
+        const reply = await client.call(command.name, ...command.args);
+        documents.push({
+          command: command.raw,
+          reply: decodeReply(reply),
+        });
+      }
+    } catch (error) {
+      throw mapRedisError(error);
+    }
+    const result: DocumentResult = {
+      count: documents.length,
+      documents,
+      executionTimeMs: 0,
+      isTruncated,
+      resultType: "documents",
+    };
+    return result;
   }
 
   explain(


### PR DESCRIPTION
## Summary
- **Redis driver**: probe now calls `client.connect()` before `ping()` — previously the unconnected client surfaced opaque connection failures. Adds the failure-path tests.
- **Redis keys panel**: subscribes to live `useConnection().isConnected` instead of hard-coding `true`, so polling stops once the connection drops.
- **Query tab bar**: tabs now have a 7–14rem range and align left instead of stretching the row; the strip scrolls horizontally when crowded.
- **Drag-to-reorder**: tabs reorder via Framer Motion's `Reorder`, using stable string IDs as values so identity survives unrelated tab state updates (status/sql/result changes mid-drag no longer break the drop). Persists per-connection via the existing tabs save flow.

## Test plan
- [x] `bun run check-types`
- [x] `bun run check`
- [x] `bun run --cwd apps/app test` (917 passing, including new Redis connect-failure cases)
- [ ] Smoke test in `bun run --cwd apps/app desktop:dev`: drag tabs while a query runs in another tab; confirm Redis connect/disconnect behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Redis command execution in the query editor and refines the query tab bar with left‑aligned, scrollable tabs and drag‑to‑reorder. Also fixes Redis connect probing and halts Redis key polling when disconnected.

- **New Features**
  - Query editor: run Redis commands via client.call; supports quoted args and comments, decodes Buffer replies, honors selected DB, truncates to maxRows, and returns document results.
  - Query tab bar: left‑aligned tabs with 7–14rem width and horizontal scroll; drag‑to‑reorder via `Reorder` using stable IDs; order persists per‑connection; close button no longer starts a drag.

- **Bug Fixes**
  - Redis driver: call `connect()` before `ping()` in probe and connect; tear down client on failure; added connect‑failure tests.
  - Redis keys panel: uses live `isConnected` to stop polling after disconnect.

<sup>Written for commit 5ef1ffdc689fea4390d9d492275de41a76f62393. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

