### PR TITLE
Add tests for uncovered hooks and components

### DIFF
--- a/apps/app/src/mainview/components/__snapshots__/loader.browser.test.tsx.snap
+++ b/apps/app/src/mainview/components/__snapshots__/loader.browser.test.tsx.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`loader > renders a centered spinner 1`] = `
+<div>
+  <div
+    class="flex h-full items-center justify-center pt-8"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-loader-circle animate-spin"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M21 12a9 9 0 1 1-6.219-8.56"
+      />
+    </svg>
+  </div>
+</div>
+`;

--- a/apps/app/src/mainview/components/app-providers.browser.test.tsx
+++ b/apps/app/src/mainview/components/app-providers.browser.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { AppProviders } from "./app-providers";
+
+describe("app-providers", () => {
+  it("wraps children inside the provider tree", () => {
+    const screen = render(
+      <AppProviders>
+        <span>hello</span>
+      </AppProviders>
+    );
+    expect(screen.getByText("hello")).toBeVisible();
+  });
+});

--- a/apps/app/src/mainview/components/loader.browser.test.tsx
+++ b/apps/app/src/mainview/components/loader.browser.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import Loader from "./loader";
+
+describe("loader", () => {
+  it("renders a centered spinner", () => {
+    const screen = render(<Loader />);
+    expect(screen.container).toMatchSnapshot();
+  });
+});

--- a/apps/app/src/mainview/components/titlebar/dynamic-island/app-island.browser.test.tsx
+++ b/apps/app/src/mainview/components/titlebar/dynamic-island/app-island.browser.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { IslandProvider } from "@/contexts/island-context";
+
+import { AppIsland } from "./dynamic-island";
+
+describe("app-island", () => {
+  it("renders nothing visible when the snapshot is hidden", () => {
+    const screen = render(
+      <IslandProvider>
+        <AppIsland />
+      </IslandProvider>
+    );
+    expect(screen.getByRole("status").query()).toBeNull();
+    expect(screen.getByRole("alert").query()).toBeNull();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/ai-actions-button.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/ai-actions-button.browser.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { AIActionsButton } from "./ai-actions-button";
+
+describe("ai-actions-button", () => {
+  it("opens the dropdown and dispatches generate", async () => {
+    const onAction = vi.fn();
+    const screen = render(
+      <AIActionsButton hasError={false} hasQuery onAction={onAction} />
+    );
+    await screen.getByRole("button", { name: "AI actions" }).click();
+    await screen.getByRole("menuitem", { name: /Generate SQL/ }).click();
+    expect(onAction).toHaveBeenCalledWith("generate");
+  });
+
+  it("disables Explain when there is no query", async () => {
+    const screen = render(
+      <AIActionsButton hasError={false} hasQuery={false} onAction={vi.fn()} />
+    );
+    await screen.getByRole("button", { name: "AI actions" }).click();
+    const explain = screen.getByRole("menuitem", { name: /Explain Query/ });
+    expect(explain.element()).toHaveAttribute("data-disabled");
+  });
+
+  it("enables Fix when there is an error even without a query", async () => {
+    const onAction = vi.fn();
+    const screen = render(
+      <AIActionsButton hasError hasQuery={false} onAction={onAction} />
+    );
+    await screen.getByRole("button", { name: "AI actions" }).click();
+    await screen.getByRole("menuitem", { name: /Fix Query/ }).click();
+    expect(onAction).toHaveBeenCalledWith("fix");
+  });
+});

--- a/apps/app/src/mainview/components/workspace/close-confirm-dialog.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/close-confirm-dialog.browser.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { CloseConfirmDialog } from "./close-confirm-dialog";
+
+describe("close-confirm-dialog", () => {
+  it("does not render content when open is false", () => {
+    const screen = render(
+      <CloseConfirmDialog
+        dirtyCount={2}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        open={false}
+      />
+    );
+    expect(screen.getByText(/Unsaved changes/).query()).toBeNull();
+  });
+
+  it("renders title and pluralized message when multiple tabs are dirty", () => {
+    const screen = render(
+      <CloseConfirmDialog
+        dirtyCount={3}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        open
+      />
+    );
+    expect(screen.getByText(/Unsaved changes/)).toBeVisible();
+    expect(screen.getByText(/3 tabs with unexecuted changes/)).toBeVisible();
+  });
+
+  it("uses singular wording for one dirty tab", () => {
+    const screen = render(
+      <CloseConfirmDialog
+        dirtyCount={1}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        open
+      />
+    );
+    expect(screen.getByText(/1 tab with unexecuted changes/)).toBeVisible();
+  });
+
+  it("calls onCancel when Cancel is clicked", async () => {
+    const onCancel = vi.fn();
+    const screen = render(
+      <CloseConfirmDialog
+        dirtyCount={1}
+        onCancel={onCancel}
+        onConfirm={vi.fn()}
+        open
+      />
+    );
+    await screen.getByRole("button", { name: "Cancel" }).click();
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("calls onConfirm when Close anyway is clicked", async () => {
+    const onConfirm = vi.fn();
+    const screen = render(
+      <CloseConfirmDialog
+        dirtyCount={1}
+        onCancel={vi.fn()}
+        onConfirm={onConfirm}
+        open
+      />
+    );
+    await screen.getByRole("button", { name: "Close anyway" }).click();
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/command-editor.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/command-editor.browser.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { CommandEditor } from "./command-editor";
+
+describe("command-editor", () => {
+  it("renders Redis-specific placeholder", () => {
+    const screen = render(
+      <CommandEditor
+        databaseType="redis"
+        onChange={vi.fn()}
+        onExecute={vi.fn()}
+        value=""
+      />
+    );
+    const textarea = screen.getByRole("textbox");
+    expect(textarea.element()).toHaveAttribute(
+      "placeholder",
+      expect.stringContaining("GET mykey")
+    );
+  });
+
+  it("calls onChange when the textarea is edited", async () => {
+    const onChange = vi.fn();
+    const screen = render(
+      <CommandEditor
+        databaseType="redis"
+        onChange={onChange}
+        onExecute={vi.fn()}
+        value=""
+      />
+    );
+    await screen.getByRole("textbox").fill("PING");
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe("PING");
+  });
+
+  it("falls back to a generic placeholder for unknown database types", () => {
+    const screen = render(
+      <CommandEditor
+        databaseType={"sqlite" as never}
+        onChange={vi.fn()}
+        onExecute={vi.fn()}
+        value=""
+      />
+    );
+    expect(screen.getByRole("textbox").element()).toHaveAttribute(
+      "placeholder",
+      "Enter command..."
+    );
+  });
+
+  it("respects readOnly", () => {
+    const screen = render(
+      <CommandEditor
+        databaseType="redis"
+        onChange={vi.fn()}
+        onExecute={vi.fn()}
+        readOnly
+        value="GET k"
+      />
+    );
+    expect(screen.getByRole("textbox").element()).toHaveAttribute("readonly");
+  });
+});

--- a/apps/app/src/mainview/components/workspace/dialect-selector.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/dialect-selector.browser.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
+import { page } from "vitest/browser";
 
 import { DialectSelector } from "./dialect-selector";
 
@@ -16,7 +17,7 @@ describe("dialect-selector", () => {
     expect(screen.getByText(/Transpiling to/).query()).toBeNull();
   });
 
-  it("shows transpile chip with display name when source dialect differs", async () => {
+  it("shows the transpile badge with the target dialect label", async () => {
     const screen = render(
       <DialectSelector
         connectionDialect="postgresql"
@@ -24,9 +25,16 @@ describe("dialect-selector", () => {
         value="mysql"
       />
     );
+    // The badge wraps a lucide icon; hovering it opens the tooltip whose
+    // content names the *target* (connection) dialect, not the SELECT value.
+    const badge = screen.container.querySelector(
+      "span.text-amber-500"
+    ) as HTMLElement | null;
+    expect(badge).not.toBeNull();
+    await page.elementLocator(badge as HTMLElement).hover();
     await expect
-      .poll(() => screen.getByRole("combobox").element().textContent)
-      .toMatch(/MySQL/i);
+      .poll(() => page.getByText("Transpiling to PostgreSQL").query() !== null)
+      .toBe(true);
   });
 
   it("calls onChange when the user picks another dialect", async () => {

--- a/apps/app/src/mainview/components/workspace/dialect-selector.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/dialect-selector.browser.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { DialectSelector } from "./dialect-selector";
+
+describe("dialect-selector", () => {
+  it("does not show the transpile chip when value matches connectionDialect", () => {
+    const screen = render(
+      <DialectSelector
+        connectionDialect="postgresql"
+        onChange={vi.fn()}
+        value="postgresql"
+      />
+    );
+    expect(screen.getByRole("combobox")).toBeVisible();
+    expect(screen.getByText(/Transpiling to/).query()).toBeNull();
+  });
+
+  it("shows transpile chip with display name when source dialect differs", async () => {
+    const screen = render(
+      <DialectSelector
+        connectionDialect="postgresql"
+        onChange={vi.fn()}
+        value="mysql"
+      />
+    );
+    await expect
+      .poll(() => screen.getByRole("combobox").element().textContent)
+      .toMatch(/MySQL/i);
+  });
+
+  it("calls onChange when the user picks another dialect", async () => {
+    const onChange = vi.fn();
+    const screen = render(
+      <DialectSelector
+        connectionDialect="postgresql"
+        onChange={onChange}
+        value="postgresql"
+      />
+    );
+    await screen.getByRole("combobox").click();
+    await screen.getByRole("option", { name: "MySQL" }).click();
+    expect(onChange).toHaveBeenCalledWith("mysql");
+  });
+});

--- a/apps/app/src/mainview/components/workspace/execute-button.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/execute-button.browser.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { ExecuteButton } from "./execute-button";
+
+describe("execute-button", () => {
+  it("invokes onClick when enabled and idle", async () => {
+    const onClick = vi.fn();
+    const screen = render(
+      <ExecuteButton disabled={false} isRunning={false} onClick={onClick} />
+    );
+    const btn = screen.getByRole("button");
+    await btn.click();
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("is disabled while running", () => {
+    const screen = render(
+      <ExecuteButton disabled={false} isRunning onClick={vi.fn()} />
+    );
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("is disabled when explicitly disabled", () => {
+    const screen = render(
+      <ExecuteButton disabled isRunning={false} onClick={vi.fn()} />
+    );
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/explain-panel/plan-node-details.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/explain-panel/plan-node-details.browser.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import type { PlanNode } from "@/lib/tauri";
+
+import { PlanNodeDetails } from "./plan-node-details";
+
+const baseNode: PlanNode = {
+  children: [],
+  cost: { actualTotalMs: 8.4, selfMs: 1.2, startup: 0, total: 100 },
+  details: [],
+  id: "n0",
+  label: "Seq Scan on users",
+  nodeType: "Seq Scan",
+  rows: { actual: 100, estimated: 50 },
+  timing: { actualTotalMs: 8.4, loops: 1, startupMs: 0 },
+  warnings: [],
+};
+
+describe("plan-node-details", () => {
+  it("renders label, type, and core metrics", () => {
+    const screen = render(<PlanNodeDetails node={baseNode} />);
+    expect(screen.getByText("Seq Scan on users")).toBeVisible();
+    expect(screen.getByText("Seq Scan", { exact: true })).toBeVisible();
+    expect(screen.getByText("Rows (est.)")).toBeVisible();
+    expect(screen.getByText("Rows (actual)")).toBeVisible();
+    expect(screen.getByText("Cost (est.)")).toBeVisible();
+  });
+
+  it("hides loops when only one loop ran", () => {
+    const screen = render(<PlanNodeDetails node={baseNode} />);
+    expect(screen.getByText("Loops").query()).toBeNull();
+  });
+
+  it("shows loops when greater than one", () => {
+    const node: PlanNode = {
+      ...baseNode,
+      timing: { ...baseNode.timing, loops: 5 },
+    };
+    const screen = render(<PlanNodeDetails node={node} />);
+    expect(screen.getByText("Loops")).toBeVisible();
+    expect(screen.getByText("5", { exact: true })).toBeVisible();
+  });
+
+  it("renders warnings list when present", () => {
+    const node: PlanNode = {
+      ...baseNode,
+      warnings: ["Sequential scan on large table", "Missing index"],
+    };
+    const screen = render(<PlanNodeDetails node={node} />);
+    expect(screen.getByText("Sequential scan on large table")).toBeVisible();
+    expect(screen.getByText("Missing index")).toBeVisible();
+  });
+
+  it("renders the details key-value list", () => {
+    const node: PlanNode = {
+      ...baseNode,
+      details: [
+        ["Filter", "id > 10"],
+        ["Index", "users_pkey"],
+      ],
+    };
+    const screen = render(<PlanNodeDetails node={node} />);
+    expect(screen.getByText("Filter")).toBeVisible();
+    expect(screen.getByText("id > 10")).toBeVisible();
+    expect(screen.getByText("Index")).toBeVisible();
+    expect(screen.getByText("users_pkey")).toBeVisible();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/explain-panel/plan-raw-view.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/explain-panel/plan-raw-view.browser.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { PlanRawView } from "./plan-raw-view";
+
+describe("plan-raw-view", () => {
+  it("renders the raw plan text", () => {
+    const screen = render(<PlanRawView raw="Seq Scan on users" />);
+    expect(screen.getByText("Seq Scan on users")).toBeVisible();
+  });
+
+  it("copies to the clipboard and updates the button label", async () => {
+    const writeText = vi.fn(async () => {
+      await Promise.resolve();
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const screen = render(<PlanRawView raw="hello" />);
+    await screen.getByRole("button", { name: "Copy raw plan" }).click();
+    expect(writeText).toHaveBeenCalledWith("hello");
+    await expect.poll(() => screen.getByText("Copied").query()).not.toBeNull();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/format-button.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/format-button.browser.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { FormatButton } from "./format-button";
+
+describe("format-button", () => {
+  it("invokes onClick when enabled", async () => {
+    const onClick = vi.fn();
+    const screen = render(<FormatButton disabled={false} onClick={onClick} />);
+    const btn = screen.getByRole("button", { name: "Format SQL" });
+    await btn.click();
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders disabled when disabled is true", () => {
+    const screen = render(<FormatButton disabled onClick={vi.fn()} />);
+    const btn = screen.getByRole("button", { name: "Format SQL" });
+    expect(btn).toBeDisabled();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/keyboard-shortcuts-overlay.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/keyboard-shortcuts-overlay.browser.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { KeyboardShortcutsOverlay } from "./keyboard-shortcuts-overlay";
+
+describe("keyboard-shortcuts-overlay", () => {
+  it("does not render content when closed", () => {
+    const screen = render(
+      <KeyboardShortcutsOverlay onOpenChange={vi.fn()} open={false} />
+    );
+    expect(
+      screen.getByRole("heading", { name: "Keyboard shortcuts" }).query()
+    ).toBeNull();
+  });
+
+  it("lists all section headings when open", () => {
+    const screen = render(
+      <KeyboardShortcutsOverlay onOpenChange={vi.fn()} open />
+    );
+    expect(
+      screen.getByRole("heading", { name: "Keyboard shortcuts" })
+    ).toBeVisible();
+    for (const heading of ["Query", "Tabs", "Layout", "Schema", "Help"]) {
+      expect(screen.getByRole("heading", { name: heading })).toBeVisible();
+    }
+  });
+});

--- a/apps/app/src/mainview/components/workspace/redis/key-row.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/redis/key-row.browser.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import type { RedisKey } from "@/lib/tauri";
+
+import { KeyRow } from "./key-row";
+
+const sampleKey: RedisKey = {
+  kind: "STRING",
+  name: "users:1",
+  size: 128,
+  sizeUnit: "bytes",
+  ttlSecs: 600,
+};
+
+describe("key-row", () => {
+  it("renders the display name and type badge", () => {
+    const screen = render(
+      <KeyRow
+        depth={0}
+        displayName="display"
+        isActive={false}
+        onActivate={vi.fn()}
+        redisKey={sampleKey}
+      />
+    );
+    expect(screen.getByText("display")).toBeVisible();
+    expect(screen.getByText("STR")).toBeVisible();
+  });
+
+  it("invokes onActivate with the key name when clicked", async () => {
+    const onActivate = vi.fn();
+    const screen = render(
+      <KeyRow
+        depth={0}
+        displayName="1"
+        isActive={false}
+        onActivate={onActivate}
+        redisKey={sampleKey}
+      />
+    );
+    await screen.getByRole("button").click();
+    expect(onActivate).toHaveBeenCalledWith("users:1");
+  });
+
+  it("flags itself as active via data-active", () => {
+    const screen = render(
+      <KeyRow
+        depth={1}
+        displayName="1"
+        isActive
+        onActivate={vi.fn()}
+        redisKey={sampleKey}
+      />
+    );
+    expect(screen.getByRole("button").element()).toHaveAttribute("data-active");
+  });
+});

--- a/apps/app/src/mainview/components/workspace/redis/keys-panel-header.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/redis/keys-panel-header.browser.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { KeysPanelHeader } from "./keys-panel-header";
+
+const baseProps = {
+  dbIndex: 0,
+  isLoading: false,
+  onPatternChange: vi.fn(),
+  onRefresh: vi.fn(),
+  onSelectDb: vi.fn(),
+  patternFocusKey: 0,
+  totalKeys: null,
+};
+
+describe("keys-panel-header", () => {
+  it("invokes onRefresh when the refresh button is clicked", async () => {
+    const onRefresh = vi.fn();
+    const screen = render(
+      <KeysPanelHeader {...baseProps} onRefresh={onRefresh} />
+    );
+    await screen.getByRole("button", { name: "Refresh keys" }).click();
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("disables the refresh button while loading", () => {
+    const screen = render(<KeysPanelHeader {...baseProps} isLoading />);
+    expect(screen.getByRole("button", { name: "Refresh keys" })).toBeDisabled();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/redis/namespace-row.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/redis/namespace-row.browser.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { NamespaceRow } from "./namespace-row";
+
+describe("namespace-row", () => {
+  it("renders the segment label and key count", () => {
+    const screen = render(
+      <NamespaceRow
+        depth={0}
+        fullName="users"
+        isActive={false}
+        isExpanded={false}
+        keyCount={42}
+        onToggle={vi.fn()}
+        segment="users"
+      />
+    );
+    expect(screen.getByText("users")).toBeVisible();
+    expect(screen.getByText("42")).toBeVisible();
+  });
+
+  it("calls onToggle with fullName when clicked", async () => {
+    const onToggle = vi.fn();
+    const screen = render(
+      <NamespaceRow
+        depth={0}
+        fullName="users"
+        isActive={false}
+        isExpanded={false}
+        keyCount={1}
+        onToggle={onToggle}
+        segment="users"
+      />
+    );
+    await screen.getByRole("button").click();
+    expect(onToggle).toHaveBeenCalledWith("users");
+  });
+
+  it("exposes data-expanded when isExpanded", () => {
+    const screen = render(
+      <NamespaceRow
+        depth={0}
+        fullName="users"
+        isActive={false}
+        isExpanded
+        keyCount={1}
+        onToggle={vi.fn()}
+        segment="users"
+      />
+    );
+    expect(screen.getByRole("button").element()).toHaveAttribute(
+      "data-expanded"
+    );
+  });
+});

--- a/apps/app/src/mainview/components/workspace/redis/size-chip.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/redis/size-chip.browser.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { SizeChip } from "./size-chip";
+
+describe("size-chip", () => {
+  it("renders an em-dash when size is null", () => {
+    const screen = render(<SizeChip size={null} unit="bytes" />);
+    expect(screen.getByText("—")).toBeVisible();
+  });
+
+  it("formats bytes under 1 KiB with the B suffix", () => {
+    const screen = render(<SizeChip size={512} unit="bytes" />);
+    expect(screen.getByText("512")).toBeVisible();
+    expect(screen.getByText("B")).toBeVisible();
+  });
+
+  it("formats bytes in the kilobyte range", () => {
+    const screen = render(<SizeChip size={2048} unit="bytes" />);
+    expect(screen.getByText("2.0k")).toBeVisible();
+  });
+
+  it("formats bytes in the megabyte range", () => {
+    const screen = render(<SizeChip size={2 * 1024 * 1024} unit="bytes" />);
+    expect(screen.getByText("2.0M")).toBeVisible();
+  });
+
+  it("formats counts with locale separators for non-byte units", () => {
+    const screen = render(<SizeChip size={12_345} unit="entries" />);
+    expect(screen.getByText("12,345")).toBeVisible();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/redis/ttl-chip.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/redis/ttl-chip.browser.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { TtlChip } from "./ttl-chip";
+
+describe("ttl-chip", () => {
+  it("renders an em-dash and aria-hidden when no TTL is set", () => {
+    const screen = render(<TtlChip ttlSecs={null} />);
+    expect(screen.getByText("—")).toBeVisible();
+  });
+
+  it("formats sub-minute TTLs in seconds and flags expiring", () => {
+    const screen = render(<TtlChip ttlSecs={45} />);
+    expect(screen.getByText("45s")).toBeVisible();
+  });
+
+  it("formats minutes for sub-hour TTLs", () => {
+    const screen = render(<TtlChip ttlSecs={120} />);
+    expect(screen.getByText("2m")).toBeVisible();
+  });
+
+  it("formats hours for sub-day TTLs", () => {
+    const screen = render(<TtlChip ttlSecs={3 * 3600} />);
+    expect(screen.getByText("3h")).toBeVisible();
+  });
+
+  it("formats days for long TTLs", () => {
+    const screen = render(<TtlChip ttlSecs={2 * 86_400} />);
+    expect(screen.getByText("2d")).toBeVisible();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/redis/type-badge.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/redis/type-badge.browser.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { TypeBadge } from "./type-badge";
+
+describe("type-badge", () => {
+  it.each([
+    ["STRING", "STR"],
+    ["HASH", "HASH"],
+    ["LIST", "LIST"],
+    ["SET", "SET"],
+    ["ZSET", "ZSET"],
+    ["STREAM", "STRM"],
+    ["UNKNOWN", "???"],
+  ] as const)("renders %s as %s", (kind, label) => {
+    const screen = render(<TypeBadge kind={kind} />);
+    expect(screen.getByText(label)).toBeVisible();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/syntax-tree-node.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/syntax-tree-node.browser.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import type { TreeNodeData } from "@/hooks/use-syntax-tree";
+
+import { SyntaxTreeNode } from "./syntax-tree-node";
+
+const makeNode = (
+  id: string,
+  name: string,
+  text = "",
+  children: TreeNodeData[] = [],
+  isError = false
+): TreeNodeData => ({
+  children,
+  from: 0,
+  id,
+  isError,
+  name,
+  text,
+  to: 1,
+});
+
+describe("syntax-tree-node", () => {
+  it("renders the node name and offset range", () => {
+    const node = makeNode("0", "Statement", "SELECT 1");
+    const screen = render(
+      <SyntaxTreeNode cursorNodeId={null} depth={0} node={node} />
+    );
+    expect(screen.getByText("Statement")).toBeVisible();
+    expect(screen.getByText("[0..1]")).toBeVisible();
+  });
+
+  it("truncates long text with an ellipsis", () => {
+    const node = makeNode("0", "Long", "x".repeat(80));
+    const screen = render(
+      <SyntaxTreeNode cursorNodeId={null} depth={0} node={node} />
+    );
+    expect(screen.getByText(/^x{50}\.\.\.$/)).toBeVisible();
+  });
+
+  it("toggles expansion when a node with children is clicked", async () => {
+    const node = makeNode("0", "Parent", "", [
+      makeNode("0.0", "Child", "leaf"),
+    ]);
+    const screen = render(
+      <SyntaxTreeNode cursorNodeId={null} depth={0} node={node} />
+    );
+    expect(screen.getByText("Child")).toBeVisible();
+    await screen
+      .getByRole("button", { name: /Parent/ })
+      .first()
+      .click();
+    expect(screen.getByText("Child").query()).toBeNull();
+  });
+
+  it("auto-collapses children at depth >= 2 unless an ancestor of the cursor", () => {
+    const node = makeNode("0", "Deep", "", [makeNode("0.0", "Inner", "x")]);
+    const screen = render(
+      <SyntaxTreeNode cursorNodeId={null} depth={3} node={node} />
+    );
+    expect(screen.getByText("Inner").query()).toBeNull();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/syntax-tree-panel.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/syntax-tree-panel.browser.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import type { SyntaxTreeData, TreeNodeData } from "@/hooks/use-syntax-tree";
+
+import { SyntaxTreePanel } from "./syntax-tree-panel";
+
+const makeNode = (
+  id: string,
+  name: string,
+  children: TreeNodeData[] = []
+): TreeNodeData => ({
+  children,
+  from: 0,
+  id,
+  isError: false,
+  name,
+  text: "",
+  to: 1,
+});
+
+describe("syntax-tree-panel", () => {
+  it("shows an empty hint when there is no root", () => {
+    const data: SyntaxTreeData = { cursorNodeId: null, root: null };
+    const screen = render(<SyntaxTreePanel treeData={data} />);
+    expect(screen.getByText("Type SQL to see the syntax tree")).toBeVisible();
+  });
+
+  it("renders the root node and counts descendants", () => {
+    const data: SyntaxTreeData = {
+      cursorNodeId: null,
+      root: makeNode("0", "Statement", [
+        makeNode("0.0", "Select"),
+        makeNode("0.1", "From"),
+      ]),
+    };
+    const screen = render(<SyntaxTreePanel treeData={data} />);
+    expect(screen.getByText("Syntax Tree")).toBeVisible();
+    expect(screen.getByText("(3 nodes)")).toBeVisible();
+  });
+});

--- a/apps/app/src/mainview/components/workspace/syntax-tree-toggle.browser.test.tsx
+++ b/apps/app/src/mainview/components/workspace/syntax-tree-toggle.browser.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { SyntaxTreeToggle } from "./syntax-tree-toggle";
+
+describe("syntax-tree-toggle", () => {
+  it('shows the "open" label when closed', () => {
+    const screen = render(
+      <SyntaxTreeToggle isOpen={false} onToggle={vi.fn()} />
+    );
+    expect(
+      screen.getByRole("button", { name: "Open Syntax Tree" })
+    ).toBeVisible();
+  });
+
+  it('shows the "close" label when open', () => {
+    const screen = render(<SyntaxTreeToggle isOpen onToggle={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: "Close Syntax Tree" })
+    ).toBeVisible();
+  });
+
+  it("invokes onToggle when clicked", async () => {
+    const onToggle = vi.fn();
+    const screen = render(
+      <SyntaxTreeToggle isOpen={false} onToggle={onToggle} />
+    );
+    await screen.getByRole("button", { name: "Open Syntax Tree" }).click();
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/app/src/mainview/hooks/use-active-query-sync.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-active-query-sync.browser.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { QueryTab } from "@/lib/query-types";
+
+import { renderHook } from "@/test/render-hook";
+
+const setExecutionState = vi.fn();
+const setCancelActive = vi.fn();
+const cancelTab = vi.fn();
+const setActiveSql = vi.fn();
+const setExecutionSnapshot = vi.fn();
+const setSelectedSql = vi.fn();
+const setTabTitle = vi.fn();
+
+vi.mock(import("@/contexts/query-execution-context"), () => ({
+  useQueryExecution: (() => ({
+    cancelActive: null,
+    setCancelActive,
+    setExecutionState,
+    state: {
+      error: null,
+      result: null,
+      startedAt: null,
+      status: "idle",
+    },
+  })) as never,
+}));
+
+vi.mock(import("@/contexts/query-tabs-context"), () => ({
+  useQueryTabsContext: (() => ({ cancelTab })) as never,
+}));
+
+vi.mock(import("@/contexts/active-query-context"), () => ({
+  useActiveQuery: (() => ({
+    getSnapshot: () => ({}),
+    meta: {},
+    setActiveSql,
+    setExecutionSnapshot,
+    setSelectedSql,
+    setTabTitle,
+  })) as never,
+}));
+
+const { useActiveQuerySync } = await import("@/hooks/use-active-query-sync");
+
+const makeTab = (overrides: Partial<QueryTab> = {}): QueryTab => ({
+  error: null,
+  errorCode: null,
+  executedSql: null,
+  explainAnalyze: false,
+  explainDensity: "comfortable",
+  explainError: null,
+  explainResult: null,
+  explainSql: null,
+  explainStatus: "idle",
+  id: "tab-1",
+  pendingExecution: null,
+  result: null,
+  runningExplainId: null,
+  runningQueryId: null,
+  sourceDialect: null,
+  sql: "SELECT 1",
+  status: "idle",
+  title: "Query 1",
+  ...overrides,
+});
+
+describe("useActiveQuerySync", () => {
+  it("forwards SQL, title, and snapshot when an active tab is provided", () => {
+    setActiveSql.mockClear();
+    setTabTitle.mockClear();
+    setSelectedSql.mockClear();
+    setExecutionSnapshot.mockClear();
+
+    renderHook(() => useActiveQuerySync(makeTab({ sql: "SELECT 42" })));
+
+    expect(setActiveSql).toHaveBeenCalledWith("SELECT 42");
+    expect(setTabTitle).toHaveBeenCalledWith("Query 1");
+    expect(setSelectedSql).toHaveBeenCalledWith(null);
+    expect(setExecutionSnapshot.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("registers a cancel handler when running with a queryId", () => {
+    setCancelActive.mockClear();
+    renderHook(() =>
+      useActiveQuerySync(makeTab({ runningQueryId: "q-1", status: "running" }))
+    );
+    expect(setCancelActive.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("clears tab title and SQL when the active tab is undefined", () => {
+    setActiveSql.mockClear();
+    setTabTitle.mockClear();
+    const noTab: QueryTab | undefined = undefined;
+    renderHook(() => useActiveQuerySync(noTab));
+    expect(setActiveSql).toHaveBeenCalledWith("");
+    expect(setTabTitle).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/app/src/mainview/hooks/use-ai-chat.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-ai-chat.browser.test.tsx
@@ -1,0 +1,109 @@
+import { act } from "react";
+import { describe, expect, it } from "vitest";
+
+import { useAiChat } from "@/hooks/use-ai-chat";
+import { useAiChatStore } from "@/stores/ai-chat-store";
+import { renderHook } from "@/test/render-hook";
+
+describe("useAiChat", () => {
+  it("ensures the store has a slot for the connection on mount", () => {
+    useAiChatStore.setState({ byConnection: {} });
+
+    renderHook(() =>
+      useAiChat({
+        connectionId: "conn-9",
+        databaseType: "postgresql",
+        schema: null,
+      })
+    );
+
+    expect(useAiChatStore.getState().byConnection["conn-9"]).toBeDefined();
+  });
+
+  it("exposes the current connection state from the store", () => {
+    useAiChatStore.setState({
+      byConnection: {
+        "conn-1": {
+          abortController: null,
+          error: null,
+          isStreaming: false,
+          lastUserMessage: null,
+          messages: [{ content: "hi", id: "m1", role: "user" }],
+        },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useAiChat({
+        connectionId: "conn-1",
+        databaseType: "postgresql",
+        schema: null,
+      })
+    );
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.isStreaming).toBeFalsy();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clearError resets the error in the store", () => {
+    useAiChatStore.setState({
+      byConnection: {
+        "conn-2": {
+          abortController: null,
+          error: {
+            message: "oops",
+            retryable: false,
+            suggestion: "—",
+            type: "unknown",
+          },
+          isStreaming: false,
+          lastUserMessage: null,
+          messages: [],
+        },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useAiChat({
+        connectionId: "conn-2",
+        databaseType: "postgresql",
+        schema: null,
+      })
+    );
+
+    act(() => {
+      result.current.clearError();
+    });
+    expect(useAiChatStore.getState().byConnection["conn-2"]?.error).toBeNull();
+  });
+
+  it("clearMessages empties the connection's message list", () => {
+    useAiChatStore.setState({
+      byConnection: {
+        "conn-3": {
+          abortController: null,
+          error: null,
+          isStreaming: false,
+          lastUserMessage: null,
+          messages: [{ content: "hi", id: "x", role: "user" }],
+        },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useAiChat({
+        connectionId: "conn-3",
+        databaseType: "postgresql",
+        schema: null,
+      })
+    );
+
+    act(() => {
+      result.current.clearMessages();
+    });
+    expect(
+      useAiChatStore.getState().byConnection["conn-3"]?.messages
+    ).toStrictEqual([]);
+  });
+});

--- a/apps/app/src/mainview/hooks/use-favorite-tables.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-favorite-tables.browser.test.tsx
@@ -1,0 +1,71 @@
+import { act } from "react";
+import { describe, expect, it } from "vitest";
+
+import { useFavoriteTables } from "@/hooks/use-favorite-tables";
+import { renderHook } from "@/test/render-hook";
+
+describe("useFavoriteTables", () => {
+  it("starts empty when no entries are stored", () => {
+    const { result } = renderHook(() => useFavoriteTables("conn-1"));
+    expect(result.current.favoriteTables).toStrictEqual([]);
+    expect(result.current.isFavorite("users")).toBeFalsy();
+  });
+
+  it("toggles a table on and off and persists via storage", () => {
+    const { result } = renderHook(() => useFavoriteTables("conn-1"));
+
+    act(() => {
+      result.current.toggleFavorite("users");
+    });
+    expect(result.current.favoriteTables).toStrictEqual(["users"]);
+    expect(result.current.isFavorite("users")).toBeTruthy();
+    expect(localStorage.getItem("oh-my-query-favorite-tables-conn-1")).toBe(
+      JSON.stringify(["users"])
+    );
+
+    act(() => {
+      result.current.toggleFavorite("users");
+    });
+    expect(result.current.favoriteTables).toStrictEqual([]);
+  });
+
+  it("loads existing favorites from storage on mount", () => {
+    localStorage.setItem(
+      "oh-my-query-favorite-tables-conn-2",
+      JSON.stringify(["orders", "products"])
+    );
+    const { result } = renderHook(() => useFavoriteTables("conn-2"));
+    expect(result.current.favoriteTables).toStrictEqual(["orders", "products"]);
+  });
+
+  it("migrates legacy pinned-tables entries to the new key", () => {
+    localStorage.setItem(
+      "oh-my-query-pinned-tables-legacy",
+      JSON.stringify(["legacy"])
+    );
+    const { result } = renderHook(() => useFavoriteTables("legacy"));
+    expect(result.current.favoriteTables).toStrictEqual(["legacy"]);
+    expect(localStorage.getItem("oh-my-query-pinned-tables-legacy")).toBeNull();
+    expect(localStorage.getItem("oh-my-query-favorite-tables-legacy")).toBe(
+      JSON.stringify(["legacy"])
+    );
+  });
+
+  it("reloads when connectionId changes", () => {
+    localStorage.setItem(
+      "oh-my-query-favorite-tables-a",
+      JSON.stringify(["t1"])
+    );
+    localStorage.setItem(
+      "oh-my-query-favorite-tables-b",
+      JSON.stringify(["t2"])
+    );
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useFavoriteTables(id),
+      { initialProps: { id: "a" } }
+    );
+    expect(result.current.favoriteTables).toStrictEqual(["t1"]);
+    rerender({ id: "b" });
+    expect(result.current.favoriteTables).toStrictEqual(["t2"]);
+  });
+});

--- a/apps/app/src/mainview/hooks/use-menu-navigation.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-menu-navigation.browser.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { renderHook } from "@/test/render-hook";
+
+const navigate = vi.fn();
+
+vi.mock(import("@tanstack/react-router"), () => ({
+  useNavigate: () => navigate,
+}));
+
+const menuHandlers: ((route: string) => void)[] = [];
+
+vi.mock(import("@/lib/ipc"), () => ({
+  onMenuNavigate: (handler: (route: string) => void) => {
+    menuHandlers.push(handler);
+    return () => {
+      const i = menuHandlers.indexOf(handler);
+      if (i !== -1) {
+        menuHandlers.splice(i, 1);
+      }
+    };
+  },
+}));
+
+const { useMenuNavigation } = await import("@/hooks/use-menu-navigation");
+
+describe("useMenuNavigation", () => {
+  it("navigates to /settings when the menu emits a known route", () => {
+    navigate.mockClear();
+    renderHook(() => useMenuNavigation());
+    menuHandlers.at(-1)?.("/settings");
+    expect(navigate).toHaveBeenCalledWith({ to: "/settings" });
+  });
+
+  it("ignores unknown routes", () => {
+    navigate.mockClear();
+    renderHook(() => useMenuNavigation());
+    menuHandlers.at(-1)?.("/unknown");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/mainview/hooks/use-query-history.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-query-history.browser.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import type { HistoryEntry } from "@/lib/persistence";
+
+import { useQueryHistory } from "@/hooks/use-query-history";
+import { HISTORY_UPDATED_EVENT } from "@/lib/persistence";
+import { renderHook, waitFor } from "@/test/render-hook";
+import { mockTauri } from "@/test/tauri-mock";
+
+const sampleEntry: HistoryEntry = {
+  connectionId: "conn-1",
+  database: "public",
+  dialect: null,
+  error: null,
+  executionTimeMs: 12,
+  sql: "SELECT 1",
+  success: true,
+  timestamp: "2024-01-01T00:00:00.000Z",
+};
+
+describe("useQueryHistory", () => {
+  it("loads history entries on mount", async () => {
+    mockTauri({
+      getHistory: () => [sampleEntry],
+    });
+    const { result } = renderHook(() => useQueryHistory("conn-1"));
+
+    await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+    expect(result.current.entries).toStrictEqual([sampleEntry]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("captures an error message when the RPC fails", async () => {
+    mockTauri({
+      getHistory: () => {
+        throw new Error("kaboom");
+      },
+    });
+    const { result } = renderHook(() => useQueryHistory("conn-1"));
+
+    await waitFor(() => expect(result.current.error).toBe("kaboom"));
+    expect(result.current.entries).toStrictEqual([]);
+    expect(result.current.isLoading).toBeFalsy();
+  });
+
+  it("refetches when the HISTORY_UPDATED_EVENT fires", async () => {
+    let calls = 0;
+    mockTauri({
+      getHistory: () => {
+        calls += 1;
+        return [];
+      },
+    });
+    renderHook(() => useQueryHistory("conn-1"));
+    await waitFor(() => expect(calls).toBe(1));
+
+    window.dispatchEvent(new Event(HISTORY_UPDATED_EVENT));
+    await waitFor(() => expect(calls).toBe(2));
+  });
+
+  it("re-fetches when connectionId changes", async () => {
+    const calls: string[] = [];
+    mockTauri({
+      getHistory: (payload) => {
+        calls.push(payload.connectionId as string);
+        return [];
+      },
+    });
+    const { rerender } = renderHook(
+      ({ id }: { id: string }) => useQueryHistory(id),
+      { initialProps: { id: "conn-a" } }
+    );
+    await waitFor(() => expect(calls).toContain("conn-a"));
+    rerender({ id: "conn-b" });
+    await waitFor(() => expect(calls).toContain("conn-b"));
+  });
+});

--- a/apps/app/src/mainview/hooks/use-query-tabs.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-query-tabs.browser.test.tsx
@@ -1,0 +1,219 @@
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DatabaseConnection } from "@/lib/connections";
+
+import { renderHook, waitFor } from "@/test/render-hook";
+import { mockTauri } from "@/test/tauri-mock";
+
+const baseConnection: DatabaseConnection = {
+  createdAt: "2024-01-01T00:00:00.000Z",
+  database: "app",
+  host: "localhost",
+  id: "conn-1",
+  lastConnectedAt: null,
+  name: "Local",
+  password: "",
+  pinned: false,
+  port: 5432,
+  type: "postgresql",
+  username: "postgres",
+};
+
+vi.mock(import("@/contexts/connection-context"), async () => {
+  const { resolveRunConfig } = await import("@/lib/connections");
+  return {
+    useConnection: () => ({
+      connection: baseConnection,
+      error: null,
+      isConnected: true,
+      isConnecting: false,
+      isReconnecting: false,
+      reconnect: vi.fn(),
+      runConfig: resolveRunConfig(baseConnection),
+      serverVersion: null,
+      setRunConfig: vi.fn(),
+    }),
+  };
+});
+
+vi.mock(import("@/contexts/safe-mode-context"), () => ({
+  useSafeMode: () => ({
+    enabled: false,
+    requestConfirmation: async () => {
+      await Promise.resolve();
+      return true;
+    },
+    toggle: vi.fn(),
+  }),
+}));
+
+const { useQueryTabs } = await import("@/hooks/use-query-tabs");
+
+describe("useQueryTabs", () => {
+  beforeEach(() => {
+    mockTauri({
+      executeQuery: () => ({
+        columns: [],
+        executionTimeMs: 0,
+        isTruncated: false,
+        resultType: "tabular",
+        rowCount: 0,
+        rows: [],
+      }),
+      getTabs: () => null,
+      saveTabs: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("hydrates with one default tab on a fresh connection", async () => {
+    const { result } = renderHook(() => useQueryTabs("conn-1", "public"));
+    await waitFor(() => expect(result.current.isRestored).toBeTruthy());
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.activeTabId).toBe(result.current.tabs[0]?.id);
+    expect(result.current.activeTab?.title).toBe("Query 1");
+  });
+
+  it("addTab appends a new tab and selects it", async () => {
+    const { result } = renderHook(() => useQueryTabs("conn-1", "public"));
+    await waitFor(() => expect(result.current.isRestored).toBeTruthy());
+
+    act(() => {
+      result.current.addTab();
+    });
+
+    expect(result.current.tabs).toHaveLength(2);
+    expect(result.current.activeTabId).toBe(result.current.tabs[1]?.id);
+    expect(result.current.tabs[1]?.title).toBe("Query 2");
+  });
+
+  it("addTabWithSql seeds the new tab's sql", async () => {
+    const { result } = renderHook(() => useQueryTabs("conn-1", "public"));
+    await waitFor(() => expect(result.current.isRestored).toBeTruthy());
+
+    act(() => {
+      result.current.addTabWithSql("SELECT 42");
+    });
+
+    expect(result.current.tabs[1]?.sql).toBe("SELECT 42");
+  });
+
+  it("updateTabSql edits a tab's sql", async () => {
+    const { result } = renderHook(() => useQueryTabs("conn-1", "public"));
+    await waitFor(() => expect(result.current.isRestored).toBeTruthy());
+    const { id } = result.current.tabs[0] as { id: string };
+
+    act(() => {
+      result.current.updateTabSql(id, "SELECT 1");
+    });
+    expect(result.current.tabs[0]?.sql).toBe("SELECT 1");
+  });
+
+  it("updateTabDialect sets sourceDialect", async () => {
+    const { result } = renderHook(() => useQueryTabs("conn-1", "public"));
+    await waitFor(() => expect(result.current.isRestored).toBeTruthy());
+    const { id } = result.current.tabs[0] as { id: string };
+
+    act(() => {
+      result.current.updateTabDialect(id, "mysql");
+    });
+    expect(result.current.tabs[0]?.sourceDialect).toBe("mysql");
+  });
+
+  it("closeTab removes a tab and reopenTab restores it", async () => {
+    const { result } = renderHook(() => useQueryTabs("conn-1", "public"));
+    await waitFor(() => expect(result.current.isRestored).toBeTruthy());
+
+    act(() => {
+      result.current.addTab();
+    });
+    const closingId = (result.current.tabs[1] as { id: string }).id;
+
+    act(() => {
+      result.current.closeTab(closingId);
+    });
+    expect(result.current.tabs).toHaveLength(1);
+
+    act(() => {
+      result.current.reopenTab();
+    });
+    expect(result.current.tabs.some((t) => t.id === closingId)).toBeTruthy();
+  });
+
+  it("closeTab on the last tab creates a fresh empty tab", async () => {
+    const { result } = renderHook(() => useQueryTabs("conn-1", "public"));
+    await waitFor(() => expect(result.current.isRestored).toBeTruthy());
+    const onlyId = (result.current.tabs[0] as { id: string }).id;
+
+    act(() => {
+      result.current.closeTab(onlyId);
+    });
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.tabs[0]?.id).not.toBe(onlyId);
+  });
+
+  it("reorderTabs accepts a permutation and rejects mismatched length", async () => {
+    const { result } = renderHook(() => useQueryTabs("conn-1", "public"));
+    await waitFor(() => expect(result.current.isRestored).toBeTruthy());
+
+    act(() => {
+      result.current.addTab();
+    });
+    const [a, b] = result.current.tabs.map((t) => t.id);
+
+    act(() => {
+      result.current.reorderTabs([b as string, a as string]);
+    });
+    expect(result.current.tabs.map((t) => t.id)).toStrictEqual([b, a]);
+
+    act(() => {
+      result.current.reorderTabs([a as string]);
+    });
+    // Length mismatch — order unchanged
+    expect(result.current.tabs.map((t) => t.id)).toStrictEqual([b, a]);
+  });
+
+  it("setExplainAnalyze and setExplainDensity update flags", async () => {
+    const { result } = renderHook(() => useQueryTabs("conn-1", "public"));
+    await waitFor(() => expect(result.current.isRestored).toBeTruthy());
+    const { id } = result.current.tabs[0] as { id: string };
+
+    act(() => {
+      result.current.setExplainAnalyze(id, true);
+      result.current.setExplainDensity(id, "compact");
+    });
+    expect(result.current.tabs[0]?.explainAnalyze).toBeTruthy();
+    expect(result.current.tabs[0]?.explainDensity).toBe("compact");
+  });
+
+  it("executeTab no-ops when sql is blank", async () => {
+    const { result } = renderHook(() => useQueryTabs("conn-1", "public"));
+    await waitFor(() => expect(result.current.isRestored).toBeTruthy());
+
+    const { id } = result.current.tabs[0] as { id: string };
+    act(() => {
+      result.current.executeTab(id);
+    });
+    // No status change — still idle
+    expect(result.current.tabs[0]?.status).toBe("idle");
+  });
+
+  it("addTabWithSqlAndRun replaces an empty active tab in place", async () => {
+    const { result } = renderHook(() => useQueryTabs("conn-1", "public"));
+    await waitFor(() => expect(result.current.isRestored).toBeTruthy());
+    const initialId = result.current.tabs[0]?.id;
+
+    act(() => {
+      result.current.addTabWithSqlAndRun("SELECT 1");
+    });
+
+    // SQL applied to the existing empty tab; no new tab added.
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.tabs[0]?.id).toBe(initialId);
+    expect(result.current.tabs[0]?.sql).toBe("SELECT 1");
+  });
+});

--- a/apps/app/src/mainview/hooks/use-syntax-tree.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-syntax-tree.browser.test.tsx
@@ -1,0 +1,67 @@
+import { sql } from "@codemirror/lang-sql";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { act } from "react";
+import { describe, expect, it } from "vitest";
+
+import { useSyntaxTree } from "@/hooks/use-syntax-tree";
+import { renderHook, waitFor } from "@/test/render-hook";
+
+const buildView = (doc: string): EditorView => {
+  const state = EditorState.create({ doc, extensions: [sql()] });
+  return new EditorView({ state });
+};
+
+const dispatch = (
+  view: EditorView,
+  override: Partial<{ docChanged: boolean; selectionSet: boolean }> = {}
+) => {
+  // Construct a synthetic ViewUpdate-like object
+  const update = {
+    docChanged: override.docChanged ?? false,
+    selectionSet: override.selectionSet ?? false,
+    state: view.state,
+  } as unknown as Parameters<
+    ReturnType<typeof useSyntaxTree>["handleEditorUpdate"]
+  >[0];
+  return update;
+};
+
+describe("useSyntaxTree", () => {
+  it("returns an empty tree when disabled", () => {
+    const { result } = renderHook(() => useSyntaxTree(false));
+    expect(result.current.treeData.root).toBeNull();
+  });
+
+  it("ignores updates while disabled", () => {
+    const { result } = renderHook(() => useSyntaxTree(false));
+    const view = buildView("SELECT 1");
+    act(() => {
+      result.current.handleEditorUpdate(dispatch(view, { selectionSet: true }));
+    });
+    expect(result.current.treeData.root).toBeNull();
+  });
+
+  it("processes selectionSet updates synchronously", () => {
+    const { result } = renderHook(() => useSyntaxTree(true));
+    const view = buildView("SELECT 1");
+    act(() => {
+      result.current.handleEditorUpdate(dispatch(view, { selectionSet: true }));
+    });
+    expect(result.current.treeData.root).not.toBeNull();
+    expect(result.current.treeData.root?.children.length).toBeGreaterThan(0);
+  });
+
+  it("debounces docChanged updates", async () => {
+    const { result } = renderHook(() => useSyntaxTree(true));
+    const view = buildView("SELECT 1");
+    act(() => {
+      result.current.handleEditorUpdate(dispatch(view, { docChanged: true }));
+    });
+    // Not yet processed
+    expect(result.current.treeData.root).toBeNull();
+    await waitFor(() => expect(result.current.treeData.root).not.toBeNull(), {
+      timeout: 500,
+    });
+  });
+});

--- a/apps/app/src/mainview/hooks/use-tab-explain.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-tab-explain.browser.test.tsx
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DatabaseConnection } from "@/lib/connections";
+import type { QueryTab } from "@/lib/query-types";
+
+import { renderHook, waitFor } from "@/test/render-hook";
+import { mockTauri } from "@/test/tauri-mock";
+
+const baseConnection: DatabaseConnection = {
+  createdAt: "2024-01-01T00:00:00.000Z",
+  database: "app",
+  host: "localhost",
+  id: "conn-1",
+  lastConnectedAt: null,
+  name: "Local",
+  password: "",
+  pinned: false,
+  port: 5432,
+  type: "postgresql",
+  username: "postgres",
+};
+
+vi.mock(import("@/contexts/connection-context"), async () => {
+  const { resolveRunConfig } = await import("@/lib/connections");
+  return {
+    useConnection: () => ({
+      connection: baseConnection,
+      error: null,
+      isConnected: true,
+      isConnecting: false,
+      isReconnecting: false,
+      reconnect: vi.fn(),
+      runConfig: resolveRunConfig(baseConnection),
+      serverVersion: null,
+      setRunConfig: vi.fn(),
+    }),
+  };
+});
+
+const { useTabExplain } = await import("@/hooks/use-tab-explain");
+
+const makeTab = (overrides: Partial<QueryTab> = {}): QueryTab => ({
+  error: null,
+  errorCode: null,
+  executedSql: null,
+  explainAnalyze: false,
+  explainDensity: "comfortable",
+  explainError: null,
+  explainResult: null,
+  explainSql: null,
+  explainStatus: "idle",
+  id: "tab-1",
+  pendingExecution: null,
+  result: null,
+  runningExplainId: null,
+  runningQueryId: null,
+  sourceDialect: null,
+  sql: "SELECT 1",
+  status: "idle",
+  title: "Query 1",
+  ...overrides,
+});
+
+const applyUpdate = <T,>(prev: T[], update: T[] | ((p: T[]) => T[])): T[] =>
+  typeof update === "function" ? update(prev) : update;
+
+const makeSetTabs = (initial: QueryTab[]) => {
+  const state = { tabs: initial };
+  const setTabs = vi.fn(
+    (update: QueryTab[] | ((prev: QueryTab[]) => QueryTab[])) => {
+      state.tabs = applyUpdate(state.tabs, update);
+    }
+  );
+  return { setTabs, state };
+};
+
+describe("useTabExplain", () => {
+  it("captures a successful EXPLAIN result", async () => {
+    const planNode = {
+      actualRows: null,
+      children: [],
+      cost: null,
+      cost_pct: null,
+      hot_path: false,
+      kind: "Seq Scan",
+      object: "users",
+      planRows: null,
+      properties: {},
+      timing: null,
+    };
+    mockTauri({
+      explainQuery: () => ({
+        analyze: false,
+        engine: "postgres",
+        executionTimeMs: 1,
+        plan: planNode,
+        rawText: null,
+      }),
+    });
+
+    const { setTabs, state } = makeSetTabs([makeTab()]);
+    const { result } = renderHook(() =>
+      useTabExplain({
+        connectionId: "conn-1",
+        selectedDatabase: "public",
+        setTabs,
+      })
+    );
+
+    await result.current.explain("tab-1", "SELECT 1", null, false);
+
+    await waitFor(() => expect(state.tabs[0]?.explainStatus).toBe("success"));
+    expect(state.tabs[0]?.explainSql).toBe("SELECT 1");
+    expect(state.tabs[0]?.explainError).toBeNull();
+    expect(state.tabs[0]?.runningExplainId).toBeNull();
+  });
+
+  it("records error message when EXPLAIN fails", async () => {
+    mockTauri({
+      explainQuery: () => {
+        throw Object.assign(new Error("plan failed"), { code: "42P01" });
+      },
+    });
+
+    const { setTabs, state } = makeSetTabs([makeTab()]);
+    const { result } = renderHook(() =>
+      useTabExplain({
+        connectionId: "conn-1",
+        selectedDatabase: "public",
+        setTabs,
+      })
+    );
+
+    await result.current.explain("tab-1", "SELECT 1", null, false);
+
+    await waitFor(() => expect(state.tabs[0]?.explainStatus).toBe("error"));
+    expect(state.tabs[0]?.explainError).toBe("plan failed");
+  });
+
+  it("treats QUERY_CANCELLED as idle without an error", async () => {
+    mockTauri({
+      explainQuery: () => {
+        throw Object.assign(new Error("cancelled"), {
+          code: "QUERY_CANCELLED",
+        });
+      },
+    });
+
+    const { setTabs, state } = makeSetTabs([makeTab()]);
+    const { result } = renderHook(() =>
+      useTabExplain({
+        connectionId: "conn-1",
+        selectedDatabase: "public",
+        setTabs,
+      })
+    );
+
+    await result.current.explain("tab-1", "SELECT 1", null, false);
+
+    await waitFor(() => expect(state.tabs[0]?.explainStatus).toBe("idle"));
+    expect(state.tabs[0]?.explainError).toBeNull();
+  });
+
+  it("forwards cancel() to cancelQuery RPC", async () => {
+    const cancel = vi.fn();
+    mockTauri({ cancelQuery: cancel });
+
+    const { result } = renderHook(() =>
+      useTabExplain({
+        connectionId: "conn-1",
+        selectedDatabase: null,
+        setTabs: vi.fn(),
+      })
+    );
+
+    await result.current.cancel("q-explain");
+    expect(cancel).toHaveBeenCalledWith(
+      expect.objectContaining({ queryId: "q-explain" })
+    );
+  });
+
+  it("forwards analyze and dialect to explainQuery", async () => {
+    const calls: Record<string, unknown>[] = [];
+    mockTauri({
+      explainQuery: (payload) => {
+        calls.push(payload);
+        return {
+          analyze: true,
+          engine: "postgres",
+          executionTimeMs: 0,
+          plan: {
+            actualRows: null,
+            children: [],
+            cost: null,
+            cost_pct: null,
+            hot_path: false,
+            kind: "Result",
+            object: null,
+            planRows: null,
+            properties: {},
+            timing: null,
+          },
+          rawText: null,
+        };
+      },
+    });
+
+    const { setTabs } = makeSetTabs([makeTab()]);
+    const { result } = renderHook(() =>
+      useTabExplain({
+        connectionId: "conn-1",
+        selectedDatabase: "analytics",
+        setTabs,
+      })
+    );
+
+    await result.current.explain("tab-1", "SELECT 2", "mysql", true);
+
+    expect(calls[0]).toMatchObject({
+      params: {
+        analyze: true,
+        connectionId: "conn-1",
+        schema: "analytics",
+        sourceDialect: "mysql",
+        sql: "SELECT 2",
+      },
+    });
+  });
+});

--- a/apps/app/src/mainview/hooks/use-tab-explain.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-tab-explain.browser.test.tsx
@@ -2,9 +2,35 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { DatabaseConnection } from "@/lib/connections";
 import type { QueryTab } from "@/lib/query-types";
+import type { ExplainResult, PlanNode } from "@/lib/tauri";
 
 import { renderHook, waitFor } from "@/test/render-hook";
 import { mockTauri } from "@/test/tauri-mock";
+
+const makePlanNode = (overrides: Partial<PlanNode> = {}): PlanNode => ({
+  children: [],
+  cost: { actualTotalMs: null, selfMs: null, startup: null, total: null },
+  details: [],
+  id: "n0",
+  label: "Seq Scan on users",
+  nodeType: "Seq Scan",
+  rows: { actual: null, estimated: null },
+  timing: { actualTotalMs: null, loops: null, startupMs: null },
+  warnings: [],
+  ...overrides,
+});
+
+const makeExplainResult = (
+  overrides: Partial<ExplainResult> = {}
+): ExplainResult => ({
+  analyzeRan: false,
+  engine: "postgresql",
+  executionTimeMs: 0,
+  raw: "",
+  root: makePlanNode(),
+  supportsAnalyze: true,
+  ...overrides,
+});
 
 const baseConnection: DatabaseConnection = {
   createdAt: "2024-01-01T00:00:00.000Z",
@@ -76,26 +102,9 @@ const makeSetTabs = (initial: QueryTab[]) => {
 
 describe("useTabExplain", () => {
   it("captures a successful EXPLAIN result", async () => {
-    const planNode = {
-      actualRows: null,
-      children: [],
-      cost: null,
-      cost_pct: null,
-      hot_path: false,
-      kind: "Seq Scan",
-      object: "users",
-      planRows: null,
-      properties: {},
-      timing: null,
-    };
     mockTauri({
-      explainQuery: () => ({
-        analyze: false,
-        engine: "postgres",
-        executionTimeMs: 1,
-        plan: planNode,
-        rawText: null,
-      }),
+      explainQuery: () =>
+        makeExplainResult({ executionTimeMs: 1, raw: "Seq Scan on users" }),
     });
 
     const { setTabs, state } = makeSetTabs([makeTab()]);
@@ -184,24 +193,10 @@ describe("useTabExplain", () => {
     mockTauri({
       explainQuery: (payload) => {
         calls.push(payload);
-        return {
-          analyze: true,
-          engine: "postgres",
-          executionTimeMs: 0,
-          plan: {
-            actualRows: null,
-            children: [],
-            cost: null,
-            cost_pct: null,
-            hot_path: false,
-            kind: "Result",
-            object: null,
-            planRows: null,
-            properties: {},
-            timing: null,
-          },
-          rawText: null,
-        };
+        return makeExplainResult({
+          analyzeRan: true,
+          root: makePlanNode({ id: "n0", label: "Result", nodeType: "Result" }),
+        });
       },
     });
 

--- a/apps/app/src/mainview/hooks/use-workspace-hotkeys.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-workspace-hotkeys.browser.test.tsx
@@ -28,12 +28,18 @@ const Harness = (props: Props) => {
   return <div data-testid="harness" />;
 };
 
+const isMacPlatform =
+  typeof navigator !== "undefined" &&
+  (navigator.platform.toLowerCase().includes("mac") ||
+    navigator.userAgent.toLowerCase().includes("mac"));
+
 const fireKey = (key: string, options: KeyboardEventInit = {}) => {
   const event = new KeyboardEvent("keydown", {
     bubbles: true,
     cancelable: true,
+    ctrlKey: !isMacPlatform,
     key,
-    metaKey: true,
+    metaKey: isMacPlatform,
     ...options,
   });
   document.body.dispatchEvent(event);

--- a/apps/app/src/mainview/hooks/use-workspace-hotkeys.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-workspace-hotkeys.browser.test.tsx
@@ -1,0 +1,147 @@
+import type { ReactNode } from "react";
+
+import { HotkeysProvider } from "@tanstack/react-hotkeys";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import type { QueryTab } from "@/lib/query-types";
+
+import { useWorkspaceHotkeys } from "@/hooks/use-workspace-hotkeys";
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <HotkeysProvider>{children}</HotkeysProvider>
+);
+
+interface Props {
+  tabs: QueryTab[];
+  activeTab: QueryTab | undefined;
+  addTab: () => void;
+  closeTab: (id: string) => void;
+  reopenTab: () => void;
+  setActiveTabId: (id: string) => void;
+  handleFormat: () => void;
+  handleExplain: () => void;
+}
+
+const Harness = (props: Props) => {
+  useWorkspaceHotkeys(props);
+  return <div data-testid="harness" />;
+};
+
+const fireKey = (key: string, options: KeyboardEventInit = {}) => {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key,
+    metaKey: true,
+    ...options,
+  });
+  document.body.dispatchEvent(event);
+};
+
+const baseTab: QueryTab = {
+  error: null,
+  errorCode: null,
+  executedSql: null,
+  explainAnalyze: false,
+  explainDensity: "comfortable",
+  explainError: null,
+  explainResult: null,
+  explainSql: null,
+  explainStatus: "idle",
+  id: "tab-1",
+  pendingExecution: null,
+  result: null,
+  runningExplainId: null,
+  runningQueryId: null,
+  sourceDialect: null,
+  sql: "",
+  status: "idle",
+  title: "Query 1",
+};
+
+describe("useWorkspaceHotkeys", () => {
+  it("mod+T fires addTab", () => {
+    const addTab = vi.fn();
+    render(
+      <Wrapper>
+        <Harness
+          activeTab={baseTab}
+          addTab={addTab}
+          closeTab={vi.fn()}
+          handleExplain={vi.fn()}
+          handleFormat={vi.fn()}
+          reopenTab={vi.fn()}
+          setActiveTabId={vi.fn()}
+          tabs={[baseTab]}
+        />
+      </Wrapper>
+    );
+    fireKey("t");
+    expect(addTab).toHaveBeenCalledWith();
+  });
+
+  it("mod+W closes the active tab", () => {
+    const closeTab = vi.fn();
+    render(
+      <Wrapper>
+        <Harness
+          activeTab={baseTab}
+          addTab={vi.fn()}
+          closeTab={closeTab}
+          handleExplain={vi.fn()}
+          handleFormat={vi.fn()}
+          reopenTab={vi.fn()}
+          setActiveTabId={vi.fn()}
+          tabs={[baseTab]}
+        />
+      </Wrapper>
+    );
+    fireKey("w");
+    expect(closeTab).toHaveBeenCalledWith("tab-1");
+  });
+
+  it("mod+1 selects the first tab", () => {
+    const setActive = vi.fn();
+    const tabs = [
+      { ...baseTab, id: "a" },
+      { ...baseTab, id: "b" },
+    ];
+    render(
+      <Wrapper>
+        <Harness
+          activeTab={tabs[0]}
+          addTab={vi.fn()}
+          closeTab={vi.fn()}
+          handleExplain={vi.fn()}
+          handleFormat={vi.fn()}
+          reopenTab={vi.fn()}
+          setActiveTabId={setActive}
+          tabs={tabs}
+        />
+      </Wrapper>
+    );
+    fireKey("1");
+    expect(setActive).toHaveBeenCalledWith("a");
+  });
+
+  it("mod+Shift+F triggers handleFormat", () => {
+    const handleFormat = vi.fn();
+    render(
+      <Wrapper>
+        <Harness
+          activeTab={baseTab}
+          addTab={vi.fn()}
+          closeTab={vi.fn()}
+          handleExplain={vi.fn()}
+          handleFormat={handleFormat}
+          reopenTab={vi.fn()}
+          setActiveTabId={vi.fn()}
+          tabs={[baseTab]}
+        />
+      </Wrapper>
+    );
+    fireKey("F", { shiftKey: true });
+    expect(handleFormat).toHaveBeenCalledWith();
+  });
+});

--- a/apps/app/src/mainview/hooks/use-workspace-mode-hotkeys.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-workspace-mode-hotkeys.browser.test.tsx
@@ -17,13 +17,19 @@ const Harness = ({ setMode }: { setMode: (m: WorkspaceMode) => void }) => {
   return null;
 };
 
+const isMacPlatform =
+  typeof navigator !== "undefined" &&
+  (navigator.platform.toLowerCase().includes("mac") ||
+    navigator.userAgent.toLowerCase().includes("mac"));
+
 const fireMeta = (key: string, shift = true) => {
   document.body.dispatchEvent(
     new KeyboardEvent("keydown", {
       bubbles: true,
       cancelable: true,
+      ctrlKey: !isMacPlatform,
       key,
-      metaKey: true,
+      metaKey: isMacPlatform,
       shiftKey: shift,
     })
   );

--- a/apps/app/src/mainview/hooks/use-workspace-mode-hotkeys.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-workspace-mode-hotkeys.browser.test.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react";
+
+import { HotkeysProvider } from "@tanstack/react-hotkeys";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import type { WorkspaceMode } from "@/lib/workspace-mode";
+
+import { useWorkspaceModeHotkeys } from "@/hooks/use-workspace-mode-hotkeys";
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <HotkeysProvider>{children}</HotkeysProvider>
+);
+
+const Harness = ({ setMode }: { setMode: (m: WorkspaceMode) => void }) => {
+  useWorkspaceModeHotkeys({ setMode });
+  return null;
+};
+
+const fireMeta = (key: string, shift = true) => {
+  document.body.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key,
+      metaKey: true,
+      shiftKey: shift,
+    })
+  );
+};
+
+describe("useWorkspaceModeHotkeys", () => {
+  it("mod+Shift+1 sets editor mode", () => {
+    const setMode = vi.fn();
+    render(
+      <Wrapper>
+        <Harness setMode={setMode} />
+      </Wrapper>
+    );
+    fireMeta("1");
+    expect(setMode).toHaveBeenCalledWith("editor");
+  });
+
+  it("mod+Shift+2 sets split mode", () => {
+    const setMode = vi.fn();
+    render(
+      <Wrapper>
+        <Harness setMode={setMode} />
+      </Wrapper>
+    );
+    fireMeta("2");
+    expect(setMode).toHaveBeenCalledWith("split");
+  });
+
+  it("mod+Shift+3 sets chat mode", () => {
+    const setMode = vi.fn();
+    render(
+      <Wrapper>
+        <Harness setMode={setMode} />
+      </Wrapper>
+    );
+    fireMeta("3");
+    expect(setMode).toHaveBeenCalledWith("chat");
+  });
+});

--- a/apps/app/src/mainview/hooks/use-workspace-mode.browser.test.tsx
+++ b/apps/app/src/mainview/hooks/use-workspace-mode.browser.test.tsx
@@ -1,0 +1,48 @@
+import { act } from "react";
+import { describe, expect, it } from "vitest";
+
+import { useWorkspaceMode } from "@/hooks/use-workspace-mode";
+import { renderHook } from "@/test/render-hook";
+
+describe("useWorkspaceMode", () => {
+  it("falls back to the default split mode when nothing is stored", () => {
+    const { result } = renderHook(() => useWorkspaceMode("conn-1"));
+    expect(result.current.mode).toBe("split");
+  });
+
+  it("loads a stored mode from localStorage", () => {
+    localStorage.setItem("oh-my-query-workspace-mode-conn-2", "chat");
+    const { result } = renderHook(() => useWorkspaceMode("conn-2"));
+    expect(result.current.mode).toBe("chat");
+  });
+
+  it("ignores invalid values and uses the default", () => {
+    localStorage.setItem("oh-my-query-workspace-mode-conn-3", "bogus");
+    const { result } = renderHook(() => useWorkspaceMode("conn-3"));
+    expect(result.current.mode).toBe("split");
+  });
+
+  it("setMode updates state and persists the new value", () => {
+    const { result } = renderHook(() => useWorkspaceMode("conn-4"));
+
+    act(() => {
+      result.current.setMode("editor");
+    });
+    expect(result.current.mode).toBe("editor");
+    expect(localStorage.getItem("oh-my-query-workspace-mode-conn-4")).toBe(
+      "editor"
+    );
+  });
+
+  it("re-reads when the connectionId changes", () => {
+    localStorage.setItem("oh-my-query-workspace-mode-a", "editor");
+    localStorage.setItem("oh-my-query-workspace-mode-b", "chat");
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useWorkspaceMode(id),
+      { initialProps: { id: "a" } }
+    );
+    expect(result.current.mode).toBe("editor");
+    rerender({ id: "b" });
+    expect(result.current.mode).toBe("chat");
+  });
+});

--- a/apps/app/src/mainview/lib/sql-schema.test.ts
+++ b/apps/app/src/mainview/lib/sql-schema.test.ts
@@ -1,0 +1,195 @@
+import { sql } from "@codemirror/lang-sql";
+import { EditorState } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+
+import type { SchemaInfo } from "@/lib/tauri";
+
+import {
+  createColumnCompletionSource,
+  createTableCompletionSource,
+  getDefaultSchema,
+  schemaInfoToSQLNamespace,
+} from "./sql-schema";
+
+const schema: SchemaInfo = {
+  schemas: [
+    {
+      name: "public",
+      tables: [
+        {
+          columns: [
+            {
+              dataType: "int4",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: true,
+              name: "id",
+            },
+            {
+              dataType: "text",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "email",
+            },
+          ],
+          foreignKeys: [],
+          indexes: [],
+          name: "users",
+          rowEstimate: null,
+        },
+        {
+          columns: [
+            {
+              dataType: "int4",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: true,
+              name: "id",
+            },
+            {
+              dataType: "int4",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "user_id",
+            },
+          ],
+          foreignKeys: [],
+          indexes: [],
+          name: "orders",
+          rowEstimate: null,
+        },
+      ],
+      views: [
+        {
+          columns: [
+            {
+              dataType: "int4",
+              defaultValue: null,
+              isNullable: false,
+              isPrimaryKey: false,
+              name: "total",
+            },
+          ],
+          name: "user_stats",
+        },
+      ],
+    },
+  ],
+};
+
+describe("schemaInfoToSQLNamespace", () => {
+  it("converts schema info into a SQL namespace tree", () => {
+    const ns = schemaInfoToSQLNamespace(schema) as Record<
+      string,
+      {
+        children: Record<string, { children: unknown[] }>;
+      }
+    >;
+    expect(Object.keys(ns)).toContain("public");
+    expect(Object.keys(ns.public.children)).toContain("users");
+    expect(Object.keys(ns.public.children)).toContain("user_stats");
+  });
+});
+
+describe("getDefaultSchema", () => {
+  it("prefers a public schema when present", () => {
+    expect(getDefaultSchema(schema)).toBe("public");
+  });
+
+  it("falls back to main when public is absent", () => {
+    expect(
+      getDefaultSchema({
+        schemas: [
+          { name: "main", tables: [], views: [] },
+          { name: "other", tables: [], views: [] },
+        ],
+      })
+    ).toBe("main");
+  });
+
+  it("returns the only schema when there is exactly one", () => {
+    expect(
+      getDefaultSchema({ schemas: [{ name: "alpha", tables: [], views: [] }] })
+    ).toBe("alpha");
+  });
+
+  it("returns undefined when there is no obvious default", () => {
+    expect(
+      getDefaultSchema({
+        schemas: [
+          { name: "alpha", tables: [], views: [] },
+          { name: "beta", tables: [], views: [] },
+        ],
+      })
+    ).toBeUndefined();
+  });
+});
+
+const buildState = (doc: string) =>
+  EditorState.create({ doc, extensions: [sql()] });
+
+const buildContext = (doc: string, pos = doc.length) => {
+  const state = buildState(doc);
+  return {
+    explicit: true,
+    matchBefore: (re: RegExp) => {
+      const before = state.doc.sliceString(0, pos);
+      const m = before.match(new RegExp(`(${re.source})$`));
+      if (!m || m[0] === "") {
+        return null;
+      }
+      return { from: pos - m[0].length, text: m[0], to: pos };
+    },
+    pos,
+    state,
+  };
+};
+
+interface SyncCompletionResult {
+  options: { label: string }[];
+  from: number;
+}
+
+describe("createTableCompletionSource", () => {
+  it("offers tables and views after FROM", () => {
+    const source = createTableCompletionSource(schema);
+    const result = source(
+      buildContext("SELECT * FROM ", "SELECT * FROM ".length) as never
+    ) as SyncCompletionResult | null;
+    expect(result?.options.map((o) => o.label)).toStrictEqual(
+      expect.arrayContaining(["users", "orders", "user_stats"])
+    );
+  });
+
+  it("returns null when not in a FROM/JOIN clause", () => {
+    const source = createTableCompletionSource(schema);
+    const result = source(
+      buildContext("SELECT id FROM users WHERE ", 26) as never
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("createColumnCompletionSource", () => {
+  it("offers columns from referenced tables", () => {
+    const source = createColumnCompletionSource(schema);
+    const sqlText = "SELECT  FROM users";
+    // Cursor placed after the SELECT token (column position)
+    const result = source(
+      buildContext(sqlText, "SELECT ".length) as never
+    ) as SyncCompletionResult;
+    expect(result).not.toBeNull();
+    const labels = result.options.map((o) => o.label);
+    expect(labels).toStrictEqual(expect.arrayContaining(["id", "email"]));
+  });
+
+  it("returns null inside FROM/JOIN clause", () => {
+    const source = createColumnCompletionSource(schema);
+    const result = source(
+      buildContext("SELECT id FROM ", "SELECT id FROM ".length) as never
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/apps/app/src/mainview/lib/sql-schema.test.ts
+++ b/apps/app/src/mainview/lib/sql-schema.test.ts
@@ -173,16 +173,20 @@ describe("createTableCompletionSource", () => {
 });
 
 describe("createColumnCompletionSource", () => {
-  it("offers columns from referenced tables", () => {
+  it("scopes columns to the table referenced by FROM", () => {
     const source = createColumnCompletionSource(schema);
+    // Cursor sits in the SELECT projection; getReferencedTables still walks the
+    // whole statement and picks up `users`, so completions are scoped to it.
     const sqlText = "SELECT  FROM users";
-    // Cursor placed after the SELECT token (column position)
     const result = source(
       buildContext(sqlText, "SELECT ".length) as never
     ) as SyncCompletionResult;
     expect(result).not.toBeNull();
     const labels = result.options.map((o) => o.label);
     expect(labels).toStrictEqual(expect.arrayContaining(["id", "email"]));
+    // Columns from unreferenced tables/views must not leak in.
+    expect(labels).not.toContain("user_id");
+    expect(labels).not.toContain("total");
   });
 
   it("returns null inside FROM/JOIN clause", () => {


### PR DESCRIPTION
## Summary
- Adds 34 colocated test files covering previously untested hooks and components — primary targets were `use-query-tabs`, `use-tab-explain`, `use-favorite-tables`, `use-workspace-mode`, workspace toolbar buttons, redis chips/rows, syntax-tree views, and EXPLAIN plan panels.
- Lifts overall line coverage from **57.5% → 66.83%** (+9.3pp; 2186 lines added across the test suite, 1042 tests now pass).
- Mirrors existing test conventions: `*.browser.test.tsx` with `vitest-browser-react` and `renderHook`, `mockTauri` for RPC, snapshot serialization stripping volatile motion styles.

## Test plan
- [x] `bun run --cwd apps/app test` — all 173 test files / 1042 tests pass
- [x] `bun run check-types` — clean
- [x] `bun run check` — clean (Ultracite lint + format)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 34 colocated test files for previously untested hooks and components—covering `use-query-tabs`, `use-tab-explain`, `use-favorite-tables`, `use-workspace-mode`, workspace buttons, Redis UI, syntax tree, and EXPLAIN panels. Raises line coverage from 57.5% to 66.83% and brings the suite to 1042 passing tests in `apps/app`.

- **Bug Fixes**
  - Make hotkey tests portable by mapping Mod to `metaKey` on macOS and `ctrlKey` on Linux/Windows to fix CI failures.

- **Refactors**
  - Rebuild `use-tab-explain` plan-node and explain-result fixtures to match current RPC interfaces.
  - Tighten `sql-schema` tests to assert columns from unreferenced tables/views are excluded.
  - Update `dialect-selector` test to assert the transpile tooltip by hovering the badge ("Transpiling to PostgreSQL").

<sup>Written for commit 7dbe24ec899ad9ad7652e52e2124a9a069aa87e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

